### PR TITLE
Polish ops-dashboard cards, hierarchy, responsiveness + README notes

### DIFF
--- a/apps/ops-dashboard/README.md
+++ b/apps/ops-dashboard/README.md
@@ -1,0 +1,35 @@
+# ops-dashboard
+
+Operations dashboard built with **Next.js (App Router) + TypeScript + Tailwind CSS v4 + shadcn/ui**.
+
+## Stack notes
+
+- **TypeScript** is enabled via `tsconfig.json` and `next-env.d.ts`.
+- **Tailwind CSS v4** is configured through `app/globals.css` using `@import "tailwindcss"` and CSS theme tokens.
+- **shadcn/ui** is configured with `components.json`; card primitives are in `components/ui/card.tsx`.
+- UI data sources are file-backed JSON fixtures under `data/` and loaded by `lib/data.ts`.
+
+## Local development
+
+From repo root:
+
+```bash
+npm --prefix apps/ops-dashboard install
+npm --prefix apps/ops-dashboard run dev
+```
+
+Then open: `http://localhost:3000`
+
+## Build and run
+
+```bash
+npm --prefix apps/ops-dashboard run build
+npm --prefix apps/ops-dashboard run start
+```
+
+## Validation checklist
+
+- Dashboard renders the three key card groups: **Agents**, **Cron Jobs**, **Activity**.
+- Layout is responsive across mobile/tablet/desktop widths.
+- Data views remain functional (no schema changes required for existing JSON fixtures).
+- Build passes: `npm --prefix apps/ops-dashboard run build`.

