### PR TITLE
docs: publish migration notes and memory-model cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ All comments begin with `@<agent-id>`.
 
 ## Daily Agent Memory Workflow
 
-- Per-agent memory now lives in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
+- Per-agent memory lives in daily files only: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
 - Runtime read policy: load today's file by default; consult yesterday only when needed.
 - On first run of a new UTC day, run:
   - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`
@@ -141,8 +141,14 @@ All comments begin with `@<agent-id>`.
   - ensure today's memory file exists
   - detect day rollover with a local state marker
   - summarize the previous day into today's file
-  - promote novel durable lessons into the agent directive
-  - keep historical compatibility notes non-normative while daily files remain the only active memory path
+
+### Migration notes (legacy memory files)
+
+- Legacy monolithic files remain as pointers only:
+  - `agents/memory/<agent-id>.md`
+- Historical archive content moved under:
+  - `agents/memory/<agent-id>/legacy.md`
+- New run logs must be written to daily files only (`agents/memory/<agent-id>/YYYY-MM-DD.md`).
 
 ---
 

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -23,9 +23,10 @@ All comments must be proper Markdown via `--body-file` (no escaped `\\n` output)
 See `operatives/COMMENT_STYLE.md`.
 
 ## Agent memory protocol
-- Agents store raw execution notes in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
+- Agents store raw execution notes in daily files only: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
 - Agents should read today's file by default; read yesterday only when needed for continuity.
 - On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
+- Legacy `agents/memory/<agent-id>.md` files are compatibility pointers only (not active run logs).
 
 ## Merge condition
 A PR is merge-ready only when:


### PR DESCRIPTION
## Linked issue
Closes #34

## Issue coverage checklist
- [x] Migration notes added and aligned to the daily-memory model.
- [x] Final docs explicitly treat daily files as the only active run-log path.
- [x] Legacy memory-file handling documented as pointer/archive-only.

## Evidence
- Manual docs review of `README.md` and `operatives/ISSUE_PR_PROTOCOL.md`.
- Validation command (equivalent to issue regex check):
  - `grep -RIn "agents/memory/.*/YYYY-MM-DD.md\|rollover" README.md operatives agents/directives`
- Result: references consistently point to daily memory files and rollover flow; legacy monolithic paths documented as compatibility pointers only.

## Risks / Notes
- Scope intentionally limited to documentation updates only.
- No script/runtime behavior changes in this PR.
