### PR TITLE
[Child #33] Enforce daily-memory paths in scripts/automation

### DIFF
--- a/scripts/agent-memory-rollover.sh
+++ b/scripts/agent-memory-rollover.sh
@@ -13,13 +13,9 @@ AGENT_ID="$1"
 DIRECTIVE_FILE="$2"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TODAY="$(date -u +%F)"
-NOW_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
-
 MEMORY_DIR="${REPO_ROOT}/agents/memory/${AGENT_ID}"
 TODAY_FILE="${MEMORY_DIR}/${TODAY}.md"
 STATE_FILE="${MEMORY_DIR}/.rollover-state"
-LEGACY_FILE="${REPO_ROOT}/agents/memory/${AGENT_ID}.md"
-LEGACY_ARCHIVE="${MEMORY_DIR}/legacy.md"
 
 mkdir -p "${MEMORY_DIR}"
 
@@ -28,34 +24,7 @@ if [[ ! -f "${DIRECTIVE_FILE}" ]]; then
   exit 1
 fi
 
-# One-time migration/deprecation of monolithic memory file.
-if [[ -f "${LEGACY_FILE}" ]]; then
-  if [[ ! -f "${LEGACY_ARCHIVE}" ]]; then
-    cp "${LEGACY_FILE}" "${LEGACY_ARCHIVE}"
-  fi
-  if [[ ! -f "${TODAY_FILE}" ]]; then
-    {
-      echo "# Memory — ${AGENT_ID} (${TODAY})"
-      echo
-      echo "_Migrated from legacy file on ${NOW_UTC}._"
-      echo
-      cat "${LEGACY_FILE}"
-      echo
-    } > "${TODAY_FILE}"
-  fi
-  cat > "${LEGACY_FILE}" <<EOF
-# Deprecated Memory Path
-
-This file is deprecated.
-
-Use daily memory files under:
-- agents/memory/${AGENT_ID}/YYYY-MM-DD.md
-
-Legacy content archived at:
-- agents/memory/${AGENT_ID}/legacy.md
-EOF
-fi
-
+# Daily-memory-first behavior: create today's file if missing.
 if [[ ! -f "${TODAY_FILE}" ]]; then
   cat > "${TODAY_FILE}" <<EOF
 # Memory — ${AGENT_ID} (${TODAY})

--- a/scripts/memory-sync.sh
+++ b/scripts/memory-sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync one memory file directly to origin/main with a simple lock + retry.
+# Sync one daily memory/directive file directly to origin/main with a simple lock + retry.
 # Usage: ./scripts/memory-sync.sh <agent-id> <memory-file> [note]
 
 if [[ $# -lt 2 ]]; then
@@ -17,6 +17,19 @@ LOCK_FILE="${REPO_ROOT}/.git/memory-sync.lock"
 
 if [[ ! -f "${MEM_FILE}" ]]; then
   echo "Memory file not found: ${MEM_FILE}" >&2
+  exit 1
+fi
+
+# Enforce daily-memory and directive sync targets only; reject deprecated monolithic paths.
+if [[ "${MEM_FILE}" == *"agents/memory/${AGENT_ID}.md" ]]; then
+  echo "Refusing deprecated memory path: ${MEM_FILE}" >&2
+  echo "Use agents/memory/${AGENT_ID}/YYYY-MM-DD.md instead." >&2
+  exit 1
+fi
+
+if [[ "${MEM_FILE}" != agents/memory/${AGENT_ID}/*.md && "${MEM_FILE}" != agents/directives/${AGENT_ID}.md ]]; then
+  echo "Unsupported sync target: ${MEM_FILE}" >&2
+  echo "Allowed: agents/memory/${AGENT_ID}/YYYY-MM-DD.md or agents/directives/${AGENT_ID}.md" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Linked issue
Closes #33

## Issue coverage checklist
- [x] Script flow is daily-memory-first with no deprecated-path dependency.
- [x] Rollover behavior remains active and documented in script comments.
- [x] Planner/worker loops can run without touching deprecated memory files.

## Evidence
- `bash -n scripts/agent-memory-rollover.sh scripts/memory-sync.sh` ✅
- `./scripts/agent-memory-rollover.sh dacl-worker-02 agents/directives/dacl-worker-02.md` ✅ (safe/idempotent execution)
- `./scripts/memory-sync.sh dacl-worker-02 agents/memory/dacl-worker-02.md "test deprecated path guard"` ✅ rejected deprecated path with exit code `1`
- `grep -RIn "legacy|deprecated" scripts || true` ✅ no stale deprecated-path handling left in active script flow.

## Risks / Notes
- `memory-sync.sh` now hard-fails unsupported targets and allows only:
  - `agents/memory/<agent-id>/YYYY-MM-DD.md`
  - `agents/directives/<agent-id>.md`
- This intentionally tightens behavior to prevent accidental writes to deprecated monolithic memory paths.
