### PR TITLE
Add one-command subagent setup with required Solana wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ This script:
 Then add the printed `.pub` key to GitHub under:
 **Settings → SSH and GPG keys → New signing key**
 
+### Quickstart: one-command subagent setup (identity + wallet)
+
+```bash
+./scripts/setup-subagent.sh dacl-agent-001 /path/to/DACL
+```
+
+What it does:
+- Creates a dedicated git worktree at `.worktrees/<agent-id>`
+- Configures git identity + SSH signing in that worktree
+- Generates a Solana wallet keypair (if missing)
+- Persists wallet pubkey + paths to `agents/metadata/<agent-id>.json`
+- Prints a concise success summary (agent id, git identity, wallet pubkey)
+
+Example output:
+
+```text
+✅ Subagent setup complete
+agent id: dacl-agent-001
+git identity: dacl-agent-001 <dacl-agent-001@users.noreply.github.com>
+wallet pubkey: 9w...abc
+```
+
 ## Reviewer Agents (v1)
 
 Two initial PR reviewer specializations are defined under `agents/reviewers/`:

--- a/scripts/setup-subagent.sh
+++ b/scripts/setup-subagent.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command subagent bootstrap:
+# - creates a per-agent git worktree
+# - configures git identity + SSH commit signing
+# - generates a Solana wallet (if missing)
+# - persists wallet metadata
+#
+# Usage:
+#   ./scripts/setup-subagent.sh <agent-id> [repo-root]
+# Example:
+#   ./scripts/setup-subagent.sh dacl-agent-001 /path/to/DACL
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <agent-id> [repo-root]" >&2
+  exit 1
+fi
+
+AGENT_ID="$1"
+REPO_ROOT="${2:-$(pwd)}"
+WORKTREE_PATH="${REPO_ROOT}/.worktrees/${AGENT_ID}"
+METADATA_DIR="${REPO_ROOT}/agents/metadata"
+METADATA_FILE="${METADATA_DIR}/${AGENT_ID}.json"
+WALLET_DIR="${HOME}/.config/solana/dacl-agents"
+WALLET_FILE="${WALLET_DIR}/${AGENT_ID}.json"
+
+if ! git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: ${REPO_ROOT} is not a git repository" >&2
+  exit 1
+fi
+
+mkdir -p "${WALLET_DIR}" "${METADATA_DIR}" "${REPO_ROOT}/.worktrees"
+
+if [[ ! -d "${WORKTREE_PATH}" ]]; then
+  git -C "${REPO_ROOT}" worktree add --detach "${WORKTREE_PATH}" >/dev/null
+fi
+
+"${REPO_ROOT}/scripts/setup-agent-identity.sh" "${AGENT_ID}" "${WORKTREE_PATH}" >/dev/null
+
+if [[ ! -f "${WALLET_FILE}" ]]; then
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "${TMPDIR}"' EXIT
+
+  openssl genpkey -algorithm Ed25519 -out "${TMPDIR}/wallet.pem" >/dev/null 2>&1
+
+  PRIV_HEX="$(openssl pkey -in "${TMPDIR}/wallet.pem" -text -noout | awk '/^priv:/{f=1;next}/^pub:/{f=0}f' | tr -d '[:space:]:' )"
+  PUB_HEX="$(openssl pkey -in "${TMPDIR}/wallet.pem" -text -noout | awk '/^pub:/{f=1;next}f' | tr -d '[:space:]:' )"
+
+  python3 - "${PRIV_HEX}" "${PUB_HEX}" "${WALLET_FILE}" <<'PY'
+import json
+import pathlib
+import sys
+
+priv = bytes.fromhex(sys.argv[1])
+pub = bytes.fromhex(sys.argv[2])
+out = pathlib.Path(sys.argv[3])
+keypair = list(priv + pub)
+out.write_text(json.dumps(keypair))
+PY
+fi
+
+WALLET_PUBKEY="$(python3 - "${WALLET_FILE}" <<'PY'
+import json
+import sys
+
+alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+def b58encode(data: bytes) -> str:
+    n = int.from_bytes(data, 'big')
+    encoded = ''
+    while n:
+        n, rem = divmod(n, 58)
+        encoded = alphabet[rem] + encoded
+    pad = 0
+    for b in data:
+        if b == 0:
+            pad += 1
+        else:
+            break
+    return '1' * pad + (encoded or '1')
+
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    arr = json.load(f)
+raw = bytes(arr)
+pub = raw[32:64]
+print(b58encode(pub))
+PY
+)"
+
+cat > "${METADATA_FILE}" <<EOF
+{
+  "agentId": "${AGENT_ID}",
+  "worktreePath": "${WORKTREE_PATH}",
+  "git": {
+    "name": "${AGENT_ID}",
+    "email": "${AGENT_ID}@users.noreply.github.com"
+  },
+  "wallet": {
+    "network": "solana",
+    "keypairPath": "${WALLET_FILE}",
+    "pubkey": "${WALLET_PUBKEY}"
+  }
+}
+EOF
+
+echo "✅ Subagent setup complete"
+echo "agent id: ${AGENT_ID}"
+echo "git identity: ${AGENT_ID} <${AGENT_ID}@users.noreply.github.com>"
+echo "wallet pubkey: ${WALLET_PUBKEY}"
+echo "worktree: ${WORKTREE_PATH}"
+echo "metadata: ${METADATA_FILE}"


### PR DESCRIPTION
## Summary
- add `scripts/setup-subagent.sh` to bootstrap a subagent in one command
- create per-agent worktree, configure git identity/signing, and require Solana wallet generation
- persist wallet pubkey and paths in `agents/metadata/<agent-id>.json`
- print concise setup summary including agent id, git identity, and wallet pubkey
- document quickstart + example in README

## Validation
- `bash -n scripts/setup-agent-identity.sh scripts/setup-subagent.sh`
- smoke-run: `./scripts/setup-subagent.sh dacl-agent-smoke /home/openclaw/.openclaw/workspace/DACL/.worktrees/builder-agent`

Closes #1