--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -1,12 +1,62 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { getDashboardData, type ActivityRecord, type AgentRecord, type CronJobRecord } from '../lib/data';
 
 function EmptyState({ message }: { message: string }) {
-  return <p className="text-muted-foreground text-sm">{message}</p>;
+  return (
+    <p className="rounded-lg border border-dashed border-border/70 bg-background/20 px-4 py-6 text-center text-sm text-muted-foreground">
+      {message}
+    </p>
+  );
 }
 
 function ErrorState({ message }: { message: string }) {
-  return <p className="text-sm text-rose-300">{message}</p>;
+  return (
+    <p className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-6 text-center text-sm text-rose-200">
+      {message}
+    </p>
+  );
+}
+
+function Pill({
+  label,
+  tone = 'neutral',
+}: {
+  label: string;
+  tone?: 'neutral' | 'good' | 'warn' | 'bad';
+}) {
+  const toneClass =
+    tone === 'good'
+      ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
+      : tone === 'warn'
+        ? 'border-amber-400/40 bg-amber-500/15 text-amber-200'
+        : tone === 'bad'
+          ? 'border-rose-400/40 bg-rose-500/15 text-rose-200'
+          : 'border-border/60 bg-background/40 text-muted-foreground';
+
+  return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${toneClass}`}>{label}</span>;
+}
+
+function toneFromText(input: string): 'neutral' | 'good' | 'warn' | 'bad' {
+  const value = input.toLowerCase();
+  if (value.includes('ok') || value.includes('healthy') || value.includes('success') || value.includes('online')) return 'good';
+  if (value.includes('degrad') || value.includes('retry') || value.includes('slow') || value.includes('pending')) return 'warn';
+  if (value.includes('error') || value.includes('fail') || value.includes('down') || value.includes('offline')) return 'bad';
+  return 'neutral';
+}
+
+function StackRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 sm:grid-cols-[8.5rem_1fr] sm:items-center sm:gap-3">
+      <span className="text-xs tracking-wide text-muted-foreground uppercase">{label}</span>
+      <span className="text-sm leading-relaxed text-foreground/95">{value}</span>
+    </div>
+  );
 }
 
 function AgentSection({ agents }: { agents: AgentRecord[] | undefined }) {
@@ -16,10 +66,17 @@ function AgentSection({ agents }: { agents: AgentRecord[] | undefined }) {
   return (
     <ul className="grid gap-3">
       {agents.map((agent) => (
-        <li key={agent.id} className="grid gap-0.5 rounded-md border border-border/70 bg-background/30 p-3">
-          <strong>{agent.id}</strong>
-          <span className="text-muted-foreground text-sm">Role: {agent.role}</span>
-          <span className="text-muted-foreground text-sm">Status: {agent.statusSummary}</span>
+        <li
+          key={agent.id}
+          className="rounded-xl border border-border/80 bg-background/30 p-4 shadow-sm transition-colors hover:border-border"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <p className="text-base font-semibold tracking-tight">{agent.id}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground uppercase">{agent.role}</p>
+            </div>
+            <Pill label={agent.statusSummary} tone={toneFromText(agent.statusSummary)} />
+          </div>
         </li>
       ))}
     </ul>
@@ -33,12 +90,20 @@ function CronSection({ cronJobs }: { cronJobs: CronJobRecord[] | undefined }) {
   return (
     <ul className="grid gap-3">
       {cronJobs.map((job) => (
-        <li key={job.name} className="grid gap-0.5 rounded-md border border-border/70 bg-background/30 p-3">
-          <strong>{job.name}</strong>
-          <span className="text-muted-foreground text-sm">Schedule/interval: {job.schedule}</span>
-          <span className="text-muted-foreground text-sm">Enabled: {String(job.enabled)}</span>
-          <span className="text-muted-foreground text-sm">Next run: {job.nextRun}</span>
-          <span className="text-muted-foreground text-sm">Last run/status: {job.lastRunStatus}</span>
+        <li
+          key={job.name}
+          className="rounded-xl border border-border/80 bg-background/30 p-4 shadow-sm transition-colors hover:border-border"
+        >
+          <div className="mb-3 flex items-start justify-between gap-2">
+            <p className="text-base font-semibold tracking-tight">{job.name}</p>
+            <Pill label={job.enabled ? 'Enabled' : 'Disabled'} tone={job.enabled ? 'good' : 'warn'} />
+          </div>
+
+          <div className="space-y-2.5">
+            <StackRow label="Schedule" value={job.schedule} />
+            <StackRow label="Next run" value={job.nextRun} />
+            <StackRow label="Last run" value={job.lastRunStatus} />
+          </div>
         </li>
       ))}
     </ul>
@@ -52,10 +117,15 @@ function ActivitySection({ activity }: { activity: ActivityRecord[] | undefined 
   return (
     <ul className="grid gap-3">
       {activity.map((row) => (
-        <li key={`${row.agentId}-${row.updatedAt}`} className="grid gap-0.5 rounded-md border border-border/70 bg-background/30 p-3">
-          <strong>{row.agentId}</strong>
-          <span className="text-muted-foreground text-sm">Action: {row.lastKnownAction}</span>
-          <span className="text-muted-foreground text-sm">Timestamp: {row.updatedAt}</span>
+        <li
+          key={`${row.agentId}-${row.updatedAt}`}
+          className="rounded-xl border border-border/80 bg-background/30 p-4 shadow-sm transition-colors hover:border-border"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <p className="text-base font-semibold tracking-tight">{row.agentId}</p>
+            <Pill label={row.updatedAt} />
+          </div>
+          <p className="mt-2 text-sm leading-relaxed text-foreground/90">{row.lastKnownAction}</p>
         </li>
       ))}
     </ul>
@@ -71,39 +141,64 @@ export default async function HomePage() {
     data = null;
   }
 
+  const totalAgents = data?.agents?.length ?? 0;
+  const totalCronJobs = data?.cronJobs?.length ?? 0;
+  const totalActivity = data?.activity?.length ?? 0;
+
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 py-12">
-      <header className="space-y-2">
-        <p className="text-muted-foreground text-xs tracking-[0.16em] uppercase">DACL</p>
-        <h1 className="text-4xl font-semibold tracking-tight">Ops Dashboard</h1>
-        <p className="text-muted-foreground">Live overview for agents, cron jobs, and recent activity.</p>
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10 lg:gap-7 lg:px-8 lg:py-12">
+      <header className="space-y-3">
+        <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1.5">
+            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Ops Dashboard</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+              Operational overview for agents, cron jobs, and recent activity.
+            </p>
+          </div>
+
+          <div className="grid w-full grid-cols-3 gap-2 text-center sm:w-auto sm:gap-3">
+            <div className="rounded-lg border border-border/70 bg-background/30 px-3 py-2">
+              <p className="text-lg font-semibold leading-none sm:text-xl">{totalAgents}</p>
+              <p className="mt-1 text-xs text-muted-foreground uppercase">Agents</p>
+            </div>
+            <div className="rounded-lg border border-border/70 bg-background/30 px-3 py-2">
+              <p className="text-lg font-semibold leading-none sm:text-xl">{totalCronJobs}</p>
+              <p className="mt-1 text-xs text-muted-foreground uppercase">Cron Jobs</p>
+            </div>
+            <div className="rounded-lg border border-border/70 bg-background/30 px-3 py-2">
+              <p className="text-lg font-semibold leading-none sm:text-xl">{totalActivity}</p>
+              <p className="mt-1 text-xs text-muted-foreground uppercase">Activity</p>
+            </div>
+          </div>
+        </div>
       </header>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" aria-label="Agents, cron jobs, and activity">
-        <Card>
-          <CardHeader>
-            <CardTitle>Agents</CardTitle>
-            <CardDescription>Current worker and planner state.</CardDescription>
+        <Card className="border-border/80 bg-card/95">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-xl">Agents</CardTitle>
+            <CardDescription>Worker and planner status at a glance.</CardDescription>
           </CardHeader>
           <CardContent>
             <AgentSection agents={data?.agents} />
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Cron Jobs</CardTitle>
-            <CardDescription>Schedules and run health.</CardDescription>
+        <Card className="border-border/80 bg-card/95">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-xl">Cron Jobs</CardTitle>
+            <CardDescription>Schedule coverage and most recent health data.</CardDescription>
           </CardHeader>
           <CardContent>
             <CronSection cronJobs={data?.cronJobs} />
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Activity</CardTitle>
-            <CardDescription>Latest agent updates.</CardDescription>
+        <Card className="border-border/80 bg-card/95 md:col-span-2 xl:col-span-1">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-xl">Activity</CardTitle>
+            <CardDescription>Latest actions reported by dashboard agents.</CardDescription>
           </CardHeader>
           <CardContent>
             <ActivitySection activity={data?.activity} />


### PR DESCRIPTION
## Summary
This PR completes issue #26 by polishing the `apps/ops-dashboard` card UI and responsive hierarchy while keeping existing data views intact.

Closes #26

## What changed
- Redesigned card content presentation for:
  - Agents
  - Cron Jobs
  - Activity
- Improved visual hierarchy and readability:
  - Added status pills with tone mapping (`good/warn/bad/neutral`)
  - Increased spacing, rounded card containers, and stronger typography structure
  - Added compact summary stat chips in the dashboard header
- Responsive polish:
  - Tuned page/container spacing across breakpoints
  - Refined grid behavior for card sections on mobile/tablet/desktop
  - Improved row formatting for cron metadata on smaller widths
- Added `apps/ops-dashboard/README.md` with stack/setup notes for TypeScript + Tailwind + shadcn/ui.

## Validation / evidence
### Build
```bash
cd apps/ops-dashboard
npm run build
```
Result: ✅ successful production build (Next.js 16.1.6), static page generation completed.

### Notes
- `npm run lint` currently fails due `next lint` argument handling in this Next.js setup (`Invalid project directory .../lint`), unrelated to UI changes.

## Checklist
- [x] Agents / cron jobs / activity cards visually upgraded and readable
- [x] Responsive layout remains usable across small + desktop viewports
- [x] Existing functional data views remain intact
- [x] README updated with TS/Tailwind/shadcn stack notes
- [x] Changes scoped to `apps/ops-dashboard`
