### PR TITLE
[Child #42] Add canonical run-log template + path helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ All comments begin with `@<agent-id>`.
 
 ## Daily Agent Memory Workflow
 
-- Per-agent memory now lives in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
+- Canonical run-log template source: `operatives/RUN_LOG_TEMPLATE.md`.
+- Canonical path/write helper: `scripts/agent-runlog.sh` creates or resolves:
+  - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
+- During migration, per-agent daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) remain supported to prevent data loss.
 - Runtime read policy: load today's file by default; consult yesterday only when needed.
 - On first run of a new UTC day, run:
   - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -23,7 +23,9 @@ All comments must be proper Markdown via `--body-file` (no escaped `\\n` output)
 See `operatives/COMMENT_STYLE.md`.
 
 ## Agent memory protocol
-- Agents store raw execution notes in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
+- Canonical per-run log template source: `operatives/RUN_LOG_TEMPLATE.md`.
+- Canonical path/write helper: `scripts/agent-runlog.sh` targeting `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
+- During migration, agents may still maintain daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) to avoid data loss.
 - Agents should read today's file by default; read yesterday only when needed for continuity.
 - On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
 

--- a/operatives/RUN_LOG_TEMPLATE.md
+++ b/operatives/RUN_LOG_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Run Log
+- agent_id: {{agent_id}}
+- role: {{role}}
+- timestamp_utc: {{timestamp_utc}}
+- run_id: {{run_id}}
+- repo: {{repo}}
+
+## Actions Taken
+- ...
+
+## Learning
+- ...
+
+## Blockers
+- ... (or "none")
+
+## Next Step
+- ...

--- a/scripts/agent-runlog.sh
+++ b/scripts/agent-runlog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve and optionally initialize canonical per-run agent memory log.
+#
+# Usage:
+#   ./scripts/agent-runlog.sh --agent-id <id> --role <role> --run-id <run-id> [--repo <repo>] [--date YYYY-MM-DD] [--timestamp "YYYY-MM-DD HH:MM UTC"] [--dry-run]
+#
+# Output:
+#   Prints resolved target path to stdout.
+
+AGENT_ID=""
+ROLE=""
+RUN_ID=""
+REPO_LABEL=""
+DATE_UTC="$(date -u +%F)"
+TIMESTAMP_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-id)
+      AGENT_ID="${2:-}"
+      shift 2
+      ;;
+    --role)
+      ROLE="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO_LABEL="${2:-}"
+      shift 2
+      ;;
+    --date)
+      DATE_UTC="${2:-}"
+      shift 2
+      ;;
+    --timestamp)
+      TIMESTAMP_UTC="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" || -z "$ROLE" || -z "$RUN_ID" ]]; then
+  echo "Missing required arguments: --agent-id, --role, --run-id" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [[ -z "$REPO_LABEL" ]]; then
+  REPO_LABEL="$(basename "$REPO_ROOT")"
+fi
+
+TEMPLATE_FILE="$REPO_ROOT/operatives/RUN_LOG_TEMPLATE.md"
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "Template not found: $TEMPLATE_FILE" >&2
+  exit 1
+fi
+
+TARGET_DIR="$REPO_ROOT/agents/memory/$AGENT_ID/$DATE_UTC"
+TARGET_PATH="$TARGET_DIR/$RUN_ID.md"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  mkdir -p "$TARGET_DIR"
+  if [[ ! -f "$TARGET_PATH" ]]; then
+    sed \
+      -e "s/{{agent_id}}/$AGENT_ID/g" \
+      -e "s/{{role}}/$ROLE/g" \
+      -e "s/{{timestamp_utc}}/$TIMESTAMP_UTC/g" \
+      -e "s/{{run_id}}/$RUN_ID/g" \
+      -e "s|{{repo}}|$REPO_LABEL|g" \
+      "$TEMPLATE_FILE" > "$TARGET_PATH"
+  fi
+fi
+
+echo "$TARGET_PATH"


### PR DESCRIPTION
Closes #42

## Summary
Implements the canonical run-log schema and shared path/write helper for the parent #41 memory-layout migration.

## What changed
- Added canonical run-log template source at `operatives/RUN_LOG_TEMPLATE.md`.
- Added helper script `scripts/agent-runlog.sh` that resolves/writes:
  - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
- Updated protocol/docs to point implementers to the canonical source/helper:
  - `operatives/ISSUE_PR_PROTOCOL.md`
  - `README.md`
- Preserved migration compatibility note for existing daily-file logs.

## Issue coverage checklist
- [x] Repo contains canonical run-log schema/template matching parent requirements.
- [x] Helper resolves/writes `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
- [x] Template includes `agent_id`, `role`, `timestamp_utc`, `run_id`, `repo`, plus Actions/Learning/Blockers/Next Step sections.
- [x] Documentation points implementers to canonical template source.

## Validation evidence
```bash
scripts/agent-runlog.sh --agent-id dacl-worker-01 --role worker --run-id ac42-170741 --dry-run
# => /home/openclaw/.openclaw/workspace/DACL/.worktrees/dacl-worker-01/agents/memory/dacl-worker-01/2026-03-05/ac42-170741.md

scripts/agent-runlog.sh --agent-id dacl-worker-01 --role worker --run-id ac42-170741 --repo DACL
# created file with required fields/sections from operatives/RUN_LOG_TEMPLATE.md
```

## Risk
Low. Adds new helper/template and doc references; no runtime behavior replaced yet.
