### PR TITLE
Fix ops-dashboard data paths to match agent-kernel layout

### DIFF
--- a/apps/ops-dashboard/README.md
+++ b/apps/ops-dashboard/README.md
@@ -4,14 +4,14 @@ Operations dashboard built with **Next.js (App Router) + TypeScript + Tailwind C
 
 ## Live data architecture
 
-`lib/data.ts` hydrates all primary panels from repo/runtime-backed sources:
+`lib/data.ts` hydrates all primary panels from repo-backed sources:
 
-- **Agents** → `agents/registry.json` + each `agents/config/*.json`
-- **Cron Jobs** → `cron/jobs.json`
-- **Runlog History** → `agents/runlogs/<agent-id>/<YYYY-MM-DD>/*.md`
-- **Activity** → derived from each agent's latest parsed runlog entry
+- **Agents** → derived from `agent-kernel/cron/cron-jobs.json` entries (role inferred from `contexts` array)
+- **Cron Jobs** → `agent-kernel/cron/cron-jobs.json`
+- **Runlog History** → not yet available (graceful empty state); target schema: `agents/runlogs/<agent-id>/<YYYY-MM-DD>/*.md`
+- **Activity** → derived from each agent's latest parsed runlog entry (empty until runlogs exist)
 
-The dashboard no longer depends on static fixture files for primary views.
+There is no separate agent registry — agents are defined by their cron job entries.
 
 ## UX resilience
 

