### PR TITLE
feat: live dashboard adapters for agent inventory metadata

### DIFF
--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -70,12 +70,19 @@ function AgentSection({ agents }: { agents: AgentRecord[] | undefined }) {
           key={agent.id}
           className="rounded-xl border border-border/80 bg-background/30 p-4 shadow-sm transition-colors hover:border-border"
         >
-          <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
             <div>
               <p className="text-base font-semibold tracking-tight">{agent.id}</p>
               <p className="mt-0.5 text-xs text-muted-foreground uppercase">{agent.role}</p>
             </div>
             <Pill label={agent.statusSummary} tone={toneFromText(agent.statusSummary)} />
+          </div>
+
+          <div className="space-y-2.5">
+            <StackRow label="Operative" value={agent.operativeFile} />
+            <StackRow label="Worktree" value={agent.worktree} />
+            <StackRow label="Path" value={agent.worktreePath} />
+            <StackRow label="Wallet" value={`${agent.walletNetwork}: ${agent.walletPubkey}`} />
           </div>
         </li>
       ))}
@@ -144,6 +151,7 @@ export default async function HomePage() {
   const totalAgents = data?.agents?.length ?? 0;
   const totalCronJobs = data?.cronJobs?.length ?? 0;
   const totalActivity = data?.activity?.length ?? 0;
+  const dataErrors = data?.errors ?? [];
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10 lg:gap-7 lg:px-8 lg:py-12">
@@ -173,6 +181,10 @@ export default async function HomePage() {
           </div>
         </div>
       </header>
+
+      {dataErrors.length > 0 ? (
+        <ErrorState message={`Some data sources failed to load: ${dataErrors.join(' | ')}`} />
+      ) : null}
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" aria-label="Agents, cron jobs, and activity">
         <Card className="border-border/80 bg-card/95">

--- a/apps/ops-dashboard/lib/data.ts
+++ b/apps/ops-dashboard/lib/data.ts
@@ -4,6 +4,11 @@ import path from 'node:path';
 export type AgentRecord = {
   id: string;
   role: string;
+  operativeFile: string;
+  worktree: string;
+  worktreePath: string;
+  walletNetwork: string;
+  walletPubkey: string;
   statusSummary: string;
 };
 
@@ -25,17 +30,40 @@ export type DashboardData = {
   agents: AgentRecord[];
   cronJobs: CronJobRecord[];
   activity: ActivityRecord[];
+  errors: string[];
 };
 
 const repoRoot = path.resolve(process.cwd(), '..', '..');
 
+type RegistryAgent = {
+  agentId?: unknown;
+  role?: unknown;
+  operative?: unknown;
+  config?: unknown;
+};
+
+type AgentConfig = {
+  operativeFile?: unknown;
+  worktree?: unknown;
+  worktreePath?: unknown;
+  wallet?: {
+    network?: unknown;
+    pubkey?: unknown;
+  };
+};
+
 async function readJson(relativePath: string): Promise<unknown> {
   const filePath = path.join(repoRoot, relativePath);
+  const content = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(content) as unknown;
+}
 
+async function readJsonSafe(relativePath: string, errors: string[]): Promise<unknown | null> {
   try {
-    const content = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(content) as unknown;
-  } catch {
+    return await readJson(relativePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    errors.push(`${relativePath}: ${message}`);
     return null;
   }
 }
@@ -44,47 +72,65 @@ function ensureString(value: unknown, fallback = 'unknown'): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
-function deriveStatusSummary(config: unknown): string {
-  if (!config || typeof config !== 'object') {
-    return 'No config available';
-  }
-
-  const worktree = ensureString((config as { worktree?: unknown }).worktree, 'no worktree configured');
-  return `Configured (${worktree})`;
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
 }
 
-async function getAgents(): Promise<AgentRecord[]> {
-  const registry = await readJson('agents/registry.json');
-  const registryAgents =
-    registry && typeof registry === 'object' && Array.isArray((registry as { agents?: unknown }).agents)
-      ? ((registry as { agents: unknown[] }).agents ?? [])
-      : [];
+function deriveStatusSummary(config: AgentConfig | null): string {
+  if (!config) return 'Config unavailable';
 
-  const mappedAgents = await Promise.all(
-    registryAgents.map(async (agent): Promise<AgentRecord> => {
-      const safeAgent = agent && typeof agent === 'object' ? (agent as { agentId?: unknown; role?: unknown; config?: unknown }) : {};
-      const config = typeof safeAgent.config === 'string' ? await readJson(safeAgent.config) : null;
+  const hasWorktree = typeof config.worktree === 'string' && config.worktree.trim().length > 0;
+  const hasOperative = typeof config.operativeFile === 'string' && config.operativeFile.trim().length > 0;
+  const walletObject = asObject(config.wallet);
+  const hasWallet = Boolean(walletObject && typeof walletObject.pubkey === 'string' && walletObject.pubkey.trim().length > 0);
+
+  if (hasWorktree && hasOperative && hasWallet) return 'Ready';
+  if (hasWorktree || hasOperative || hasWallet) return 'Partial config';
+  return 'Config missing fields';
+}
+
+async function getAgents(errors: string[]): Promise<AgentRecord[]> {
+  const registry = await readJsonSafe('agents/registry.json', errors);
+  const registryObject = asObject(registry);
+  const registryAgents = Array.isArray(registryObject?.agents) ? (registryObject.agents as unknown[]) : [];
+
+  return Promise.all(
+    registryAgents.map(async (entry): Promise<AgentRecord> => {
+      const safeAgent = asObject(entry) as RegistryAgent | null;
+      const agentId = ensureString(safeAgent?.agentId);
+      const role = ensureString(safeAgent?.role);
+      const configPath = ensureString(safeAgent?.config, '');
+      const fallbackOperative = ensureString(safeAgent?.operative, 'not provided');
+
+      let config: AgentConfig | null = null;
+      if (configPath) {
+        const rawConfig = await readJsonSafe(configPath, errors);
+        config = asObject(rawConfig) as AgentConfig | null;
+      }
+
+      const wallet = asObject(config?.wallet);
 
       return {
-        id: ensureString(safeAgent.agentId),
-        role: ensureString(safeAgent.role),
+        id: agentId,
+        role,
+        operativeFile: ensureString(config?.operativeFile, fallbackOperative),
+        worktree: ensureString(config?.worktree, 'not configured'),
+        worktreePath: ensureString(config?.worktreePath, 'not configured'),
+        walletNetwork: ensureString(wallet?.network, 'unknown'),
+        walletPubkey: ensureString(wallet?.pubkey, 'not configured'),
         statusSummary: deriveStatusSummary(config)
       };
     })
   );
-
-  return mappedAgents;
 }
 
-async function getCronJobs(): Promise<CronJobRecord[]> {
-  const source = await readJson('apps/ops-dashboard/data/cron-jobs.json');
-  const jobs =
-    source && typeof source === 'object' && Array.isArray((source as { cronJobs?: unknown }).cronJobs)
-      ? ((source as { cronJobs: unknown[] }).cronJobs ?? [])
-      : [];
+async function getCronJobs(errors: string[]): Promise<CronJobRecord[]> {
+  const source = await readJsonSafe('apps/ops-dashboard/data/cron-jobs.json', errors);
+  const sourceObj = asObject(source);
+  const jobs = Array.isArray(sourceObj?.cronJobs) ? (sourceObj.cronJobs as unknown[]) : [];
 
   return jobs.map((job): CronJobRecord => {
-    const safeJob = job && typeof job === 'object' ? (job as Record<string, unknown>) : {};
+    const safeJob = asObject(job) ?? {};
 
     return {
       name: ensureString(safeJob.name),
@@ -96,15 +142,13 @@ async function getCronJobs(): Promise<CronJobRecord[]> {
   });
 }
 
-async function getActivity(): Promise<ActivityRecord[]> {
-  const source = await readJson('apps/ops-dashboard/data/activity.json');
-  const rows =
-    source && typeof source === 'object' && Array.isArray((source as { activity?: unknown }).activity)
-      ? ((source as { activity: unknown[] }).activity ?? [])
-      : [];
+async function getActivity(errors: string[]): Promise<ActivityRecord[]> {
+  const source = await readJsonSafe('apps/ops-dashboard/data/activity.json', errors);
+  const sourceObj = asObject(source);
+  const rows = Array.isArray(sourceObj?.activity) ? (sourceObj.activity as unknown[]) : [];
 
   return rows.map((row): ActivityRecord => {
-    const safeRow = row && typeof row === 'object' ? (row as Record<string, unknown>) : {};
+    const safeRow = asObject(row) ?? {};
 
     return {
       agentId: ensureString(safeRow.agentId),
@@ -115,11 +159,13 @@ async function getActivity(): Promise<ActivityRecord[]> {
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
-  const [agents, cronJobs, activity] = await Promise.all([getAgents(), getCronJobs(), getActivity()]);
+  const errors: string[] = [];
+  const [agents, cronJobs, activity] = await Promise.all([getAgents(errors), getCronJobs(errors), getActivity(errors)]);
 
   return {
     agents,
     cronJobs,
-    activity
+    activity,
+    errors
   };
 }


### PR DESCRIPTION
## Summary
- replace static/mock agent inventory mapping with live adapters sourced from `agents/registry.json` and per-agent config files
- normalize dashboard agent records to include metadata fields used by cards (operative file, worktree, worktree path, wallet network/pubkey)
- add safe JSON parsing + validation fallbacks so missing/invalid files do not crash the dashboard
- surface data-source failures in the UI via a clean error banner while still rendering partial data

## Validation
- `npm run build` (apps/ops-dashboard)

Closes #79
Parent #78
