### PR TITLE
docs: operatives-only architecture + migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,15 +136,31 @@ All comments begin with `@<agent-id>`.
 - Per-agent memory now lives in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
 - Runtime read policy: load today's file by default; consult yesterday only when needed.
 - On first run of a new UTC day, run:
-  - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`
+  - `scripts/agent-memory-rollover.sh <agent-id> operatives/<ROLE>.md`
+  - Example (worker): `scripts/agent-memory-rollover.sh dacl-worker-02 operatives/WORKER.md`
 - Rollover script responsibilities:
   - ensure today's memory file exists
   - detect day rollover with a local state marker
   - summarize the previous day into today's file
-  - promote novel durable lessons into the agent directive
+  - promote novel durable lessons into the shared role operative (`operatives/PLANNER.md`, `operatives/WORKER.md`, etc.)
   - migrate/deprecate legacy monolithic memory files under `agents/memory/<agent-id>.md`
 
 ---
+
+
+## Operatives-only Architecture + Migration
+
+Canonical behavior source is role-based operatives under `operatives/`:
+- planners -> `operatives/PLANNER.md`
+- workers -> `operatives/WORKER.md`
+- orchestrator -> `operatives/ORCHESTRATOR.md`
+
+`agents/directives/*` is now migration/legacy context only and must not be treated as a required runtime dependency for planner/worker loops.
+
+### Migration notes (existing agents)
+- Keep per-agent daily memory paths unchanged: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
+- For rollover/self-improvement, point promotion to role operative file, not per-agent directive file.
+- Any leftover `agents/directives/<agent-id>.md` references should be interpreted as backward-compat notes only until removed.
 
 ## Operatives (Playbooks)
 

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -25,7 +25,9 @@ See `operatives/COMMENT_STYLE.md`.
 ## Agent memory protocol
 - Agents store raw execution notes in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
 - Agents should read today's file by default; read yesterday only when needed for continuity.
-- On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
+- On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> operatives/<ROLE>.md` before normal issue/PR work.
+  - Worker example: `scripts/agent-memory-rollover.sh dacl-worker-02 operatives/WORKER.md`
+  - Planner example: `scripts/agent-memory-rollover.sh dacl-planner-01 operatives/PLANNER.md`
 
 ## Merge condition
 A PR is merge-ready only when:

--- a/operatives/PLANNER.md
+++ b/operatives/PLANNER.md
@@ -1,6 +1,6 @@
 # PLANNER OPERATIVE
 
-Agent ID: `@dacl-planner-01`
+Agent Scope: all `@dacl-planner-*` agents (shared planner behavior)
 
 ## Mission
 Turn broad goals into precise, executable child issues and validate delivered work.
@@ -21,3 +21,8 @@ If a PR does not satisfy acceptance criteria, do not approve it.
 - Planner should merge non-parent implementation PRs once acceptance criteria pass and checks are green.
 - Planner should explicitly comment merge rationale before merging.
 - Alex remains final reviewer/merge authority for the main parent PR.
+
+
+## Operatives-only note
+- This file is the canonical planner behavior source.
+- Per-agent directive files are optional context and must not be required for runtime correctness.

--- a/operatives/WORKER.md
+++ b/operatives/WORKER.md
@@ -1,6 +1,6 @@
 # WORKER OPERATIVE
 
-Agent ID: `@dacl-worker-01`
+Agent Scope: all `@dacl-worker-*` agents (shared worker behavior)
 
 ## Mission
 Implement child issues quickly and correctly.
@@ -19,3 +19,8 @@ Implement child issues quickly and correctly.
 
 ## Rule
 No broad replanning. Execute defined scope.
+
+
+## Operatives-only note
+- This file is the canonical worker behavior source.
+- Per-agent directive files are optional context and must not be required for runtime correctness.


### PR DESCRIPTION
## Linked issue
Closes #40

## Issue coverage checklist
- [x] Docs consistently describe operatives-only model.
- [x] Migration path is explicit and non-ambiguous.
- [x] No contradictions across README + operative docs.

## What changed
- Updated `README.md` daily-memory/rollover guidance to point at role operatives (`operatives/<ROLE>.md`) instead of per-agent directives.
- Added explicit **Operatives-only Architecture + Migration** section to `README.md` with canonical role mapping and migration notes.
- Updated `operatives/ISSUE_PR_PROTOCOL.md` memory protocol to use role operative target examples (planner/worker).
- Updated `operatives/PLANNER.md` and `operatives/WORKER.md` to clarify shared role scope and canonical-source status.

## Evidence
- Validation grep:
  - `grep -RInE "agents/directives|per-agent directive" README.md operatives`
  - Result: remaining references are explicitly marked migration/legacy context in `README.md`; no operative doc requires per-agent directive runtime dependency.
- Manual consistency read-through:
  - `README.md`
  - `operatives/ISSUE_PR_PROTOCOL.md`
  - `operatives/PLANNER.md`
  - `operatives/WORKER.md`

## Risks / Notes
- This PR is docs/protocol-only and does not change runtime code paths directly.
