### PR TITLE
fix: add runtime proof validator for per-run memory emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ All comments begin with `@<agent-id>`.
 - Canonical run-log template source: `operatives/RUN_LOG_TEMPLATE.md`.
 - Canonical path/write helper: `scripts/agent-runlog.sh` creates or resolves:
   - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
+- Runtime proof helper: `scripts/validate-runlog-emission.sh` validates one planner + one worker run each emit exactly one new run-log file and include canonical sections.
 - During migration, per-agent daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) remain supported to prevent data loss.
 - Runtime read policy: load today's file by default; consult yesterday only when needed.
 - On first run of a new UTC day, run:

--- a/scripts/validate-runlog-emission.sh
+++ b/scripts/validate-runlog-emission.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates one-file-per-run emission + canonical schema for planner/worker run logs.
+# Usage: ./scripts/validate-runlog-emission.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATE_UTC="$(date -u +%F)"
+TS_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
+
+emit_and_verify() {
+  local agent_id="$1"
+  local role="$2"
+  local run_id="issue-57-${agent_id}-$(date -u +%Y%m%dT%H%M%SZ)-$RANDOM"
+  local dir="$REPO_ROOT/agents/memory/${agent_id}/${DATE_UTC}"
+
+  mkdir -p "$dir"
+
+  local before after
+  before=$(find "$dir" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+
+  "$REPO_ROOT/scripts/agent-runlog.sh" \
+    --agent-id "$agent_id" \
+    --role "$role" \
+    --run-id "$run_id" \
+    --repo "DACL" \
+    --date "$DATE_UTC" \
+    --timestamp "$TS_UTC"
+
+  local file="$dir/${run_id}.md"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: expected run-log file not found: $file" >&2
+    return 1
+  fi
+
+  after=$(find "$dir" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+  if [[ $((after - before)) -ne 1 ]]; then
+    echo "ERROR: expected exactly one new file for ${agent_id}; before=${before} after=${after}" >&2
+    return 1
+  fi
+
+  grep -q '^# Run Log$' "$file"
+  grep -q '^## Actions Taken$' "$file"
+  grep -q '^## Learning$' "$file"
+  grep -q '^## Blockers$' "$file"
+  grep -q '^## Next Step$' "$file"
+
+  echo "PASS ${agent_id} (${role}) -> ${file}"
+}
+
+emit_and_verify "dacl-planner-01" "planner"
+emit_and_verify "dacl-worker-01" "worker"
+
+echo "Validation complete: one-file-per-run emission + canonical template sections verified."


### PR DESCRIPTION
## Linked issue
Closes #57

## Issue coverage checklist
- [x] Validation includes one planner run and one worker run (not docs-only changes).
- [x] Exactly one new run-log file is created per run in the expected folder layout.
- [x] Sample emitted files match canonical schema sections from #42.
- [x] PR scope remains focused; no unrelated churn.

## What changed
- Added `scripts/validate-runlog-emission.sh` to run controlled planner+worker emissions and assert one-file-per-run behavior.
- Added canonical schema checks for required run-log sections:
  - `# Run Log`
  - `## Actions Taken`
  - `## Learning`
  - `## Blockers`
  - `## Next Step`
- Documented the runtime proof helper in `README.md` Daily Agent Memory Workflow.

## Evidence
- command: `./scripts/validate-runlog-emission.sh`
- result:
  - `PASS dacl-planner-01 (planner) -> agents/memory/dacl-planner-01/2026-03-05/issue-57-dacl-planner-01-20260305T174700Z-23161.md`
  - `PASS dacl-worker-01 (worker) -> agents/memory/dacl-worker-01/2026-03-05/issue-57-dacl-worker-01-20260305T174700Z-2790.md`
  - `Validation complete: one-file-per-run emission + canonical template sections verified.`
- schema snippet check (first lines of emitted files):
  - planner file contains `# Run Log`, role `planner`, and canonical section headers
  - worker file contains `# Run Log`, role `worker`, and canonical section headers

## Risks / Notes
- Validation intentionally creates ephemeral run-log files during execution; these are runtime artifacts and are not committed on issue branches.
