### PR TITLE
feat: implement typed data layer for ops dashboard

### DIFF
--- a/apps/ops-dashboard/app/api/dashboard/route.js
+++ b/apps/ops-dashboard/app/api/dashboard/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getDashboardData } from '../../../lib/data';
+
+export async function GET() {
+  try {
+    const data = await getDashboardData();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        agents: [],
+        cronJobs: [],
+        activity: [],
+        error: 'Failed to load dashboard data',
+        details: error instanceof Error ? error.message : 'unknown error'
+      },
+      { status: 200 }
+    );
+  }
+}

--- a/apps/ops-dashboard/app/page.js
+++ b/apps/ops-dashboard/app/page.js
@@ -1,34 +1,66 @@
-const sections = [
-  {
-    title: 'Agents',
-    description: 'Agent health and role summaries will render here.'
-  },
-  {
-    title: 'Cron Jobs',
-    description: 'Scheduled jobs and run outcomes will render here.'
-  },
-  {
-    title: 'Activity',
-    description: 'Recent planner/worker activity will render here.'
-  }
-];
+import { getDashboardData } from '../lib/data';
 
-export default function HomePage() {
+function EmptyState({ message }) {
+  return <p className="subtitle">{message}</p>;
+}
+
+export default async function HomePage() {
+  const data = await getDashboardData();
+  const { agents, cronJobs, activity } = data;
+
   return (
     <main className="container">
       <header>
         <p className="eyebrow">DACL</p>
         <h1>Ops Dashboard</h1>
-        <p className="subtitle">Minimal Next.js shell ready for iterative sections.</p>
+        <p className="subtitle">Unified data path for agents, cron jobs, and activity.</p>
       </header>
 
-      <section className="grid" aria-label="Dashboard sections">
-        {sections.map((section) => (
-          <article key={section.title} className="card">
-            <h2>{section.title}</h2>
-            <p>{section.description}</p>
-          </article>
-        ))}
+      <section className="grid" aria-label="Agents">
+        <article className="card">
+          <h2>Agents</h2>
+          {agents.length === 0 ? (
+            <EmptyState message="No agent data found." />
+          ) : (
+            <ul>
+              {agents.map((agent) => (
+                <li key={agent.id}>
+                  <strong>{agent.id}</strong> — {agent.role} — {agent.statusSummary}
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="card">
+          <h2>Cron Jobs</h2>
+          {cronJobs.length === 0 ? (
+            <EmptyState message="No cron data found." />
+          ) : (
+            <ul>
+              {cronJobs.map((job) => (
+                <li key={job.name}>
+                  <strong>{job.name}</strong> — {job.schedule} — enabled: {String(job.enabled)} — next: {job.nextRun} — last: {job.lastRunStatus}
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="card">
+          <h2>Activity</h2>
+          {activity.length === 0 ? (
+            <EmptyState message="No activity data found." />
+          ) : (
+            <ul>
+              {activity.map((row) => (
+                <li key={`${row.agentId}-${row.updatedAt}`}>
+                  <strong>{row.agentId}</strong> — {row.lastKnownAction} — {row.updatedAt}
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
       </section>
     </main>
   );

--- a/apps/ops-dashboard/data/activity.json
+++ b/apps/ops-dashboard/data/activity.json
@@ -1,0 +1,14 @@
+{
+  "activity": [
+    {
+      "agentId": "dacl-planner-01",
+      "lastKnownAction": "Reviewed child issue scope and acceptance criteria",
+      "updatedAt": "2026-03-04T22:00:00Z"
+    },
+    {
+      "agentId": "dacl-worker-01",
+      "lastKnownAction": "Implemented dashboard data layer",
+      "updatedAt": "2026-03-04T22:40:00Z"
+    }
+  ]
+}

--- a/apps/ops-dashboard/data/cron-jobs.json
+++ b/apps/ops-dashboard/data/cron-jobs.json
@@ -1,0 +1,18 @@
+{
+  "cronJobs": [
+    {
+      "name": "dacl-worker-01-loop",
+      "schedule": "*/15 * * * *",
+      "enabled": true,
+      "nextRun": "2026-03-04T22:45:00Z",
+      "lastRunStatus": "success"
+    },
+    {
+      "name": "dacl-planner-01-loop",
+      "schedule": "*/20 * * * *",
+      "enabled": true,
+      "nextRun": "2026-03-04T23:00:00Z",
+      "lastRunStatus": "success"
+    }
+  ]
+}

--- a/apps/ops-dashboard/lib/data.js
+++ b/apps/ops-dashboard/lib/data.js
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/** @typedef {{ id: string, role: string, statusSummary: string }} AgentRecord */
+/** @typedef {{ name: string, schedule: string, enabled: boolean, nextRun: string, lastRunStatus: string }} CronJobRecord */
+/** @typedef {{ agentId: string, lastKnownAction: string, updatedAt: string }} ActivityRecord */
+/** @typedef {{ agents: AgentRecord[], cronJobs: CronJobRecord[], activity: ActivityRecord[] }} DashboardData */
+
+const repoRoot = path.resolve(process.cwd(), '..', '..');
+
+async function readJson(relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function ensureString(value, fallback = 'unknown') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function deriveStatusSummary(config) {
+  if (!config) {
+    return 'No config available';
+  }
+
+  const worktree = ensureString(config.worktree, 'no worktree configured');
+  return `Configured (${worktree})`;
+}
+
+async function getAgents() {
+  const registry = await readJson('agents/registry.json');
+  const registryAgents = Array.isArray(registry?.agents) ? registry.agents : [];
+
+  const mappedAgents = await Promise.all(
+    registryAgents.map(async (agent) => {
+      const config = agent.config ? await readJson(agent.config) : null;
+
+      return {
+        id: ensureString(agent.agentId),
+        role: ensureString(agent.role),
+        statusSummary: deriveStatusSummary(config)
+      };
+    })
+  );
+
+  return mappedAgents;
+}
+
+async function getCronJobs() {
+  const source = await readJson('apps/ops-dashboard/data/cron-jobs.json');
+  const jobs = Array.isArray(source?.cronJobs) ? source.cronJobs : [];
+
+  return jobs.map((job) => ({
+    name: ensureString(job.name),
+    schedule: ensureString(job.schedule, 'not configured'),
+    enabled: Boolean(job.enabled),
+    nextRun: ensureString(job.nextRun, 'unknown'),
+    lastRunStatus: ensureString(job.lastRunStatus, 'never-run')
+  }));
+}
+
+async function getActivity() {
+  const source = await readJson('apps/ops-dashboard/data/activity.json');
+  const rows = Array.isArray(source?.activity) ? source.activity : [];
+
+  return rows.map((row) => ({
+    agentId: ensureString(row.agentId),
+    lastKnownAction: ensureString(row.lastKnownAction, 'no activity captured'),
+    updatedAt: ensureString(row.updatedAt, 'unknown')
+  }));
+}
+
+/** @returns {Promise<DashboardData>} */
+export async function getDashboardData() {
+  const [agents, cronJobs, activity] = await Promise.all([
+    getAgents(),
+    getCronJobs(),
+    getActivity()
+  ]);
+
+  return {
+    agents,
+    cronJobs,
+    activity
+  };
+}


### PR DESCRIPTION
Closes #10

## Summary
Implements a typed dashboard data layer and a unified server-side retrieval path for Agents, Cron Jobs, and Activity.

## Issue coverage checklist
- [x] Dedicated data module added: `apps/ops-dashboard/lib/data.js` with typed JSDoc structures (`AgentRecord`, `CronJobRecord`, `ActivityRecord`, `DashboardData`).
- [x] Data retrieval uses deterministic local/runtime-safe sources with graceful fallback:
  - `agents/registry.json` + optional agent config files
  - `apps/ops-dashboard/data/cron-jobs.json`
  - `apps/ops-dashboard/data/activity.json`
  - missing/invalid sources return empty arrays/default values
- [x] Unified server-side endpoint wired: `GET /api/dashboard` in `apps/ops-dashboard/app/api/dashboard/route.js`.
- [x] Empty states are explicit in UI for each section (agents/cron/activity), no crash path.

## Evidence
Run app and fetch unified payload:

```bash
cd apps/ops-dashboard
npm run dev
curl -sS http://127.0.0.1:3000/api/dashboard
```

Observed payload shape includes all required fields:
- Agents: `id`, `role`, `statusSummary`
- Cron: `name`, `schedule`, `enabled`, `nextRun`, `lastRunStatus`
- Activity: `agentId`, `lastKnownAction`, `updatedAt`

Fallback validation (missing source input):

```bash
cd apps/ops-dashboard
mv data/activity.json data/activity.json.bak
curl -sS http://127.0.0.1:3000/api/dashboard
mv data/activity.json.bak data/activity.json
```

Observed result: API still returns 200 with `activity: []` and no uncaught crash.

Fix #20 restack validation:

```bash
gh pr view 19 --json files --jq '.files[].path'
gh pr diff 19 --name-only
```

Observed diff scope now contains only #10 data-layer files under `apps/ops-dashboard/` and excludes unrelated `agents/` / `operatives/` changes.

## Risk
- Data files are currently static stubs for cron/activity; they are intentionally minimal and deterministic for v1.
