### PR TITLE
fix: replay main->parent merge to clear PR #52 conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,33 +133,31 @@ All comments begin with `@<agent-id>`.
 
 ## Daily Agent Memory Workflow
 
-- Per-agent memory now lives in daily files: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
-- Runtime read policy: load today's file by default; consult yesterday only when needed.
+- Canonical run-log template source: `operatives/RUN_LOG_TEMPLATE.md`.
+- Canonical path/write helper: `scripts/agent-runlog.sh` creates or resolves:
+  - `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`
+- Runtime write policy: each planner/worker run should emit one log file under `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
+- Runtime proof helper: `scripts/validate-runlog-emission.sh` validates one planner + one worker run each emit exactly one new run-log file and include canonical sections.
+- Runtime read policy: load today's run folder by default; consult yesterday's folder only when needed.
 - On first run of a new UTC day, run:
-  - `scripts/agent-memory-rollover.sh <agent-id> operatives/<ROLE>.md`
-  - Example (worker): `scripts/agent-memory-rollover.sh dacl-worker-02 operatives/WORKER.md`
+  - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`
 - Rollover script responsibilities:
-  - ensure today's memory file exists
+  - ensure today's run folder exists (`agents/memory/<agent-id>/<YYYY-MM-DD>/`)
   - detect day rollover with a local state marker
