### PR TITLE
fix(ops): clean restack of #39 concurrency flow with scope-only diff

### DIFF
--- a/scripts/agent-memory-rollover.sh
+++ b/scripts/agent-memory-rollover.sh
@@ -12,6 +12,7 @@ fi
 AGENT_ID="$1"
 OPERATIVE_FILE="$2"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 TODAY="$(date -u +%F)"
 NOW_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
 
@@ -27,6 +28,72 @@ if [[ ! -f "${OPERATIVE_FILE}" ]]; then
   echo "Operative file not found: ${OPERATIVE_FILE}" >&2
   exit 1
 fi
+
+infer_role() {
+  local raw="${1#dacl-}"
+  echo "${raw%%-*}"
+}
+
+canonical_operative_path() {
+  local role="$1"
+  echo "${REPO_ROOT}/operatives/$(echo "${role}" | tr '[:lower:]' '[:upper:]').md"
+}
+
+promote_to_shared_operative() {
+  local agent_id="$1"
+  local source_file="$2"
+  local role
+  role="$(infer_role "${agent_id}")"
+
+  local operative_file
+  operative_file="$(canonical_operative_path "${role}")"
+
+  if [[ ! -f "${operative_file}" ]]; then
+    echo "[rollover] Shared operative target missing for role '${role}': ${operative_file}" >&2
+    return 0
+  fi
+
+  local candidates
+  candidates="$(grep -Ei '^- .*(always|never|must|should|avoid|ensure|remember|if)\b' "${source_file}" | sed 's/^- //' || true)"
+  if [[ -z "${candidates}" ]]; then
+    echo "[rollover] No durable lesson candidates to promote for role '${role}'."
+    return 0
+  fi
+
+  mkdir -p "${GIT_COMMON_DIR}/locks"
+  local lock_file="${GIT_COMMON_DIR}/locks/operative-${role}.lock"
+
+  exec 8>"${lock_file}"
+  if ! flock -n 8; then
+    echo "[rollover] Lock contention on role '${role}' operative (${lock_file})." >&2
+    echo "[rollover] Another same-role promotion is active. Retry in a few seconds. No files were modified." >&2
+    return 75
+  fi
+
+  local section="## Distilled role learnings"
+  if ! grep -Fq "${section}" "${operative_file}"; then
+    {
+      echo
+      echo "${section}"
+      echo
+    } >> "${operative_file}"
+  fi
+
+  local added=0
+  while IFS= read -r candidate; do
+    [[ -z "${candidate}" ]] && continue
+    if ! grep -Fqi "${candidate}" "${operative_file}"; then
+      printf -- "- %s\n" "${candidate}" >> "${operative_file}"
+      added=1
+    fi
+  done <<< "${candidates}"
+
+  if [[ ${added} -eq 1 ]]; then
+    echo "[rollover] Promoted durable lessons to ${operative_file} (role=${role})."
+  else
+    echo "[rollover] Durable lessons already present in ${operative_file} (role=${role})."
+  fi
+}
 
 # One-time migration/deprecation of monolithic memory file.
 if [[ -f "${LEGACY_FILE}" ]]; then
@@ -93,24 +160,7 @@ if [[ -f "${PREV_FILE}" ]]; then
     fi
   } >> "${TODAY_FILE}"
 
-  CANDIDATES="$(grep -Ei '^- .*\b(always|never|must|should|avoid|ensure|remember|if)\b' "${PREV_FILE}" | sed 's/^- //' || true)"
-
-  if [[ -n "${CANDIDATES}" ]]; then
-    ADDED=0
-    while IFS= read -r candidate; do
-      [[ -z "${candidate}" ]] && continue
-      if ! grep -Fqi "${candidate}" "${OPERATIVE_FILE}"; then
-        if [[ ${ADDED} -eq 0 ]]; then
-          {
-            echo
-            echo "## Distilled lessons from daily memory rollover"
-          } >> "${OPERATIVE_FILE}"
-        fi
-        echo "- ${candidate}" >> "${OPERATIVE_FILE}"
-        ADDED=1
-      fi
-    done <<< "${CANDIDATES}"
-  fi
+  promote_to_shared_operative "${AGENT_ID}" "${PREV_FILE}" || true
 fi
 
 echo "${TODAY}" > "${STATE_FILE}"

