### PR TITLE
Remove dead CONTEXT.md references from run.sh

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -14,7 +14,6 @@ if [[ -f "$KERNEL_DIR/.env" ]]; then
   source "$KERNEL_DIR/.env"
   set +a
 fi
-CONTEXT_FILE="$KERNEL_DIR/CONTEXT.md"
 CLAUDE="${CLAUDE_BIN:-claude}"
 
 # ── parse flags ────────────────────────────────────────────────
@@ -80,10 +79,6 @@ fi
 
 # ── assemble system prompt from context files ─────────────────
 SYSTEM_PROMPT=""
-
-if [[ -s "$CONTEXT_FILE" ]]; then
-  SYSTEM_PROMPT="$(cat "$CONTEXT_FILE")"
-fi
 
 for ctx in "${CONTEXTS[@]}"; do
   CTX_PATH="$REPO_DIR/$ctx"


### PR DESCRIPTION
## Summary
- Removes dead `CONTEXT_FILE` variable and its conditional read from `agent-kernel/run.sh`
- These referenced a nonexistent `CONTEXT.md` file; all context is now sourced via `--context` flags

## Test plan
- [x] Verified no remaining references to `CONTEXT_FILE` or `CONTEXT.md` in run.sh
- [x] Verified `--context` flag logic and `--append-system-prompt` are preserved

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
