### PR TITLE
Update READMEs: add root README, fix stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# DACL
+
+Autonomous agent orchestration. Planner and worker agents run in isolated git worktrees, coordinating via GitHub issues.
+
+## Repo structure
+
+```
+agent-kernel/    One-shot Claude CLI wrapper, cron-friendly
+apps/
+  ops-dashboard/ Next.js operations dashboard
+contexts/        Reusable context library for agent instructions
+```
+
+- **[agent-kernel](agent-kernel/README.md)** — invoke Claude CLI with context files, run unattended via cron
+- **[ops-dashboard](apps/ops-dashboard/README.md)** — live dashboard for monitoring agents, cron jobs, and runlogs
+- **[contexts](contexts/)** — modular `.md` files that shape agent behavior (identity, constraints, planner/worker roles, handoff protocol, labels, workspace rules)
+
+## How it works
+
+Agents are stateless one-shot CLI invocations. Each run:
+
+1. `agent-kernel/run.sh` assembles a system prompt from selected context files
+2. Invokes `claude` CLI in either text-only (`--print`) or agentic mode
+3. Optionally runs inside an isolated git worktree (`--workspace`)
+
+Cron jobs drive recurring agent runs. See [`agent-kernel/cron/README.md`](agent-kernel/cron/README.md).
+
+## Getting started
+
+See [agent-kernel/README.md](agent-kernel/README.md) for setup and usage.

--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -17,7 +17,6 @@ cp agent-kernel/.env.example agent-kernel/.env
 
 | File | Purpose |
 |------|---------|
-| `CONTEXT.md` | Base system prompt — always included. Empty = skipped. |
 | `run.sh` | Invokes `claude` CLI once and exits. |
 | `.env` | Auth and overrides (gitignored). See `.env.example`. |
 | `cron/` | Cron management subsystem. See [`cron/README.md`](cron/README.md). |
@@ -46,11 +45,15 @@ Reusable context files live in `contexts/` at the repo root. Each `.md` file is 
 ```
 contexts/
   IDENTITY.md      # agent identity and rules
-  REPO_MAP.md      # codebase overview
-  CODE_STYLE.md    # coding conventions
+  CONSTRAINTS.md   # operational constraints
+  PLANNER.md       # planner agent instructions
+  WORKER.md        # worker agent instructions
+  HANDOFF.md       # task handoff protocol
+  LABELS.md        # GitHub issue labeling conventions
+  WORKSPACE.md     # git worktree and branching guidelines
 ```
 
-Select which contexts to include per invocation with `--context <path>` (repeatable, relative to repo root). The base `CONTEXT.md` is always prepended.
+Select which contexts to include per invocation with `--context <path>` (repeatable, relative to repo root).
 
 Cron jobs can also specify contexts in `cron-jobs.json`:
 ```json
@@ -64,8 +67,9 @@ Cron jobs can also specify contexts in `cron-jobs.json`:
 
 ## How it works
 
-1. `CONTEXT.md` content is always included via `--append-system-prompt` (preserves Claude's built-in capabilities)
-2. `--context <path>` flags append additional context files (paths relative to repo root)
+1. `--context <path>` flags assemble a system prompt from context files (paths relative to repo root)
+2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
 4. `--dangerously-skip-permissions` is on by default for unattended runs
 5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
+6. `--workspace <id>` runs inside an isolated git worktree at `.worktrees/<id>`


### PR DESCRIPTION
## Summary
- Create root `README.md` with project overview, repo structure, and getting-started pointers
- Fix `agent-kernel/README.md`: update context library to list actual files, remove stale `CONTEXT.md`/`REPO_MAP.md`/`CODE_STYLE.md` references, update "How it works" to match current `run.sh` behavior
- Reviewed `apps/ops-dashboard/README.md` and `agent-kernel/cron/README.md` — both accurate, no changes needed

## Test plan
- [ ] Verify root `README.md` renders correctly on GitHub
- [ ] Verify all links in root README resolve
- [ ] Verify `agent-kernel/README.md` context library matches `contexts/` directory contents
- [ ] Confirm no references to `CONTEXT.md`, `REPO_MAP.md`, or `CODE_STYLE.md` remain

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