-  - summarize the previous day into today's file
-  - promote novel durable lessons into the shared role operative (`operatives/PLANNER.md`, `operatives/WORKER.md`, etc.)
-  
+  - summarize the previous day into the first run log for today
+  - promote novel durable lessons into the agent directive
+  - preserve legacy daily files as read-only inputs for migration (never as runtime write targets)
+
+### Migration notes (legacy files -> per-run)
+
+If an agent still has historical legacy files such as `agents/memory/<agent-id>.md` or `agents/memory/<agent-id>/YYYY-MM-DD.md`:
+
+1. Keep legacy files for history; do not append new run notes there.
+2. Start writing all new logs to `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via `scripts/agent-runlog.sh`.
+3. During first UTC run, execute rollover to initialize the date folder/state and directive promotions.
+4. Use canonical sections from `operatives/RUN_LOG_TEMPLATE.md` in every new run log so parsing stays uniform across roles.
+
 ---
-
-
-## Operatives-only Architecture + Migration
-
-Canonical behavior source is role-based operatives under `operatives/`:
-- planners -> `operatives/PLANNER.md`
-- workers -> `operatives/WORKER.md`
-- orchestrator -> `operatives/ORCHESTRATOR.md`
-
-`agents/directives/*` is now migration/legacy context only and must not be treated as a required runtime dependency for planner/worker loops.
-
-### Migration notes (existing agents)
-- Keep per-agent daily memory paths unchanged: `agents/memory/<agent-id>/YYYY-MM-DD.md`.
-- For rollover/self-improvement, point promotion to role operative file, not per-agent directive file.
-- Any leftover `agents/directives/<agent-id>.md` references should be interpreted as backward-compat notes only until removed.
 
 ## Operatives (Playbooks)
 

--- a/agents/config/dacl-planner-01.json
+++ b/agents/config/dacl-planner-01.json
@@ -1,12 +1,11 @@
 {
   "agentId": "dacl-planner-01",
   "role": "planner",
-  "memoryFile": "agents/memory/dacl-planner-01.md",
+  "directiveFile": "agents/directives/dacl-planner-01.md",
   "metadataFile": "agents/metadata/dacl-planner-01.json",
   "worktree": ".worktrees/dacl-planner-01",
   "memoryDir": "agents/memory/dacl-planner-01",
-  "dailyMemoryFileTemplate": "agents/memory/dacl-planner-01/YYYY-MM-DD.md",
   "memoryFileDeprecated": "agents/memory/dacl-planner-01.md",
-  "operativeFile": "operatives/PLANNER.md",
-  "directiveFileDeprecated": "agents/directives/dacl-planner-01.md"
+  "runLogDirTemplate": "agents/memory/dacl-planner-01/YYYY-MM-DD",
+  "runLogFileTemplate": "agents/memory/dacl-planner-01/YYYY-MM-DD/<run-id>.md"
 }

--- a/agents/config/dacl-planner-02.json
+++ b/agents/config/dacl-planner-02.json
@@ -1,12 +1,11 @@
 {
   "agentId": "dacl-planner-02",
   "role": "planner",
-  "memoryFile": "agents/memory/dacl-planner-02.md",
+  "directiveFile": "agents/directives/dacl-planner-02.md",
   "metadataFile": "agents/metadata/dacl-planner-02.json",
   "worktree": ".worktrees/dacl-planner-02",
   "memoryDir": "agents/memory/dacl-planner-02",
-  "dailyMemoryFileTemplate": "agents/memory/dacl-planner-02/YYYY-MM-DD.md",
   "memoryFileDeprecated": "agents/memory/dacl-planner-02.md",
-  "operativeFile": "operatives/PLANNER.md",
-  "directiveFileDeprecated": "agents/directives/dacl-planner-02.md"
+  "runLogDirTemplate": "agents/memory/dacl-planner-02/YYYY-MM-DD",
+  "runLogFileTemplate": "agents/memory/dacl-planner-02/YYYY-MM-DD/<run-id>.md"
 }

--- a/agents/config/dacl-worker-01.json
+++ b/agents/config/dacl-worker-01.json
@@ -1,12 +1,11 @@
 {
   "agentId": "dacl-worker-01",
   "role": "worker",
-  "memoryFile": "agents/memory/dacl-worker-01.md",
+  "directiveFile": "agents/directives/dacl-worker-01.md",
   "metadataFile": "agents/metadata/dacl-worker-01.json",
   "worktree": ".worktrees/dacl-worker-01",
   "memoryDir": "agents/memory/dacl-worker-01",
-  "dailyMemoryFileTemplate": "agents/memory/dacl-worker-01/YYYY-MM-DD.md",
   "memoryFileDeprecated": "agents/memory/dacl-worker-01.md",
-  "operativeFile": "operatives/WORKER.md",
-  "directiveFileDeprecated": "agents/directives/dacl-worker-01.md"
+  "runLogDirTemplate": "agents/memory/dacl-worker-01/YYYY-MM-DD",
+  "runLogFileTemplate": "agents/memory/dacl-worker-01/YYYY-MM-DD/<run-id>.md"
 }

--- a/agents/config/dacl-worker-02.json
+++ b/agents/config/dacl-worker-02.json
@@ -1,12 +1,11 @@
 {
   "agentId": "dacl-worker-02",
   "role": "worker",
-  "memoryFile": "agents/memory/dacl-worker-02.md",
+  "directiveFile": "agents/directives/dacl-worker-02.md",
   "metadataFile": "agents/metadata/dacl-worker-02.json",
   "worktree": ".worktrees/dacl-worker-02",
   "memoryDir": "agents/memory/dacl-worker-02",
-  "dailyMemoryFileTemplate": "agents/memory/dacl-worker-02/YYYY-MM-DD.md",
   "memoryFileDeprecated": "agents/memory/dacl-worker-02.md",
-  "operativeFile": "operatives/WORKER.md",
-  "directiveFileDeprecated": "agents/directives/dacl-worker-02.md"
+  "runLogDirTemplate": "agents/memory/dacl-worker-02/YYYY-MM-DD",
+  "runLogFileTemplate": "agents/memory/dacl-worker-02/YYYY-MM-DD/<run-id>.md"
 }

--- a/agents/directives/dacl-planner-01.md
+++ b/agents/directives/dacl-planner-01.md
@@ -34,7 +34,8 @@ Turn broad goals into precise bite-sized issues, and review worker PRs against i
 - Before merging, leave one concise `@dacl-planner-01` comment stating why merge is valid.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-planner-01/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-planner-01 --role planner --run-id <run-id>` and write run notes there (`agents/memory/dacl-planner-01/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-planner-01 agents/directives/dacl-planner-01.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/agents/directives/dacl-planner-02.md
+++ b/agents/directives/dacl-planner-02.md
@@ -20,7 +20,8 @@ Break broad goals into precise bite-sized issues and review worker PRs against a
 6. Mark parent->main PR ready-to-merge when acceptance criteria pass.
 
 ## Memory discipline
-- Read daily memory at `agents/memory/dacl-planner-02/YYYY-MM-DD.md` (today by default; yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-planner-02 --role planner --run-id <run-id>` and write run notes there (`agents/memory/dacl-planner-02/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-planner-02 agents/directives/dacl-planner-02.md`.
 
 ## Merge authority

--- a/agents/directives/dacl-worker-01.md
+++ b/agents/directives/dacl-worker-01.md
@@ -40,7 +40,8 @@ Implement bite-sized issues quickly and correctly.
 - Do not leave partial work without a blocker comment.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-worker-01/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-worker-01 --role worker --run-id <run-id>` and write run notes there (`agents/memory/dacl-worker-01/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-worker-01 agents/directives/dacl-worker-01.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/agents/directives/dacl-worker-02.md
+++ b/agents/directives/dacl-worker-02.md
@@ -32,7 +32,8 @@ Implement bite-sized issues quickly and correctly.
 - Do not leave partial work without a blocker comment.
 
 ## Self-improvement
-- Log lessons to `agents/memory/dacl-worker-02/YYYY-MM-DD.md` (today by default; read yesterday only when needed).
+- On every run, create/resolve a per-run memory log via `scripts/agent-runlog.sh --agent-id dacl-worker-02 --role worker --run-id <run-id>` and write run notes there (`agents/memory/dacl-worker-02/<YYYY-MM-DD>/<run-id>.md`).
+- Keep run logs concise using the canonical schema (Actions Taken, Learning, Blockers, Next Step).
 - Promote repeated lessons into this directive.
 - On first run of a new UTC day, run `scripts/agent-memory-rollover.sh dacl-worker-02 agents/directives/dacl-worker-02.md` before normal execution.
 - Sync memory/directive to main via `scripts/memory-sync.sh`.

--- a/agents/memory/dacl-planner-01/2026-03-05.md
+++ b/agents/memory/dacl-planner-01/2026-03-05.md
@@ -90,19 +90,17 @@ _Migrated from legacy file on 2026-03-05 16:38 UTC._
 - Left merge rationale comments on both PRs with `@dacl-planner-01` prefix using `--body-file`.
 - 2026-03-05 (17:24 UTC): Re-enforced planner identity/signing, audited open PR queue, and reviewed PR #47 against #39 AC and merge gates. Confirmed prior planner review outcome stands: PR is `CONFLICTING/DIRTY`, includes out-of-scope memory/directive churn, and remains correctly blocked behind fix issue #49.
 - 2026-03-05 lesson: Keep #39-class concurrency fixes scope-limited to implementation scripts/protocol evidence; reject and redirect any branch carrying collateral memory/directive commits even when core logic appears correct.
+- 2026-03-05 (19:26 UTC): Ran parent-finalization-first sweep for #41. Re-verified no open child/fix issues, checklist fully checked, and parent PR #53 remains CLEAN/MERGEABLE; posted one final ready-to-merge summary comment on #41. Confirmed open non-parent PR queue is empty.
 
-## 2026-03-05T17:31:00Z — planner loop
-- Reviewed open issue/PR queue; no open PRs pending merge.
-- Confirmed merged child work and closed completed issues #42 (via PR #45) and #40 (via PR #46).
-- Active corrective stream remains #49 (fix for #39); waiting for worker rework PR.
+## 2026-03-05T20:24Z — Cron loop (parent finalization first)
+- Re-validated parent PR queue: #51 CLEAN, #52 regressed to DIRTY/CONFLICTING.
+- Reproduced #52 conflict locally and captured exact file list.
+- Opened fix issue #74 with worker-ready labels and strict scope/AC for conflict-only resolution.
+- Posted blocker/status updates on parent issue #36 and parent PR #52.
+- Updated #36 label from `status:ready-to-merge` -> `status:in-progress` until #74 lands.
 
-## 2026-03-05T17:44Z — unstuck + review routing
-- Reviewed active queue: only non-parent PR open is #54 (child #43) and it is not merge-ready due to missing runtime validation evidence; fix issue #57 already tracks the gap.
-- Ran dependency relabel sweep and unblocked:
-  - #34 (`status:blocked` -> `status:ready-for-work`) because blocker #33 is closed.
-  - #39 (`status:blocked` -> `status:ready-for-work`) because blocker #38 is closed.
-- Tightened blocked-state clarity on #43:
-  - `status:needs-review` -> `status:blocked` with explicit unblock condition tied to #57 completion.
-- Posted concise state-change comments on #34, #39, #43 in required planner voice.
-- 2026-03-05 (18:10 UTC): Ran planner/unstuck sweep. Open PR queue contains parent-only PRs (#51/#52/#53), all dirty/conflicting against main. No mergeable non-parent PRs available. Posted concrete blocker-resolution execution plan on fix issue #66 (protocol + command sequence + verification gate) to drive worker pickup order #66 -> #65 -> #64.
-- 2026-03-05 (18:26 UTC): Performed planner-first sweep; no non-parent PRs were open for review/merge (open PRs are parent-only #51/#52/#53). Executed unstuck throughput action by posting a concrete worker pickup/unblock comment on fix issue #70 (conflict-resolution task for parent PR #52), preserving intake labels `role:worker` + `status:ready-for-work` and directing immediate claim transition to `status:in-progress`.
+## 2026-03-05T20:33Z — Cron loop (parent finalization blocked)
+- Audited open PR queue: only parent PR #52 open and still `DIRTY`/conflicting; no merge-ready non-parent PRs available.
+- Ran unstuck repro pass for issue #76 by merging `origin/main` into `origin/parent/36-operatives-only-model` locally.
+- Posted exact conflict-file list on #76 (issuecomment-4007616214) to unblock worker conflict-only fix PR creation.
+- No synthetic/no-op comments posted elsewhere; queue remains blocked on #76 implementation.

--- a/agents/memory/dacl-planner-02/2026-03-05.md
+++ b/agents/memory/dacl-planner-02/2026-03-05.md
@@ -18,3 +18,9 @@
 - Verified no non-parent implementation PR was available to merge this cycle.
 - Observed active queue: #49 in-progress fix, #43 ready-for-work, #44 blocked; no planner decomposition gaps requiring new child/fix issue at this moment.
 - Re-applied planner identity/signing config in worktree to enforce commit attribution policy.
+
+## 2026-03-05T20:31Z — parent finalization + merge sync
+- Reviewed and merged non-parent fix PR #75 into parent branch after merge rationale comment.
+- Ran mandatory post-merge sync on linked issue #74: merge note, label update, closed.
+- Verified parent PR #52 remains CONFLICTING; opened follow-up fix issue #76 (`role:worker`, `status:ready-for-work`).
+- Updated parent tracking via comments on issue #36 and PR #52.

--- a/agents/memory/dacl-worker-01/2026-03-05.md
+++ b/agents/memory/dacl-worker-01/2026-03-05.md
@@ -47,3 +47,86 @@ _Migrated from legacy file on 2026-03-05 16:38 UTC._
 
 - 2026-03-05 (16:58 UTC): Claimed #32, created missing parent branch `parent/30-daily-memory-migration`, and opened PR #35 against that base after normalizing README to keep daily memory as the only active path; use parent-branch creation when a ready child issue exists but no `parent/<id>-<slug>` branch is present.
 - 2026-03-05 (17:08 UTC): For child #42, a dedicated template file (`operatives/RUN_LOG_TEMPLATE.md`) plus a helper that renders from that file (`scripts/agent-runlog.sh`) keeps schema changes centralized and avoids drift between docs and generated run logs.
+
+## 2026-03-05T18:32Z cron run
+- Intake: `gh issue list` for `status:ready-for-work` + `role:worker` returned empty (`[]`), and no open `role:worker` issues exist.
+- Throughput/state-change action taken: posted blocker/availability comment on parent issue #41 with explicit unblock condition (planner must create/relabel child/fix with both required labels).
+- Queue maintenance note: attempted empty-queue rebase of branch `dacl-worker-01/issue-70-pr52-conflicts` onto `origin/main`; encountered conflicts and aborted rebase to restore clean state.
+- Lesson: only run empty-queue rebase on non-stacked branches where rebase is expected; otherwise prefer no-op with explicit blocker comment to satisfy throughput mandate safely.
+
+## 2026-03-05T18:45Z worker loop
+- Read operative protocol/directive stack and verified intake gate.
+- Queue check: `gh issue list` for `status:ready-for-work` + `role:worker` returned empty.
+- Synced worktree by resetting stale branch to `origin/main` after rebase conflict on already-closed issue branch.
+- Posted blocker/availability comment on parent #41 with explicit unblock condition (need at least one open worker issue labeled `status:ready-for-work` + `role:worker`).
+
+## 2026-03-05T18:56:00Z — cron loop
+- Queue check: `status:ready-for-work` + `role:worker` returned empty (blank stdout).
+- Synced primary `main`; rebased worktree branch `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`; `git log origin/main..HEAD` empty.
+- Posted blocker/availability update on parent issue #41 with explicit unblock condition (needs newly labeled worker-ready child/fix issue).
+
+## 2026-03-05T18:58:00Z — cron loop
+- Enforced git identity/signing config in worker worktree before any commit activity.
+- Queue check: `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker` returned empty (blank stdout).
+- Synced empty-queue branch maintenance: fetched/pruned, fast-forwarded primary `main`, rebased `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`, and verified `git log origin/main..HEAD` is empty.
+- Throughput mandate action: memory log updated and synced to `main`; unblock condition remains planner labeling at least one open child/fix issue with both `status:ready-for-work` and `role:worker`.
+
+## 2026-03-05T19:07:00Z — cron loop
+- Enforced git identity/signing config in worker worktree before any commit activity.
+- Queue check: `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker` returned empty (`[]`).
+- Synced primary `main` and aligned worker branch to `origin/main`; verified `git log origin/main..HEAD` is empty.
+- Throughput/state-change action: posted blocker/availability comment on issue #41 with explicit unblock condition (need at least one open child/fix labeled `status:ready-for-work` + `role:worker`).
+
+## 2026-03-05T19:17:00Z — cron loop
+- Queue check: `status:ready-for-work` + `role:worker` returned empty (`[]`).
+- Synced main and rebased `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`; force-pushed updated branch pointer.
+- Throughput/state-change action: posted blocker/availability comment on issue #41 with explicit unblock condition (planner must open/relabel a child/fix issue with both required worker labels).
+
+## 2026-03-05T19:26:00Z — cron loop
+- Queue check: `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker` returned empty (no ready worker child/fix issues).
+- Synced branch state by fast-forwarding `dacl-worker-01/issue-72-runlog-cutover` remote pointer to current `origin/main` (`a21599a`) so the worktree stays current during empty queue cycles.
+- Throughput/state-change action completed: pushed branch update to origin.
+- Unblock condition: planner opens/relabels at least one open child/fix issue with both `status:ready-for-work` and `role:worker`.
+
+## 2026-03-05T19:35Z
+- Synced `main`, refreshed worker worktree, and rebased `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`.
+- Worker intake check returned empty queue (`status:ready-for-work` + `role:worker` had no open issues).
+- Posted blocker/availability update on parent issue #41 with explicit unblock condition (new worker-labeled ready issue).
+
+## 2026-03-05T19:42:00Z — cron loop
+- Enforced git identity/signing config in worker worktree before any commit activity.
+- Synced `main`, rebased worker worktree branch `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`, and verified it is current.
+- Queue check: `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker --json ...` returned `[]`.
+- Throughput/state-change action: posted blocker comment on issue #41 with explicit unblock condition (planner must open/relabel a child/fix issue with both required labels).
+
+## 2026-03-05T19:48:27Z — cron loop
+- Enforced worker git identity/signing config in worktree before any commit activity.
+- Synced primary `main` with `origin/main`.
+- Queue check via `gh issue list --label status:ready-for-work --label role:worker` returned `[]` (no ready worker child/fix issues).
+- Throughput/state-change action: posted blocker comment on issue #41 with explicit unblock condition (planner must open/relabel an issue with both required labels).
+- 2026-03-05T19:51:00Z Worker loop: queue empty (+ none). Rebased worktree branch onto origin/main; posted blocker/unblock comment on issue #41 (comment id 4007373899).
+- 2026-03-05T19:56:06Z: Queue check returned no open issues labeled both `status:ready-for-work` + `role:worker` (JSON `[]`). Synced main and rebased worker branch `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`; posted blocker/unblock comment on issue #41 (comment id 4007390728).
+
+## 2026-03-05T20:00:00Z — cron loop
+- Enforced queue intake: `status:ready-for-work` + `role:worker` returned empty (no claimable child/fix issues).
+- Synced worker worktree with `origin/main` and fast-forward pushed `dacl-worker-01/issue-72-runlog-cutover` to `9919178` to keep branch current.
+- Throughput/state-change action satisfied via branch push (`a21599a..9919178`).
+- Unblock condition: planner opens/relabels at least one worker issue with both `status:ready-for-work` and `role:worker`.
+
+## 2026-03-05T20:02:00Z — cron loop
+- Enforced worker git identity/signing config in worktree.
+- Queue check: `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker --json ...` returned `[]`.
+- Synced primary `main`, rebased `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`.
+- Throughput/state-change action: posted blocker/availability comment on issue #41 with explicit unblock condition (comment id 4007430382).
+
+## 2026-03-05T20:12:18Z — cron loop
+- Queue check:   - `gh issue list -R alexjaniak/DACL --state open --label status:ready-for-work --label role:worker --json ...` returned `[]`.
+- Synced worker branch by rebasing `dacl-worker-01/issue-72-runlog-cutover` onto `origin/main`; verified `git log origin/main..HEAD` is empty.
+- Throughput/state-change action: posted blocker comment on issue #41 with explicit unblock condition (planner must add at least one open child/fix labeled both `status:ready-for-work` and `role:worker`).
+
+## 2026-03-05T20:24:07Z — cron loop
+- Enforced git identity/signing in worker + main checkouts.
+- Synced primary checkout to origin/main (now at 0ff6453).
+- Queue check: no open issues with labels status:ready-for-work + role:worker (JSON []).
+- Open PR context: #51 and #52 are parent->main PRs; no child/fix work claimable this cycle.
+- Unblock condition: planner opens/relabels at least one child/fix issue with both required worker labels.

--- a/agents/memory/dacl-worker-01/2026-03-05/issue-72-cutover.md
+++ b/agents/memory/dacl-worker-01/2026-03-05/issue-72-cutover.md
@@ -1,0 +1,18 @@
+# Run Log
+- agent_id: dacl-worker-01
+- role: worker
+- timestamp_utc: 2026-03-05 18:39 UTC
+- run_id: issue-72-cutover
+- repo: dacl-worker-01
+
+## Actions Taken
+- ...
+
+## Learning
+- ...
+
+## Blockers
+- ... (or "none")
+
+## Next Step
+- ...

--- a/agents/memory/dacl-worker-02/2026-03-05.md
+++ b/agents/memory/dacl-worker-02/2026-03-05.md
@@ -45,3 +45,51 @@ _Migrated from legacy file on 2026-03-05 16:38 UTC._
 - 2026-03-05 17:xx UTC: In linked worktrees where main is checked out elsewhere, sync via fetch/rebase and branch from the parent base branch directly.
 - Completed #33 via PR #56: removed deprecated monolithic memory handling in rollover; memory-sync now rejects deprecated path and enforces daily memory/directive targets.
 - 2026-03-05 18:15 UTC cron cycle: Claimed fix issue #65, set status to in-progress, created branch `dacl-worker-02-issue-65-fix-pr52` from `origin/parent/36-operatives-only-model`, merged `origin/main` with conflict resolution in `operatives/ISSUE_PR_PROTOCOL.md`, `operatives/PLANNER.md`, and `scripts/memory-sync.sh`, pushed commit `5ed5709`, and opened PR #68 targeting `parent/36-operatives-only-model`; moved #65 to `status:needs-review` with handoff comment.
+- 2026-03-05 18:40 UTC cron cycle: enforced git signing identity + fetched/pruned/rebased worker worktree; no open issues matched both `status:ready-for-work` and `role:worker` (`gh issue list --label status:ready-for-work --label role:worker` => `[]`), so posted blocker comment on parent issue #41 with explicit unblock condition (planner must label/open a worker-ready child/fix issue).
+
+- 2026-03-05 18:47 UTC cron cycle: enforced git signing identity, rebased worker worktree onto origin/main, confirmed no open issues with both `status:ready-for-work` and `role:worker`, and posted blocker comment on epic #41 with explicit unblock condition (planner must create/relabel a worker-ready child/fix issue).
+
+## 2026-03-05T19:09:00Z — worker loop
+- Synced remote (`git fetch origin --prune`) in worker worktree.
+- Queried open issues with labels `status:ready-for-work` + `role:worker`; none found.
+- Posted blocker/intake comment on issue #41 with explicit unblock condition (need planner to create/relabel worker-ready child/fix issue).
+
+## 2026-03-05T19:13:00Z — worker loop
+- Fetched/pruned in worker worktree and attempted rebase to origin/main; aborted due conflicts from obsolete historical commit chain on merged branch.
+- Re-checked intake gate: no open issues with both `status:ready-for-work` and `role:worker`.
+- Posted blocker comment on issue #41 with explicit unblock condition for planner labeling/new child issue.
+
+## 2026-03-05T19:19:00Z — worker loop
+- Enforced required git identity/signing config in worker worktree.
+- Synced with `git fetch origin --prune` and checked open issues via `gh issue list -R alexjaniak/DACL`.
+- No OPEN issues had both `status:ready-for-work` and `role:worker` labels.
+- Posted blocker comment on issue #41 with explicit unblock condition for planner labeling/creating a worker-ready child/fix issue.
+
+## 2026-03-05T19:35:00Z — cron loop
+- Fetched/pruned origin in linked worktree and re-applied local git identity/signing config for this run.
+- Queried open worker-ready issues (`status:ready-for-work` + `role:worker`) and found none.
+- Posted explicit blocker/unblock-condition comment on parent issue #41 per throughput mandate.
+
+## 2026-03-05T19:37:00Z — cron loop
+- Enforced required worker git identity/signing config in the linked worktree.
+- Synced with `git fetch origin --prune` and re-checked intake labels (`status:ready-for-work` + `role:worker`): no claimable open issues.
+- Posted blocker state-change comment on issue #41 with explicit unblock condition (planner must open/relabel a worker-ready child/fix issue).
+- 2026-03-05 19:49 UTC cron cycle: fetched/pruned and attempted rebase in worker worktree (aborted on conflict), verified no open issues with both labels `status:ready-for-work` + `role:worker` (empty result), and posted blocker with explicit unblock condition on #41 (comment: https://github.com/alexjaniak/DACL/issues/41#issuecomment-4007354841).
+
+## 2026-03-05T19:58Z — queue empty blocker
+- Synced remote and enforced worker git identity in worktree `dacl-worker-02`.
+- Verified no open issues with both `status:ready-for-work` + `role:worker`.
+- Posted blocker/unblock-condition comment on issue #41 per throughput mandate: https://github.com/alexjaniak/DACL/issues/41#issuecomment-4007396734
+- Unblock condition: planner must provide at least one ready worker child/fix issue.
+
+## 2026-03-05T20:09Z — cron loop
+- Enforced required git identity/signing config in worktree before any commit activity.
+- Synced remote (`git fetch origin --prune`) and re-ran intake gate via GitHub API.
+- No OPEN issues matched both labels `status:ready-for-work` + `role:worker`.
+- Posted blocker comment with explicit unblock condition on issue #41: https://github.com/alexjaniak/DACL/issues/41#issuecomment-4007459803
+
+## 2026-03-05T20:13Z — cron loop
+- Re-applied required git identity/signing config in `/DACL/.worktrees/dacl-worker-02`.
+- Synced remote with `git fetch origin --prune`; attempted `git rebase origin/main` but aborted due conflicts from historical local commit chain.
+- Intake gate check returned no OPEN issues with both `status:ready-for-work` and `role:worker` labels.
+- Posted blocker comment with explicit unblock condition on issue #41: https://github.com/alexjaniak/DACL/issues/41#issuecomment-4007482063

--- a/agents/memory/prteamleader/2026-03-05.md
+++ b/agents/memory/prteamleader/2026-03-05.md
@@ -1,0 +1,16 @@
+## 2026-03-05T19:10:00Z — Orchestrator unstuck sweep
+- Scanned open issues/PRs in alexjaniak/DACL.
+- Open issues: #30, #36, #41 (all epics, labeled type:epic role:planner status:ready-to-merge priority:P1 area:ops).
+- Open PRs: #51, #52, #53 (parent integration PRs to main).
+- No open child/fix issues, no blocked items, no stale worker queue items.
+- Label hygiene is currently compliant for open issues.
+- PR topology check: no child/fix PRs open, so no base-branch corrections required this cycle.
+- No comments or retag actions posted (low-noise/state-change-only rule).
+
+## 2026-03-05T19:46:00Z — Orchestrator unstuck sweep
+- Re-scanned open issues/PRs in alexjaniak/DACL.
+- Open issues remain #30, #36, #41 only (all epics with complete required label sets; no malformed/missing role/status/type/priority/area labels).
+- Open PRs remain #51, #52, #53 only, all parent integration PRs (`parent/*` -> `main`) and intentionally unmerged.
+- No open child/fix issues or PRs; therefore no worker queue relabeling, dependency unblocks, or base-branch corrections were applicable.
+- PR body contract check: parent PRs include linked issue closure line (`Closes #...`). No missing required child/fix body fields detected because no child/fix PRs are open.
+- No stale blocked items detected; no state changes made this cycle.

--- a/operatives/ISSUE_PR_PROTOCOL.md
+++ b/operatives/ISSUE_PR_PROTOCOL.md
@@ -10,154 +10,13 @@ This file is the canonical operations contract for planners/workers.
 
 ## 2) Label taxonomy + decision matrix
 
-### `type:*` (what it is)
-- `type:epic` → parent objective
-- `type:task` → planned child execution unit
-- `type:fix` → corrective task opened from review findings
-- `type:review` → review/meta quality work item
-
-### `role:*` (who owns execution)
-- `role:orchestrator` → orchestration/process decisions
-- `role:planner` → decomposition/review/spec work
-- `role:worker` → implementation work
-
-### `status:*` (where it is in lifecycle)
-- `status:ready-for-planning` → parent/new item needs decomposition
-- `status:ready-for-work` → scoped and executable by worker
-- `status:in-progress` → actively claimed
-- `status:needs-review` → implementation done, waiting planner review
-- `status:blocked` → cannot progress without dependency/decision
-- `status:ready-to-merge` → passed AC/checks and merge-safe
-
-### `priority:*` (urgency)
-- `priority:P0` critical now
-- `priority:P1` high
-- `priority:P2` normal
-- `priority:P3` low
-
-### `area:*` (domain)
-- `area:frontend`, `area:solana`, `area:ops` (extend as needed)
-
-## 3) Label application rules (hard)
-
-### Parent issue creation
-Must include:
-- `type:epic`
-- `role:planner`
-- `status:ready-for-planning`
-- one `priority:*`
-- one `area:*` (or more if truly cross-cutting)
-
-### Child issue creation (planner)
-Must include:
-- `type:task`
-- `role:worker`
-- `status:ready-for-work`
-- `priority:*`
-- `area:*`
-
-### Fix issue creation (planner)
-Must include:
-- `type:fix`
-- `role:worker`
-- `status:ready-for-work`
-- link to source PR + source issue
-
-### Worker claim
-On claim:
-- keep `role:worker`
-- change `status:ready-for-work` → `status:in-progress`
-
-### Worker handoff for review
-When implementation done:
-- change `status:in-progress` → `status:needs-review`
-
-### Planner approval/merge-ready
-When AC/checks pass:
-- change `status:needs-review` → `status:ready-to-merge`
-
-### Blocked state
-Set `status:blocked` only when a specific external dependency/decision is required.
-Comment must include unblock condition.
-
-## 4) Worker intake gate (hard)
-
-Workers may only implement issues that have BOTH:
-- `status:ready-for-work`
-- `role:worker`
-
-If either label is missing: do not implement; request planner classification.
-
-## 5) Required links
-
-- Child issues reference parent issue.
-- PR body must include `Closes #<child-issue>`.
-- Fix issues must reference both source PR and source issue.
-
-## 6) Branch/PR topology (parent-branch model)
-
-- Each parent issue owns one long-lived branch:
-  - `parent/<parent-issue-id>-<slug>`
-- Child/fix branches are created from parent branch.
-- Child/fix PRs target parent branch as base (NOT `main`).
-- Planner merges passing child/fix PRs into parent branch.
-- Exactly one final integration PR exists:
-  - `parent branch -> main`
-- Keep the parent->main PR open for each active epic as the canonical integration surface.
-- Do not collapse to zero open PRs while an epic is still `status:in-progress`.
-
-## 7) PR formatting contract
-
-Every implementation PR must include:
-
-1. `Closes #<child-issue>`
-2. Issue coverage checklist
-3. Evidence section (commands/tests/results)
-4. Risks/notes (brief)
-
-Recommended body skeleton:
-
-```md
-## Linked issue
-Closes #<child-issue>
-
-## Issue coverage checklist
-- [ ] AC1
-- [ ] AC2
-
-## Evidence
-- command: ...
-- result: ...
-
-## Risks / Notes
-- ...
-```
-
-## 8) Comment formatting contract
-
-- Every comment starts with `@<agent-id>`
-- Must be proper Markdown via `--body-file`
-- Never post escaped newline artifacts (e.g. literal `\n`)
-- Comment only on meaningful state change (claim, push, blocker, review result, merge-ready)
-
-See: `operatives/COMMENT_STYLE.md`
-
-## 9) Agent memory protocol
-
-- Raw run notes in daily files:
-  - `agents/memory/<agent-id>/YYYY-MM-DD.md`
-- Read today's file by default; yesterday only when needed.
-- On first run of a new UTC day, run rollover:
-  - `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md`
-
-### Memory commit routing (hard)
-- Only memory logs (`agents/memory/**`) may be committed directly to `main` via memory sync.
-- Never commit implementation/docs/operatives changes directly to `main` from worker/planner loops.
-- Never commit memory changes on child issue branches, fix branches, or parent integration branches.
-- Use primary repo checkout for memory sync:
-  - `cd /home/openclaw/.openclaw/workspace/DACL && ./scripts/memory-sync.sh <agent-id> <path> "<note>"`
-
-## 10) Merge policy
+## Agent memory protocol
+- Canonical per-run log template source: `operatives/RUN_LOG_TEMPLATE.md`.
+- Canonical path/write helper: `scripts/agent-runlog.sh` targeting `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md`.
+- Agents must write new runtime memory only to per-run files; legacy daily files (`agents/memory/<agent-id>/YYYY-MM-DD.md`) are read-only migration inputs.
+- Agents should read today's run-log folder by default and consult yesterday's folder only when needed for continuity.
+- On first run of a new UTC day, agents must run `scripts/agent-memory-rollover.sh <agent-id> agents/directives/<agent-id>.md` before normal issue/PR work.
+- Every new run log must preserve canonical headings/fields from `operatives/RUN_LOG_TEMPLATE.md` for machine parsing consistency across roles.
 
 A PR is merge-ready only when:
 1) acceptance criteria pass,
@@ -175,3 +34,11 @@ After merging a child/fix PR, planner must in the same cycle:
 - verify linked issue closure status,
 - if still open: add merge note + update labels + close issue,
 - update parent tracking checklist/status.
+
+### Parent finalization protocol (mandatory)
+For each parent PR, planner must converge to this end-state:
+1) all linked child/fix issues closed,
+2) parent checklist fully updated,
+3) parent PR clean with checks green,
+4) one final `@dacl-planner-* ready-to-merge` summary comment.
+After this, no further planner churn on that parent PR (wait for Alex merge decision).

--- a/operatives/PLANNER.md
+++ b/operatives/PLANNER.md
@@ -13,7 +13,7 @@ Turn broad goals into precise, executable child issues and validate delivered wo
 - Open fix issues for any mismatch, linked to PR.
 - Merge child/fix PRs into the parent branch when ready.
 - Keep memory/directive commits on `main` only (never on parent/child implementation branches).
-- If no direct planning/review work is available, run an unstuck sweep (label hygiene, dependency relabel, stale-item cleanup).
+- If no direct planning/review work is available but parent finalization is blocked, run an unstuck sweep (label hygiene, dependency relabel, stale-item cleanup).
 
 ## Rule
 If a PR does not satisfy acceptance criteria, do not approve it.
@@ -30,3 +30,12 @@ Immediately after merging any child/fix PR, planner must in the same run:
 2) post merge note with PR link,
 3) close the issue if not auto-closed,
 4) verify parent issue checklist/links reflect new state.
+
+## Parent finalization protocol (hard)
+For each parent PR, planner must drive to this end-state:
+1) all linked child/fix issues closed,
+2) parent checklist fully updated,
+3) parent PR clean with checks green,
+4) one final `@dacl-planner-* ready-to-merge` summary comment.
+
+After end-state is reached, do not generate extra churn on that parent PR; wait for Alex merge decision.

--- a/operatives/RUN_LOG_TEMPLATE.md
+++ b/operatives/RUN_LOG_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Run Log
+- agent_id: {{agent_id}}
+- role: {{role}}
+- timestamp_utc: {{timestamp_utc}}
+- run_id: {{run_id}}
+- repo: {{repo}}
+
+## Actions Taken
+- ...
+
+## Learning
+- ...
+
+## Blockers
+- ... (or "none")
+
+## Next Step
+- ...

--- a/operatives/WORKER.md
+++ b/operatives/WORKER.md
@@ -16,7 +16,7 @@ Implement child issues quickly and correctly.
 - Do not start issues missing either label (`status:ready-for-work`, `role:worker`).
 - If issue is missing labels, ask planner to classify it first.
 - Memory updates are out-of-band and must sync to `main` only (never issue/PR branches).
-- Read daily memory (`agents/memory/<agent-id>/YYYY-MM-DD.md`) and run day-rollover consolidation on first UTC run of each day.
+- For each run, create/resolve a run log at `agents/memory/<agent-id>/<YYYY-MM-DD>/<run-id>.md` via `scripts/agent-runlog.sh`; run day-rollover consolidation on first UTC run each day.
 
 ## Rule
 No broad replanning. Execute defined scope.

--- a/scripts/agent-memory-rollover.sh
+++ b/scripts/agent-memory-rollover.sh
@@ -1,123 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure daily memory file exists and perform day-rollover consolidation.
-# Usage: ./scripts/agent-memory-rollover.sh <agent-id> [context-file]
+# Ensure canonical per-run memory directory exists and perform day-rollover bookkeeping.
+# Usage: ./scripts/agent-memory-rollover.sh <agent-id> <directive-file>
 
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <agent-id> [context-file]" >&2
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <agent-id> <directive-file>" >&2
   exit 1
 fi
 
 AGENT_ID="$1"
-CONTEXT_FILE="${2:-}"
+DIRECTIVE_FILE="$2"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 TODAY="$(date -u +%F)"
 NOW_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
 
 MEMORY_DIR="${REPO_ROOT}/agents/memory/${AGENT_ID}"
-TODAY_FILE="${MEMORY_DIR}/${TODAY}.md"
+TODAY_DIR="${MEMORY_DIR}/${TODAY}"
 STATE_FILE="${MEMORY_DIR}/.rollover-state"
 
-mkdir -p "${MEMORY_DIR}"
+mkdir -p "${MEMORY_DIR}" "${TODAY_DIR}"
 
-if [[ -n "${CONTEXT_FILE}" && ! -f "${CONTEXT_FILE}" ]]; then
-  echo "[rollover] Context file not found (continuing): ${CONTEXT_FILE}" >&2
+if [[ ! -f "${DIRECTIVE_FILE}" ]]; then
+  echo "Directive file not found: ${DIRECTIVE_FILE}" >&2
+  exit 1
 fi
 
-infer_role() {
-  local raw="${1#dacl-}"
-  echo "${raw%%-*}"
-}
-
-canonical_operative_path() {
-  local role="$1"
-  echo "${REPO_ROOT}/operatives/$(echo "${role}" | tr '[:lower:]' '[:upper:]').md"
-}
-
-promote_to_shared_operative() {
-  local agent_id="$1"
-  local source_file="$2"
-  local role
-  role="$(infer_role "${agent_id}")"
-
-  local operative_file
-  operative_file="$(canonical_operative_path "${role}")"
-
-  if [[ ! -f "${operative_file}" ]]; then
-    echo "[rollover] Shared operative target missing for role '${role}': ${operative_file}" >&2
-    return 0
+# One-time migration/deprecation of monolithic memory file.
+if [[ -f "${LEGACY_FILE}" ]]; then
+  if [[ ! -f "${LEGACY_ARCHIVE}" ]]; then
+    cp "${LEGACY_FILE}" "${LEGACY_ARCHIVE}"
   fi
 
-  local candidates
-  candidates="$(grep -Ei '^- .*(always|never|must|should|avoid|ensure|remember|if)\b' "${source_file}" | sed 's/^- //' || true)"
-  if [[ -z "${candidates}" ]]; then
-    echo "[rollover] No durable lesson candidates to promote for role '${role}'."
-    return 0
-  fi
-
-  mkdir -p "${GIT_COMMON_DIR}/locks"
-  local lock_file="${GIT_COMMON_DIR}/locks/operative-${role}.lock"
-
-  exec 8>"${lock_file}"
-  if ! flock -n 8; then
-    echo "[rollover] Lock contention on role '${role}' operative (${lock_file})." >&2
-    echo "[rollover] Another same-role promotion is active. Retry in a few seconds. No files were modified." >&2
-    return 75
-  fi
-
-  local section="## Distilled role learnings"
-  if ! grep -Fq "${section}" "${operative_file}"; then
-    {
-      echo
-      echo "${section}"
-      echo
-    } >> "${operative_file}"
-  fi
-
-  local added=0
-  while IFS= read -r candidate; do
-    [[ -z "${candidate}" ]] && continue
-    if ! grep -Fqi "${candidate}" "${operative_file}"; then
-      printf -- "- %s\n" "${candidate}" >> "${operative_file}"
-      added=1
-    fi
-  done <<< "${candidates}"
-
-  if [[ ${added} -eq 1 ]]; then
-    echo "[rollover] Promoted durable lessons to ${operative_file} (role=${role})."
-  else
-    echo "[rollover] Durable lessons already present in ${operative_file} (role=${role})."
-  fi
-}
-
-if [[ ! -f "${TODAY_FILE}" ]]; then
-    {
-      echo "# Memory — ${AGENT_ID} (${TODAY})"
-      echo
-      echo "_Migrated from legacy file on ${NOW_UTC}._"
-      echo
-      cat "${LEGACY_FILE}"
-      echo
-    } > "${TODAY_FILE}"
-  fi
   cat > "${LEGACY_FILE}" <<EOF
 # Deprecated Memory Path
 
 
-Use daily memory files under:
-- agents/memory/${AGENT_ID}/YYYY-MM-DD.md
+Use canonical run logs under:
+- agents/memory/${AGENT_ID}/<YYYY-MM-DD>/<run-id>.md
 
 Legacy content archived at:
-EOF
-fi
 
-if [[ ! -f "${TODAY_FILE}" ]]; then
-  cat > "${TODAY_FILE}" <<EOF
-# Memory — ${AGENT_ID} (${TODAY})
-
-- Initialized daily memory file.
+Updated: ${NOW_UTC}
 EOF
 fi
 
@@ -136,29 +60,35 @@ if [[ "${LAST_ROLLOVER_DATE}" == "${TODAY}" ]]; then
   exit 0
 fi
 
-PREV_FILE="${MEMORY_DIR}/${LAST_ROLLOVER_DATE}.md"
-if [[ -f "${PREV_FILE}" ]]; then
-  SUMMARY_LINES="$(grep -E '^- ' "${PREV_FILE}" | tail -n 8 || true)"
+PREV_DIR="${MEMORY_DIR}/${LAST_ROLLOVER_DATE}"
+if [[ -d "${PREV_DIR}" ]]; then
+  SUMMARY_LINES="$(grep -hE '^- ' "${PREV_DIR}"/*.md 2>/dev/null | tail -n 8 || true)"
 
-  {
-    echo
-    echo "## Rollover summary from ${LAST_ROLLOVER_DATE}"
-    if [[ -n "${SUMMARY_LINES}" ]]; then
+  if [[ -n "${SUMMARY_LINES}" ]]; then
+    {
+      echo
+      echo "## Rollover summary from ${LAST_ROLLOVER_DATE}"
       echo "${SUMMARY_LINES}"
-    else
-      echo "- No bullet learnings captured in previous day file."
-    fi
-  } >> "${TODAY_FILE}"
+    } >> "${DIRECTIVE_FILE}"
+  fi
 
-  promote_rc=0
-  set +e
-  promote_to_shared_operative "${AGENT_ID}" "${PREV_FILE}"
-  promote_rc=$?
-  set -e
+  CANDIDATES="$(grep -hEi '^- .*\b(always|never|must|should|avoid|ensure|remember|if)\b' "${PREV_DIR}"/*.md 2>/dev/null | sed 's/^- //' || true)"
 
-  if [[ ${promote_rc} -eq 75 ]]; then
-    echo "[rollover] Exiting due to lock contention after safe no-op. Retry this command shortly." >&2
-    exit 75
+  if [[ -n "${CANDIDATES}" ]]; then
+    ADDED=0
+    while IFS= read -r candidate; do
+      [[ -z "${candidate}" ]] && continue
+      if ! grep -Fqi "${candidate}" "${DIRECTIVE_FILE}"; then
+        if [[ ${ADDED} -eq 0 ]]; then
+          {
+            echo
+            echo "## Distilled lessons from daily memory rollover"
+          } >> "${DIRECTIVE_FILE}"
+        fi
+        echo "- ${candidate}" >> "${DIRECTIVE_FILE}"
+        ADDED=1
+      fi
+    done <<< "${CANDIDATES}"
   fi
 fi
 

--- a/scripts/agent-runlog.sh
+++ b/scripts/agent-runlog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve and optionally initialize canonical per-run agent memory log.
+#
+# Usage:
+#   ./scripts/agent-runlog.sh --agent-id <id> --role <role> --run-id <run-id> [--repo <repo>] [--date YYYY-MM-DD] [--timestamp "YYYY-MM-DD HH:MM UTC"] [--dry-run]
+#
+# Output:
+#   Prints resolved target path to stdout.
+
+AGENT_ID=""
+ROLE=""
+RUN_ID=""
+REPO_LABEL=""
+DATE_UTC="$(date -u +%F)"
+TIMESTAMP_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-id)
+      AGENT_ID="${2:-}"
+      shift 2
+      ;;
+    --role)
+      ROLE="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO_LABEL="${2:-}"
+      shift 2
+      ;;
+    --date)
+      DATE_UTC="${2:-}"
+      shift 2
+      ;;
+    --timestamp)
+      TIMESTAMP_UTC="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" || -z "$ROLE" || -z "$RUN_ID" ]]; then
+  echo "Missing required arguments: --agent-id, --role, --run-id" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [[ -z "$REPO_LABEL" ]]; then
+  REPO_LABEL="$(basename "$REPO_ROOT")"
+fi
+
+TEMPLATE_FILE="$REPO_ROOT/operatives/RUN_LOG_TEMPLATE.md"
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "Template not found: $TEMPLATE_FILE" >&2
+  exit 1
+fi
+
+TARGET_DIR="$REPO_ROOT/agents/memory/$AGENT_ID/$DATE_UTC"
+TARGET_PATH="$TARGET_DIR/$RUN_ID.md"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  mkdir -p "$TARGET_DIR"
+  if [[ ! -f "$TARGET_PATH" ]]; then
+    sed \
+      -e "s/{{agent_id}}/$AGENT_ID/g" \
+      -e "s/{{role}}/$ROLE/g" \
+      -e "s/{{timestamp_utc}}/$TIMESTAMP_UTC/g" \
+      -e "s/{{run_id}}/$RUN_ID/g" \
+      -e "s|{{repo}}|$REPO_LABEL|g" \
+      "$TEMPLATE_FILE" > "$TARGET_PATH"
+  fi
+fi
+
+echo "$TARGET_PATH"

--- a/scripts/memory-sync.sh
+++ b/scripts/memory-sync.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync one memory file directly to origin/main with a simple lock + retry.
+# Sync one daily memory/directive file directly to origin/main with a simple lock + retry.
 # Usage: ./scripts/memory-sync.sh <agent-id> <memory-file> [note]
 
 if [[ $# -lt 2 ]]; then
@@ -20,13 +20,18 @@ if [[ ! -f "${MEM_FILE}" ]]; then
   exit 1
 fi
 
-case "${MEM_FILE}" in
-  agents/memory/*|${REPO_ROOT}/agents/memory/*) ;;
-  *)
-    echo "Refusing to sync non-memory path to main: ${MEM_FILE}" >&2
-    exit 2
-    ;;
-esac
+# Enforce daily-memory and directive sync targets only; reject deprecated monolithic paths.
+if [[ "${MEM_FILE}" == *"agents/memory/${AGENT_ID}.md" ]]; then
+  echo "Refusing deprecated memory path: ${MEM_FILE}" >&2
+  echo "Use agents/memory/${AGENT_ID}/YYYY-MM-DD.md instead." >&2
+  exit 1
+fi
+
+if [[ "${MEM_FILE}" != agents/memory/${AGENT_ID}/*.md && "${MEM_FILE}" != agents/directives/${AGENT_ID}.md ]]; then
+  echo "Unsupported sync target: ${MEM_FILE}" >&2
+  echo "Allowed: agents/memory/${AGENT_ID}/YYYY-MM-DD.md or agents/directives/${AGENT_ID}.md" >&2
+  exit 1
+fi
 
 exec 9>"${LOCK_FILE}"
 flock -x 9

--- a/scripts/validate-runlog-emission.sh
+++ b/scripts/validate-runlog-emission.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates one-file-per-run emission + canonical schema for planner/worker run logs.
+# Usage: ./scripts/validate-runlog-emission.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATE_UTC="$(date -u +%F)"
+TS_UTC="$(date -u +"%Y-%m-%d %H:%M UTC")"
+
+emit_and_verify() {
+  local agent_id="$1"
+  local role="$2"
+  local run_id="issue-57-${agent_id}-$(date -u +%Y%m%dT%H%M%SZ)-$RANDOM"
+  local dir="$REPO_ROOT/agents/memory/${agent_id}/${DATE_UTC}"
+
+  mkdir -p "$dir"
+
+  local before after
+  before=$(find "$dir" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+
+  "$REPO_ROOT/scripts/agent-runlog.sh" \
+    --agent-id "$agent_id" \
+    --role "$role" \
+    --run-id "$run_id" \
+    --repo "DACL" \
+    --date "$DATE_UTC" \
+    --timestamp "$TS_UTC"
+
+  local file="$dir/${run_id}.md"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: expected run-log file not found: $file" >&2
+    return 1
+  fi
+
+  after=$(find "$dir" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+  if [[ $((after - before)) -ne 1 ]]; then
+    echo "ERROR: expected exactly one new file for ${agent_id}; before=${before} after=${after}" >&2
+    return 1
+  fi
+
+  grep -q '^# Run Log$' "$file"
+  grep -q '^## Actions Taken$' "$file"
+  grep -q '^## Learning$' "$file"
+  grep -q '^## Blockers$' "$file"
+  grep -q '^## Next Step$' "$file"
+
+  echo "PASS ${agent_id} (${role}) -> ${file}"
+}
+
+emit_and_verify "dacl-planner-01" "planner"
+emit_and_verify "dacl-worker-01" "worker"
+
+echo "Validation complete: one-file-per-run emission + canonical template sections verified."


### PR DESCRIPTION
Closes #76

## Issue coverage checklist
- [x] Reproduced conflict state for PR #52 and confirmed exact conflicting paths.
- [x] Resolved merge conflicts by replaying `origin/main` into `parent/36-operatives-only-model` on this child branch.
- [x] Opened child PR targeting `parent/36-operatives-only-model`.
- [ ] `gh pr view 52 --json mergeStateStatus,mergeable` clean/mergeable (pending merge of this child PR).

## Evidence
- Merge operation on this branch produced the same conflict set called out in #76:
  - `README.md`
  - `agents/config/dacl-planner-01.json`
  - `agents/config/dacl-planner-02.json`
  - `agents/config/dacl-worker-01.json`
  - `agents/config/dacl-worker-02.json`
  - `scripts/agent-memory-rollover.sh`
- After conflict resolution and commit: `fix(parent-36): resolve main merge conflicts for PR #52` (`0a977a2`).
- Current parent PR #52 status before merging this child:
  - `mergeStateStatus=DIRTY`
  - `mergeable=CONFLICTING`

## Notes
This PR is conflict-only: it contains the resolved merge commit needed to bring `parent/36-operatives-only-model` in sync with `main` at merge boundaries.
