### PR TITLE
feat: render full dashboard views and add ops-dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,36 @@ sudo apt-get install -y git gh python3 openssl cargo rustc
 
 ---
 
+## Ops Dashboard (`apps/ops-dashboard`)
+
+### Local run
+
+```bash
+cd apps/ops-dashboard
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+### Where data mapping lives
+
+- `apps/ops-dashboard/lib/data.js` reads and normalizes:
+  - `agents/registry.json` + per-agent config files
+  - `apps/ops-dashboard/data/cron-jobs.json`
+  - `apps/ops-dashboard/data/activity.json`
+- `apps/ops-dashboard/app/page.js` renders Agents, Cron Jobs, and Activity cards from that normalized shape.
+- `apps/ops-dashboard/app/api/dashboard/route.js` exposes the same data as JSON.
+
+### How to extend cards/sections
+
+1. Add/adjust source fields in `lib/data.js` (keep defaults human-readable).
+2. Update the matching section renderer in `app/page.js`.
+3. Add any minimal style tweaks in `app/globals.css`.
+4. If needed externally, mirror new fields in `app/api/dashboard/route.js`.
+
+---
+
 ## License
 
 MIT

--- a/apps/ops-dashboard/app/globals.css
+++ b/apps/ops-dashboard/app/globals.css
@@ -63,3 +63,28 @@ h1 {
   color: #cbd5e1;
   line-height: 1.4;
 }
+
+.stack-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stack-list li {
+  display: grid;
+  gap: 0.125rem;
+}
+
+.stack-list span {
+  color: #cbd5e1;
+  font-size: 0.92rem;
+}
+
+.section-state {
+  margin-bottom: 0;
+}
+
+.section-state.error {
+  color: #fda4af;
+}

--- a/apps/ops-dashboard/app/page.js
+++ b/apps/ops-dashboard/app/page.js
@@ -1,65 +1,116 @@
 import { getDashboardData } from '../lib/data';
 
 function EmptyState({ message }) {
-  return <p className="subtitle">{message}</p>;
+  return <p className="subtitle section-state">{message}</p>;
+}
+
+function ErrorState({ message }) {
+  return <p className="subtitle section-state error">{message}</p>;
+}
+
+function AgentSection({ agents }) {
+  if (!Array.isArray(agents)) {
+    return <ErrorState message="Could not render agents right now." />;
+  }
+
+  if (agents.length === 0) {
+    return <EmptyState message="No agent data found." />;
+  }
+
+  return (
+    <ul className="stack-list">
+      {agents.map((agent) => (
+        <li key={agent.id}>
+          <strong>{agent.id}</strong>
+          <span>Role: {agent.role}</span>
+          <span>Status: {agent.statusSummary}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CronSection({ cronJobs }) {
+  if (!Array.isArray(cronJobs)) {
+    return <ErrorState message="Could not render cron jobs right now." />;
+  }
+
+  if (cronJobs.length === 0) {
+    return <EmptyState message="No cron job data found." />;
+  }
+
+  return (
+    <ul className="stack-list">
+      {cronJobs.map((job) => (
+        <li key={job.name}>
+          <strong>{job.name}</strong>
+          <span>Schedule/interval: {job.schedule}</span>
+          <span>Enabled: {String(job.enabled)}</span>
+          <span>Next run: {job.nextRun}</span>
+          <span>Last run/status: {job.lastRunStatus}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ActivitySection({ activity }) {
+  if (!Array.isArray(activity)) {
+    return <ErrorState message="Could not render activity right now." />;
+  }
+
+  if (activity.length === 0) {
+    return <EmptyState message="No activity data found." />;
+  }
+
+  return (
+    <ul className="stack-list">
+      {activity.map((row) => (
+        <li key={`${row.agentId}-${row.updatedAt}`}>
+          <strong>{row.agentId}</strong>
+          <span>Action: {row.lastKnownAction}</span>
+          <span>Timestamp: {row.updatedAt}</span>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 export default async function HomePage() {
-  const data = await getDashboardData();
-  const { agents, cronJobs, activity } = data;
+  let data;
+
+  try {
+    data = await getDashboardData();
+  } catch {
+    data = null;
+  }
+
+  const agents = data?.agents;
+  const cronJobs = data?.cronJobs;
+  const activity = data?.activity;
 
   return (
     <main className="container">
       <header>
         <p className="eyebrow">DACL</p>
         <h1>Ops Dashboard</h1>
-        <p className="subtitle">Unified data path for agents, cron jobs, and activity.</p>
+        <p className="subtitle">Live overview for agents, cron jobs, and recent activity.</p>
       </header>
 
-      <section className="grid" aria-label="Agents">
+      <section className="grid" aria-label="Agents, cron jobs, and activity">
         <article className="card">
           <h2>Agents</h2>
-          {agents.length === 0 ? (
-            <EmptyState message="No agent data found." />
-          ) : (
-            <ul>
-              {agents.map((agent) => (
-                <li key={agent.id}>
-                  <strong>{agent.id}</strong> — {agent.role} — {agent.statusSummary}
-                </li>
-              ))}
-            </ul>
-          )}
+          <AgentSection agents={agents} />
         </article>
 
         <article className="card">
           <h2>Cron Jobs</h2>
-          {cronJobs.length === 0 ? (
-            <EmptyState message="No cron data found." />
-          ) : (
-            <ul>
-              {cronJobs.map((job) => (
-                <li key={job.name}>
-                  <strong>{job.name}</strong> — {job.schedule} — enabled: {String(job.enabled)} — next: {job.nextRun} — last: {job.lastRunStatus}
-                </li>
-              ))}
-            </ul>
-          )}
+          <CronSection cronJobs={cronJobs} />
         </article>
 
         <article className="card">
           <h2>Activity</h2>
-          {activity.length === 0 ? (
-            <EmptyState message="No activity data found." />
-          ) : (
-            <ul>
-              {activity.map((row) => (
-                <li key={`${row.agentId}-${row.updatedAt}`}>
-                  <strong>{row.agentId}</strong> — {row.lastKnownAction} — {row.updatedAt}
-                </li>
-              ))}
-            </ul>
-          )}
+          <ActivitySection activity={activity} />
         </article>
       </section>
     </main>


### PR DESCRIPTION
## Summary
Implements child issue #11 by rendering full dashboard views from the typed data layer and adding run/extend documentation.

Closes #11

## Issue coverage checklist
- [x] Agents section renders `id`, `role`, and `status summary`
- [x] Cron section renders `name`, `schedule/interval`, `enabled`, `next run`, and `last run/status`
- [x] Activity section renders current/last known action with timestamp
- [x] Empty/error states are human-readable for each section
- [x] README includes local run steps and folder-structure/extension notes for `apps/ops-dashboard`

## Evidence / validation
- `cd apps/ops-dashboard && npm install`
- `npm run dev` + live checks:
  - `curl -sS http://127.0.0.1:3000/api/dashboard | jq '.'` returned agents/cron/activity payload mapped from data layer
  - `curl -sS http://127.0.0.1:3000 | grep -E "Agents|Cron Jobs|Activity|Schedule/interval|Next run|Last run/status|Timestamp|Status:" -o | sort -u` returned all required UI field labels
- `npm run lint` currently fails due Next.js 16 lint CLI behavior (`next lint` resolves `lint` as a directory in this setup)
- Equivalent blocking check passed: `npm run build` compiles cleanly

## Files changed
- `apps/ops-dashboard/app/page.js`
- `apps/ops-dashboard/app/globals.css`
- `README.md`

## Risk
Low: UI/rendering + docs only; no data source mutation.