--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -45,13 +45,6 @@ function Pill({
   return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${toneClass}`}>{label}</span>;
 }
 
-function toneFromText(input: string): 'neutral' | 'good' | 'warn' | 'bad' {
-  const value = input.toLowerCase();
-  if (value.includes('ok') || value.includes('healthy') || value.includes('success') || value.includes('online')) return 'good';
-  if (value.includes('degrad') || value.includes('retry') || value.includes('slow') || value.includes('pending')) return 'warn';
-  if (value.includes('error') || value.includes('fail') || value.includes('down') || value.includes('offline')) return 'bad';
-  return 'neutral';
-}
 
 function StackRow({ label, value }: { label: string; value: string }) {
   return (
@@ -78,14 +71,12 @@ function AgentSection({ agents }: { agents: AgentRecord[] | undefined }) {
               <p className="text-base font-semibold tracking-tight">{agent.id}</p>
               <p className="mt-0.5 text-xs text-muted-foreground uppercase">{agent.role}</p>
             </div>
-            <Pill label={agent.statusSummary} tone={toneFromText(agent.statusSummary)} />
+            <Pill label={agent.agentic ? 'Agentic' : 'Non-agentic'} tone={agent.agentic ? 'good' : 'neutral'} />
           </div>
 
           <div className="space-y-2.5">
-            <StackRow label="Operative" value={agent.operativeFile} />
-            <StackRow label="Worktree" value={agent.worktree} />
-            <StackRow label="Path" value={agent.worktreePath} />
-            <StackRow label="Wallet" value={`${agent.walletNetwork}: ${agent.walletPubkey}`} />
+            <StackRow label="Interval" value={agent.interval} />
+            <StackRow label="Workspace" value={agent.workspace ? 'Isolated worktree' : 'Shared'} />
           </div>
         </li>
       ))}
@@ -106,13 +97,14 @@ function CronSection({ cronJobs }: { cronJobs: CronJobRecord[] | undefined }) {
         >
           <div className="mb-3 flex items-start justify-between gap-2">
             <p className="text-base font-semibold tracking-tight">{job.name}</p>
-            <Pill label={job.enabled ? 'Enabled' : 'Disabled'} tone={job.enabled ? 'good' : 'warn'} />
+            <Pill label={`Every ${job.interval}`} tone="good" />
           </div>
 
           <div className="space-y-2.5">
-            <StackRow label="Schedule" value={job.schedule} />
-            <StackRow label="Next run" value={job.nextRun} />
-            <StackRow label="Last run" value={job.lastRunStatus} />
+            <StackRow label="Prompt" value={job.prompt.length > 120 ? `${job.prompt.slice(0, 120)}…` : job.prompt} />
+            <StackRow label="Contexts" value={job.contexts.map((c) => c.split('/').pop()).join(', ') || 'none'} />
+            <StackRow label="Agentic" value={job.agentic ? 'Yes' : 'No'} />
+            <StackRow label="Workspace" value={job.workspace ? 'Isolated worktree' : 'Shared'} />
           </div>
         </li>
       ))}

--- a/apps/ops-dashboard/lib/data.ts
+++ b/apps/ops-dashboard/lib/data.ts
@@ -1,24 +1,21 @@
 import fs from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
 import path from 'node:path';
 
 export type AgentRecord = {
   id: string;
   role: string;
-  operativeFile: string;
-  worktree: string;
-  worktreePath: string;
-  walletNetwork: string;
-  walletPubkey: string;
-  statusSummary: string;
+  interval: string;
+  agentic: boolean;
+  workspace: boolean;
 };
 
 export type CronJobRecord = {
   name: string;
-  schedule: string;
-  enabled: boolean;
-  nextRun: string;
-  lastRunStatus: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
 };
 
 export type ActivityRecord = {
@@ -54,231 +51,92 @@ export type DashboardData = {
 };
 
 const repoRoot = path.resolve(process.cwd(), '..', '..');
-const runlogsRoot = path.join(repoRoot, 'agents/runlogs');
+const cronJobsPath = path.join(repoRoot, 'agent-kernel/cron/cron-jobs.json');
 
-type RegistryAgent = {
-  agentId?: unknown;
-  role?: unknown;
-  operative?: unknown;
-  config?: unknown;
+type CronJobEntry = {
+  id?: unknown;
+  interval?: unknown;
+  prompt?: unknown;
+  contexts?: unknown;
+  agentic?: unknown;
+  workspace?: unknown;
 };
-
-type AgentConfig = {
-  operativeFile?: unknown;
-  worktree?: unknown;
-  worktreePath?: unknown;
-  wallet?: {
-    network?: unknown;
-    pubkey?: unknown;
-  };
-};
-
-async function readJson(relativePath: string): Promise<unknown> {
-  const filePath = path.join(repoRoot, relativePath);
-  const content = await fs.readFile(filePath, 'utf8');
-  return JSON.parse(content) as unknown;
-}
-
-async function readJsonSafe(relativePath: string, errors: string[]): Promise<unknown | null> {
-  try {
-    return await readJson(relativePath);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown error';
-    errors.push(`${relativePath}: ${message}`);
-    return null;
-  }
-}
 
 function ensureString(value: unknown, fallback = 'unknown'): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
-function asObject(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+function ensureStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
 }
 
-function deriveStatusSummary(config: AgentConfig | null): string {
-  if (!config) return 'Config unavailable';
-
-  const hasWorktree = typeof config.worktree === 'string' && config.worktree.trim().length > 0;
-  const hasOperative = typeof config.operativeFile === 'string' && config.operativeFile.trim().length > 0;
-  const walletObject = asObject(config.wallet);
-  const hasWallet = Boolean(walletObject && typeof walletObject.pubkey === 'string' && walletObject.pubkey.trim().length > 0);
-
-  if (hasWorktree && hasOperative && hasWallet) return 'Ready';
-  if (hasWorktree || hasOperative || hasWallet) return 'Partial config';
-  return 'Config missing fields';
+function inferRole(contexts: string[]): string {
+  if (contexts.some((c) => c.includes('PLANNER.md'))) return 'planner';
+  if (contexts.some((c) => c.includes('WORKER.md'))) return 'worker';
+  return 'unknown';
 }
 
-async function getAgents(errors: string[]): Promise<AgentRecord[]> {
-  const registry = await readJsonSafe('agents/registry.json', errors);
-  const registryObject = asObject(registry);
-  const registryAgents = Array.isArray(registryObject?.agents) ? (registryObject.agents as unknown[]) : [];
-
-  return Promise.all(
-    registryAgents.map(async (entry): Promise<AgentRecord> => {
-      const safeAgent = asObject(entry) as RegistryAgent | null;
-      const agentId = ensureString(safeAgent?.agentId);
-      const role = ensureString(safeAgent?.role);
-      const configPath = ensureString(safeAgent?.config, '');
-      const fallbackOperative = ensureString(safeAgent?.operative, 'not provided');
-
-      let config: AgentConfig | null = null;
-      if (configPath) {
-        const rawConfig = await readJsonSafe(configPath, errors);
-        config = asObject(rawConfig) as AgentConfig | null;
-      }
-
-      const wallet = asObject(config?.wallet);
-
-      return {
-        id: agentId,
-        role,
-        operativeFile: ensureString(config?.operativeFile, fallbackOperative),
-        worktree: ensureString(config?.worktree, 'not configured'),
-        worktreePath: ensureString(config?.worktreePath, 'not configured'),
-        walletNetwork: ensureString(wallet?.network, 'unknown'),
-        walletPubkey: ensureString(wallet?.pubkey, 'not configured'),
-        statusSummary: deriveStatusSummary(config)
-      };
-    })
-  );
-}
-
-function parseRunlogTimestamp(content: string, date: string, fileName: string, mtime: Date): string {
-  const fromField = content.match(/^-\s*timestamp_utc:\s*(.+)$/m)?.[1]?.trim();
-  if (fromField) return fromField;
-
-  const fromHeader = content.match(/^# .*—\s*([^\n]+)$/m)?.[1]?.trim();
-  if (fromHeader) return fromHeader;
-
-  const fromName = fileName.match(/^(\d{2})(\d{2})(\d{2})Z\.md$/);
-  if (fromName) return `${date}T${fromName[1]}:${fromName[2]}:${fromName[3]}Z`;
-
-  return mtime.toISOString();
-}
-
-function parseRunlogPreview(content: string): string {
-  const cleaned = content
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-
-  const firstBullet = cleaned.find((line) => line.startsWith('-'));
-  return firstBullet ? firstBullet.replace(/^-\s*/, '') : 'Runlog recorded.';
-}
-
-async function getRunlogs(): Promise<AgentRunlogHistory[]> {
-  let agentDirs: Dirent[] = [];
+async function readCronJobs(errors: string[]): Promise<CronJobEntry[]> {
   try {
-    agentDirs = await fs.readdir(runlogsRoot, { withFileTypes: true });
-  } catch {
+    const content = await fs.readFile(cronJobsPath, 'utf8');
+    const parsed = JSON.parse(content) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>;
+      return Array.isArray(obj.jobs) ? (obj.jobs as CronJobEntry[]) : [];
+    }
+    return [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    errors.push(`agent-kernel/cron/cron-jobs.json: ${message}`);
     return [];
   }
-
-  const histories = await Promise.all(
-    agentDirs
-      .filter((dir) => dir.isDirectory())
-      .map(async (agentDir): Promise<AgentRunlogHistory> => {
-        const agentId = agentDir.name;
-        const agentPath = path.join(runlogsRoot, agentId);
-        let parseErrors = 0;
-        const entries: RunlogEntry[] = [];
-
-        let dateDirs: Dirent[] = [];
-        try {
-          dateDirs = await fs.readdir(agentPath, { withFileTypes: true });
-        } catch {
-          return { agentId, latest: null, byDate: [], parseErrors: 1 };
-        }
-
-        for (const dateDir of dateDirs.filter((dir) => dir.isDirectory())) {
-          const date = dateDir.name;
-          const datePath = path.join(agentPath, date);
-          let files: Dirent[] = [];
-
-          try {
-            files = await fs.readdir(datePath, { withFileTypes: true });
-          } catch {
-            parseErrors += 1;
-            continue;
-          }
-
-          for (const file of files.filter((f) => f.isFile() && f.name.endsWith('.md'))) {
-            const filePath = path.join(datePath, file.name);
-            try {
-              const [content, stat] = await Promise.all([fs.readFile(filePath, 'utf8'), fs.stat(filePath)]);
-              const timestamp = parseRunlogTimestamp(content, date, file.name, stat.mtime);
-              entries.push({
-                id: `${agentId}:${date}:${file.name}`,
-                timestamp,
-                preview: parseRunlogPreview(content),
-                path: path.relative(repoRoot, filePath)
-              });
-            } catch {
-              parseErrors += 1;
-            }
-          }
-        }
-
-        const sorted = entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-        const byDateMap = new Map<string, RunlogEntry[]>();
-        for (const entry of sorted) {
-          const day = entry.timestamp.slice(0, 10);
-          byDateMap.set(day, [...(byDateMap.get(day) ?? []), entry]);
-        }
-
-        return {
-          agentId,
-          latest: sorted[0] ?? null,
-          byDate: [...byDateMap.entries()]
-            .sort((a, b) => b[0].localeCompare(a[0]))
-            .map(([date, dayEntries]) => ({ date, entries: dayEntries })),
-          parseErrors
-        };
-      })
-  );
-
-  return histories.sort((a, b) => a.agentId.localeCompare(b.agentId));
 }
 
-async function getCronJobs(errors: string[]): Promise<CronJobRecord[]> {
-  const source = await readJsonSafe('cron/jobs.json', errors);
-  const sourceObj = asObject(source);
-  const jobs = Array.isArray(sourceObj?.jobs) ? (sourceObj.jobs as unknown[]) : [];
-
-  return jobs.map((job): CronJobRecord => {
-    const safeJob = asObject(job) ?? {};
+function getAgents(jobs: CronJobEntry[]): AgentRecord[] {
+  return jobs.map((job) => {
+    const contexts = ensureStringArray(job.contexts);
     return {
-      name: ensureString(safeJob.name),
-      schedule: ensureString(safeJob.every, 'not configured'),
-      enabled: Boolean(safeJob.enabled),
-      nextRun: 'Managed by OpenClaw runtime',
-      lastRunStatus: 'See runlog panel for latest execution output'
+      id: ensureString(job.id),
+      role: inferRole(contexts),
+      interval: ensureString(job.interval, 'not set'),
+      agentic: Boolean(job.agentic),
+      workspace: Boolean(job.workspace),
     };
   });
 }
 
-function getActivity(runlogs: AgentRunlogHistory[]): ActivityRecord[] {
-  return runlogs
-    .map((history) => ({
-      agentId: history.agentId,
-      lastKnownAction: history.latest?.preview ?? 'No activity captured yet',
-      updatedAt: history.latest?.timestamp ?? 'unknown'
-    }))
-    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+function getCronJobs(jobs: CronJobEntry[]): CronJobRecord[] {
+  return jobs.map((job) => ({
+    name: ensureString(job.id),
+    interval: ensureString(job.interval, 'not set'),
+    prompt: ensureString(job.prompt, ''),
+    contexts: ensureStringArray(job.contexts),
+    agentic: Boolean(job.agentic),
+    workspace: Boolean(job.workspace),
+  }));
+}
+
+function getRunlogs(): AgentRunlogHistory[] {
+  // Structured runlog directory (agents/runlogs/<id>/<date>/*.md) does not exist yet.
+  // Return empty array — the UI shows a graceful empty state.
+  return [];
+}
+
+function getActivity(): ActivityRecord[] {
+  // Activity is derived from runlogs, which are not yet available.
+  return [];
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
   const errors: string[] = [];
-  const [agents, cronJobs, runlogs] = await Promise.all([getAgents(errors), getCronJobs(errors), getRunlogs()]);
+  const jobs = await readCronJobs(errors);
 
   return {
-    agents,
-    cronJobs,
-    activity: getActivity(runlogs),
-    runlogs,
+    agents: getAgents(jobs),
+    cronJobs: getCronJobs(jobs),
+    activity: getActivity(),
+    runlogs: getRunlogs(),
     generatedAt: new Date().toISOString(),
-    errors
+    errors,
   };
 }


### PR DESCRIPTION
## Summary
- Rewrites `lib/data.ts` to read from `agent-kernel/cron/cron-jobs.json` instead of nonexistent legacy paths
- Derives agent list from cron job entries (role inferred from `contexts` array)
- Removes all reads from `agents/registry.json`, `agents/config/`, `cron/jobs.json`
- Runlog and activity sections show graceful empty states until structured runlogs exist
- Updates `apps/ops-dashboard/README.md` to reflect actual data sources

## Test plan
- [x] `npm run build` succeeds in `apps/ops-dashboard/`
- [ ] Verify dashboard renders agent and cron panels with data from `cron-jobs.json`
- [ ] Verify runlog and activity panels show empty states without errors

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