--- a/scripts/memory-sync.sh
+++ b/scripts/memory-sync.sh
@@ -1,38 +1,65 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync one memory file directly to origin/main with a simple lock + retry.
-# Usage: ./scripts/memory-sync.sh <agent-id> <memory-file> [note]
+# Sync one memory/operative file directly to origin/main with deterministic locking.
+# Usage: ./scripts/memory-sync.sh <agent-id> <file-path> [note]
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <agent-id> <memory-file> [note]" >&2
+  echo "Usage: $0 <agent-id> <file-path> [note]" >&2
   exit 1
 fi
 
 AGENT_ID="$1"
-MEM_FILE="$2"
+TARGET_FILE="$2"
 NOTE="${3:-update memory}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-LOCK_FILE="${REPO_ROOT}/.git/memory-sync.lock"
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 
-if [[ ! -f "${MEM_FILE}" ]]; then
-  echo "Memory file not found: ${MEM_FILE}" >&2
+if [[ ! -f "${TARGET_FILE}" ]]; then
+  echo "File not found: ${TARGET_FILE}" >&2
   exit 1
 fi
 
+infer_role() {
+  local raw="${1#dacl-}"
+  echo "${raw%%-*}"
+}
+
+role="$(infer_role "${AGENT_ID}")"
+lock_scope="memory"
+if [[ "${TARGET_FILE}" == *"/operatives/"* || "${TARGET_FILE}" == operatives/* ]]; then
+  lock_scope="operative-${role}"
+fi
+
+mkdir -p "${GIT_COMMON_DIR}/locks"
+LOCK_FILE="${GIT_COMMON_DIR}/locks/${lock_scope}-sync.lock"
+
 exec 9>"${LOCK_FILE}"
-flock -x 9
+acquired=0
+for attempt in 1 2 3; do
+  if flock -n 9; then
+    acquired=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ ${acquired} -ne 1 ]]; then
+  echo "Lock contention for ${lock_scope} sync (${LOCK_FILE})." >&2
+  echo "Another sync is in progress; retry in a few seconds. No partial writes were applied." >&2
+  exit 75
+fi
 
 git fetch origin main >/dev/null 2>&1 || true
 git checkout main >/dev/null 2>&1 || true
 git pull --ff-only origin main >/dev/null 2>&1 || true
 
-if git diff --quiet -- "${MEM_FILE}" && git diff --cached --quiet -- "${MEM_FILE}"; then
-  echo "No memory changes to sync for ${MEM_FILE}"
+if git diff --quiet -- "${TARGET_FILE}" && git diff --cached --quiet -- "${TARGET_FILE}"; then
+  echo "No changes to sync for ${TARGET_FILE}"
   exit 0
 fi
 
-git add -- "${MEM_FILE}"
+git add -- "${TARGET_FILE}"
 
 AGENT_NAME="${AGENT_ID}"
 AGENT_EMAIL="${AGENT_ID}@users.noreply.github.com"
@@ -56,4 +83,4 @@ if ! git push origin main >/dev/null 2>&1; then
   git push origin main >/dev/null 2>&1
 fi
 
-echo "Synced ${MEM_FILE} to main"
+echo "Synced ${TARGET_FILE} to main"


### PR DESCRIPTION
## Summary
Restacks the #39 concurrency-flow fix onto fresh `parent/36-operatives-only-model` and keeps scope limited to the two implementation scripts required by #49.

## Scope
- `scripts/memory-sync.sh`
- `scripts/agent-memory-rollover.sh`

## What changed
- Added role-scoped sync lock targeting (`operative-<role>-sync.lock`) for operative updates.
- Added deterministic lock retry + safe failure path (`exit 75`) with retry guidance and explicit no-partial-write messaging.
- Moved rollover durable-lesson promotion to role-shared operative targets (`operatives/<ROLE>.md`) guarded by per-role lock (`operative-<role>.lock`).

## Validation evidence
### 1) Syntax checks
```bash
bash -n scripts/memory-sync.sh && bash -n scripts/agent-memory-rollover.sh
# output
syntax_ok
```

### 2) Lock contention (shell A holds lock, shell B exits non-zero)
```bash
./scripts/memory-sync.sh dacl-worker-01 operatives/WORKER.md "lock contention evidence"
# output
exit_code=75
Lock contention for operative-worker sync (.git/locks/operative-worker-sync.lock).
Another sync is in progress; retry in a few seconds. No partial writes were applied.
```

### 3) No malformed partial markdown in target operative
```bash
grep -nE '^(<<<<<<<|=======|>>>>>>>)' operatives/WORKER.md || echo no_conflict_markers
# output
no_conflict_markers
```

## Diff guard
- No agent memory file changes
- No per-agent directive file changes

Closes #49
