### PR TITLE
[Child #43] Wire planner/worker flows to one-file-per-run memory logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ All comments begin with `@<agent-id>`.
 - Canonical run-log template source: `operatives/RUN_LOG_TEMPLATE.md`.
 - Canonical path/write helper: `scripts/agent-runlog.sh` creates or resolves:
   - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
+- Runtime write policy: each planner/worker run should emit one log file under `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
 - Runtime proof helper: `scripts/validate-runlog-emission.sh` validates one planner + one worker run each emit exactly one new run-log file and include canonical sections.
-- During migration, per-agent daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) remain supported to prevent data loss.
+- During migration, per-agent daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) remain supported only as fallback to prevent data loss.
 - Runtime read policy: load today's file by default; consult yesterday only when needed.
 - On first run of a new UTC day, run:
   - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`

--- a/agents/directives/dacl-planner-01.md
+++ b/agents/directives/dacl-planner-01.md
@@ -34,7 +34,8 @@ Turn broad goals into precise bite-sized issues, and review worker PRs against i
 - Before merging, leave one concise `@dacl-planner-01` comment stating why merge is valid.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-planner-01/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-planner-01 --role planner --run-id <run-id>` and write run notes there (`agents/memory/dacl-planner-01/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-planner-01 agents/directives/dacl-planner-01.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/agents/directives/dacl-planner-02.md
+++ b/agents/directives/dacl-planner-02.md
@@ -20,7 +20,8 @@ Break broad goals into precise bite-sized issues and review worker PRs against a
 6. Mark parent->main PR ready-to-merge when acceptance criteria pass.
 
 ## Memory discipline
-- Read daily memory at `agents/memory/dacl-planner-02/YYYY-MM-DD.md` (today by default; yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-planner-02 --role planner --run-id <run-id>` and write run notes there (`agents/memory/dacl-planner-02/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-planner-02 agents/directives/dacl-planner-02.md`.
 
 ## Merge authority

--- a/agents/directives/dacl-worker-01.md
+++ b/agents/directives/dacl-worker-01.md
@@ -40,7 +40,8 @@ Implement bite-sized issues quickly and correctly.
 - Do not leave partial work without a blocker comment.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-worker-01/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-worker-01 --role worker --run-id <run-id>` and write run notes there (`agents/memory/dacl-worker-01/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-worker-01 agents/directives/dacl-worker-01.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/agents/directives/dacl-worker-02.md
+++ b/agents/directives/dacl-worker-02.md
@@ -30,7 +30,8 @@ Implement bite-sized issues quickly and correctly.
 - Do not leave partial work without a blocker comment.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-worker-02/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-worker-02 --role worker --run-id <run-id>` and write run notes there (`agents/memory/dacl-worker-02/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-worker-02 agents/directives/dacl-worker-02.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -26,7 +26,7 @@ See `operatives/COMMENT_STYLE.md`.
 - Canonical per-run log template source: `operatives/RUN_LOG_TEMPLATE.md`.
 - Canonical path/write helper: `scripts/agent-runlog.sh` targeting `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
 - During migration, agents may still maintain daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) to avoid data loss.
-- Agents should read today's file by default; read yesterday only when needed for continuity.
+- Agents should read today's run-log folder by default and consult yesterday's folder only when needed for continuity.
 - On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
 
 ## Merge condition

--- a/operatives/WORKER.md
+++ b/operatives/WORKER.md
@@ -15,7 +15,7 @@ Implement child issues quickly and correctly.
 ## Intake gate (hard)
 - Do not start issues missing either label (`status:ready-for-work`, `role:worker`).
 - If issue is missing labels, ask planner to classify it first.
-- Read daily memory (`agents/memory/<agent-id>/YYYY-MM-DD.md`) and run day-rollover consolidation on first UTC run of each day.
+- For each run, create/resolve a run log at `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via `scripts/agent-runlog.sh`; run day-rollover consolidation on first UTC run each day.
 
 ## Rule
 No broad replanning. Execute defined scope.


### PR DESCRIPTION
## Linked issue
Closes #43

## Issue coverage checklist
- [x] Planner runs emit one new file per run under `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via explicit planner directive flow.
- [x] Worker runs emit one new file per run under `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via explicit worker directive flow.
- [x] Emitted files follow the canonical template from child #42 (directives point to `scripts/agent-runlog.sh` + canonical schema sections).
- [x] Standard flow documents no duplicate-write expectation by defining one run-log write action per run.

## Evidence
- Updated planner/worker directive execution flow to call:
  - `scripts/agent-runlog.sh --agent-id <id> --role <role> --run-id <run-id>`
- Updated worker operative + issue/PR protocol + README memory policy to use run-folder/per-run language.
- Validation commands:
  - `grep -RIn "agent-runlog.sh --agent-id dacl-\\(planner\\|worker\\)" agents/directives`
  - `grep -n "Runtime write policy" README.md`
  - `grep -n "run-log folder" operatives/ISSUE_PR_PROTOCOL.md`

## Risks / Notes
- Kept daily-file references as migration fallback only; primary runtime behavior for planner/worker loops is now per-run logging.
