### PR TITLE
fix: switch planner/worker runtime config to operatives-only

### DIFF
--- a/agents/config/dacl-planner-01.json
+++ b/agents/config/dacl-planner-01.json
@@ -1,11 +1,12 @@
 {
   "agentId": "dacl-planner-01",
   "role": "planner",
-  "directiveFile": "agents/directives/dacl-planner-01.md",
   "memoryFile": "agents/memory/dacl-planner-01.md",
   "metadataFile": "agents/metadata/dacl-planner-01.json",
   "worktree": ".worktrees/dacl-planner-01",
   "memoryDir": "agents/memory/dacl-planner-01",
   "dailyMemoryFileTemplate": "agents/memory/dacl-planner-01/YYYY-MM-DD.md",
-  "memoryFileDeprecated": "agents/memory/dacl-planner-01.md"
+  "memoryFileDeprecated": "agents/memory/dacl-planner-01.md",
+  "operativeFile": "operatives/PLANNER.md",
+  "directiveFileDeprecated": "agents/directives/dacl-planner-01.md"
 }

--- a/agents/config/dacl-planner-02.json
+++ b/agents/config/dacl-planner-02.json
@@ -1,11 +1,12 @@
 {
   "agentId": "dacl-planner-02",
   "role": "planner",
-  "directiveFile": "agents/directives/dacl-planner-02.md",
   "memoryFile": "agents/memory/dacl-planner-02.md",
   "metadataFile": "agents/metadata/dacl-planner-02.json",
   "worktree": ".worktrees/dacl-planner-02",
   "memoryDir": "agents/memory/dacl-planner-02",
   "dailyMemoryFileTemplate": "agents/memory/dacl-planner-02/YYYY-MM-DD.md",
-  "memoryFileDeprecated": "agents/memory/dacl-planner-02.md"
+  "memoryFileDeprecated": "agents/memory/dacl-planner-02.md",
+  "operativeFile": "operatives/PLANNER.md",
+  "directiveFileDeprecated": "agents/directives/dacl-planner-02.md"
 }

--- a/agents/config/dacl-worker-01.json
+++ b/agents/config/dacl-worker-01.json
@@ -1,11 +1,12 @@
 {
   "agentId": "dacl-worker-01",
   "role": "worker",
-  "directiveFile": "agents/directives/dacl-worker-01.md",
   "memoryFile": "agents/memory/dacl-worker-01.md",
   "metadataFile": "agents/metadata/dacl-worker-01.json",
   "worktree": ".worktrees/dacl-worker-01",
   "memoryDir": "agents/memory/dacl-worker-01",
   "dailyMemoryFileTemplate": "agents/memory/dacl-worker-01/YYYY-MM-DD.md",
-  "memoryFileDeprecated": "agents/memory/dacl-worker-01.md"
+  "memoryFileDeprecated": "agents/memory/dacl-worker-01.md",
+  "operativeFile": "operatives/WORKER.md",
+  "directiveFileDeprecated": "agents/directives/dacl-worker-01.md"
 }

--- a/agents/config/dacl-worker-02.json
+++ b/agents/config/dacl-worker-02.json
@@ -1,11 +1,12 @@
 {
   "agentId": "dacl-worker-02",
   "role": "worker",
-  "directiveFile": "agents/directives/dacl-worker-02.md",
   "memoryFile": "agents/memory/dacl-worker-02.md",
   "metadataFile": "agents/metadata/dacl-worker-02.json",
   "worktree": ".worktrees/dacl-worker-02",
   "memoryDir": "agents/memory/dacl-worker-02",
   "dailyMemoryFileTemplate": "agents/memory/dacl-worker-02/YYYY-MM-DD.md",
-  "memoryFileDeprecated": "agents/memory/dacl-worker-02.md"
+  "memoryFileDeprecated": "agents/memory/dacl-worker-02.md",
+  "operativeFile": "operatives/WORKER.md",
+  "directiveFileDeprecated": "agents/directives/dacl-worker-02.md"
 }

--- a/scripts/agent-memory-rollover.sh
+++ b/scripts/agent-memory-rollover.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # Ensure daily memory file exists and perform day-rollover consolidation.
-# Usage: ./scripts/agent-memory-rollover.sh <agent-id> <directive-file>
+# Usage: ./scripts/agent-memory-rollover.sh <agent-id> <operative-file>
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <agent-id> <directive-file>" >&2
+  echo "Usage: $0 <agent-id> <operative-file>" >&2
   exit 1
 fi
 
 AGENT_ID="$1"
-DIRECTIVE_FILE="$2"
+OPERATIVE_FILE="$2"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TODAY="$(date -u +%F)"
 NOW_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
@@ -23,8 +23,8 @@ LEGACY_ARCHIVE="${MEMORY_DIR}/legacy.md"
 
 mkdir -p "${MEMORY_DIR}"
 
-if [[ ! -f "${DIRECTIVE_FILE}" ]]; then
-  echo "Directive file not found: ${DIRECTIVE_FILE}" >&2
+if [[ ! -f "${OPERATIVE_FILE}" ]]; then
+  echo "Operative file not found: ${OPERATIVE_FILE}" >&2
   exit 1
 fi
 
@@ -99,14 +99,14 @@ if [[ -f "${PREV_FILE}" ]]; then
     ADDED=0
     while IFS= read -r candidate; do
       [[ -z "${candidate}" ]] && continue
-      if ! grep -Fqi "${candidate}" "${DIRECTIVE_FILE}"; then
+      if ! grep -Fqi "${candidate}" "${OPERATIVE_FILE}"; then
         if [[ ${ADDED} -eq 0 ]]; then
           {
             echo
             echo "## Distilled lessons from daily memory rollover"
-          } >> "${DIRECTIVE_FILE}"
+          } >> "${OPERATIVE_FILE}"
         fi
-        echo "- ${candidate}" >> "${DIRECTIVE_FILE}"
+        echo "- ${candidate}" >> "${OPERATIVE_FILE}"
         ADDED=1
       fi
     done <<< "${CANDIDATES}"


### PR DESCRIPTION
## Linked issue
Closes #38

## Issue coverage checklist
- [x] Runtime config no longer requires per-agent directive files for planner/worker agents (`directiveFile` removed from active config shape).
- [x] Planner/worker config now points to shared role operatives (`operatives/PLANNER.md`, `operatives/WORKER.md`).
- [x] Rollover helper usage now references role operatives (`<operative-file>`) rather than directives.
- [x] Daily memory behavior remains unchanged (`memoryDir` + `dailyMemoryFileTemplate` untouched).

## Evidence
- `grep -RIn --exclude-dir=.git --exclude-dir=.next --exclude-dir=node_modules "agents/directives/" operatives scripts agents | head -n 50`
  - Result: only legacy directive files and explicit `directiveFileDeprecated` fields reference `agents/directives/*`; active runtime fields now use `operativeFile`.
- `./scripts/agent-memory-rollover.sh dacl-worker-02 operatives/WORKER.md`
  - Result: succeeds with operative path.
- `./scripts/agent-memory-rollover.sh dacl-planner-01 operatives/PLANNER.md`
  - Result: succeeds with operative path.

## Risks / Notes
- `directiveFileDeprecated` is intentionally retained for migration/audit visibility; runtime should consume `operativeFile`.
