### PR TITLE
[Child #44] Update docs + migration guidance for per-run memory model

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,24 @@ All comments begin with `@<agent-id>`.
   - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
 - Runtime write policy: each planner/worker run should emit one log file under `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
 - Runtime proof helper: `scripts/validate-runlog-emission.sh` validates one planner + one worker run each emit exactly one new run-log file and include canonical sections.
-- During migration, per-agent daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) remain supported only as fallback to prevent data loss.
-- Runtime read policy: load today's file by default; consult yesterday only when needed.
+- Runtime read policy: load today's run folder by default; consult yesterday's folder only when needed.
 - On first run of a new UTC day, run:
   - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`
 - Rollover script responsibilities:
-  - ensure today's memory file exists
+  - ensure today's run folder exists (`agents/memory/<agent-id>/<YYYY-MM-DD>/`)
   - detect day rollover with a local state marker
-  - summarize the previous day into today's file
+  - summarize the previous day into the first run log for today
   - promote novel durable lessons into the agent directive
-  - migrate/deprecate legacy monolithic memory files under `agents/memory/<agent-id>.md`
+  - preserve legacy daily files as read-only inputs for migration (never as runtime write targets)
+
+### Migration notes (daily-file -> per-run)
+
+If an agent still has historical daily files such as `agents/memory/<agent-id>/YYYY-MM-DD.md`:
+
+1. Keep legacy files for history; do not append new run notes there.
+2. Start writing all new logs to `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via `scripts/agent-runlog.sh`.
+3. During first UTC run, execute rollover to carry forward prior-day context and directive promotions.
+4. Use canonical sections from `operatives/RUN_LOG_TEMPLATE.md` in every new run log so parsing stays uniform across roles.
 
 ---
 

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -25,9 +25,10 @@ See `operatives/COMMENT_STYLE.md`.
 ## Agent memory protocol
 - Canonical per-run log template source: `operatives/RUN_LOG_TEMPLATE.md`.
 - Canonical path/write helper: `scripts/agent-runlog.sh` targeting `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
-- During migration, agents may still maintain daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) to avoid data loss.
+- Agents must write new runtime memory only to per-run files; legacy daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) are read-only migration inputs.
 - Agents should read today's run-log folder by default and consult yesterday's folder only when needed for continuity.
 - On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
+- Every new run log must preserve canonical headings/fields from `operatives/RUN_LOG_TEMPLATE.md` for machine parsing consistency across roles.
 
 ## Merge condition
 A PR is merge-ready only when:


### PR DESCRIPTION
## Linked issue
Closes #44

## Issue coverage checklist
- [x] Docs consistently reference `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` as runtime write path.
- [x] Migration guidance explains handling of existing daily logs.
- [x] Documented examples align to canonical run-log template fields/sections.
- [x] Contradictory memory-layout write instructions removed.

## Evidence
- `grep -RIn "agents/memory/<agent-id>/YYYY-MM-DD.md" README.md operatives agents/directives`
  - now only appears as read-only migration context, not runtime write target
- `grep -RIn "RUN_LOG_TEMPLATE.md" README.md operatives/ISSUE_PR_PROTOCOL.md`
  - confirms canonical template references in both protocol + migration notes
- Manual doc review of `README.md` + `operatives/ISSUE_PR_PROTOCOL.md`
  - confirms per-run model and migration sequencing are consistent

## Risks / Notes
- Legacy daily files remain documented as historical inputs only; no automated conversion script added in this scope.
