### PR TITLE
Logging overhaul: persistent logs + pretty viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .worktrees/
 agent-kernel/.env
 agent-kernel/cron/cron-state.json
+agent-kernel/logs/*.log
 .mypy_cache
 .claude

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -61,7 +61,7 @@ If the state file gets deleted or out of sync, just run `apply` — it reconverg
 
 ## Logs
 
-Each job logs to `/tmp/agent-kernel-<id>.log`. View with:
+Each job logs to `agent-kernel/logs/<id>.log` (persistent across reboots, gitignored). View with:
 
 ```bash
 # Show last 50 lines for a specific job
@@ -73,3 +73,21 @@ Each job logs to `/tmp/agent-kernel-<id>.log`. View with:
 # Show last N lines
 ./agent-kernel/cron/manage.py logs <id> -n 100
 ```
+
+### Pretty log viewer
+
+A color-coded log viewer is available at `agent-kernel/logs/view.sh`:
+
+```bash
+# Tail all agents interleaved
+./agent-kernel/logs/view.sh
+
+# Tail a specific agent
+./agent-kernel/logs/view.sh worker-01
+
+# Live follow mode
+./agent-kernel/logs/view.sh -f
+./agent-kernel/logs/view.sh worker-01 -f
+```
+
+Each agent gets a distinct color for easy scanning.

--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -14,6 +14,7 @@ KERNEL_DIR = os.path.dirname(SCRIPT_DIR)
 REPO_DIR = os.path.dirname(KERNEL_DIR)
 JOBS_FILE = os.path.join(SCRIPT_DIR, "cron-jobs.json")
 STATE_FILE = os.path.join(SCRIPT_DIR, "cron-state.json")
+LOGS_DIR = os.path.join(KERNEL_DIR, "logs")
 TAG_PREFIX = "# DACL:agent-kernel"
 
 
@@ -30,14 +31,15 @@ def parse_interval(interval):
 
 
 def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False):
-    cmd = f"cd {REPO_DIR} && ./agent-kernel/run.sh"
+    cmd = f"cd {REPO_DIR} && mkdir -p {LOGS_DIR} && ./agent-kernel/run.sh"
     if agentic:
         cmd += " --agentic"
     if workspace:
         cmd += f" --workspace {job_id}"
     for ctx in (contexts or []):
         cmd += f" --context {ctx}"
-    cmd += f' "{prompt}" >> /tmp/agent-kernel-{job_id}.log 2>&1'
+    log_path = os.path.join(LOGS_DIR, f"{job_id}.log")
+    cmd += f' "{prompt}" >> {log_path} 2>&1'
     return cmd
 
 
@@ -199,7 +201,7 @@ def cmd_add(args):
     save_state(state)
 
     print(f"Added cron job '{args.id}' ({args.interval}): {cron_expr}")
-    print(f"  Log: /tmp/agent-kernel-{args.id}.log")
+    print(f"  Log: {os.path.join(LOGS_DIR, f'{args.id}.log')}")
 
 
 def cmd_remove(args):
@@ -238,7 +240,7 @@ def cmd_logs(args):
         print(f"No active job with id '{job_id}'", file=sys.stderr)
         sys.exit(1)
 
-    log_path = f"/tmp/agent-kernel-{job_id}.log"
+    log_path = os.path.join(LOGS_DIR, f"{job_id}.log")
     if not os.path.exists(log_path):
         print(f"No log file found at {log_path}")
         return

--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Pretty log viewer for agent-kernel logs.
+# Usage:
+#   ./view.sh              — tail all agent logs interleaved
+#   ./view.sh worker-01    — tail a specific agent's log
+#   ./view.sh -f           — follow all agent logs live
+#   ./view.sh worker-01 -f — follow a specific agent's log live
+
+set -euo pipefail
+
+LOGS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Color assignments by agent ID ─────────────────────────────
+declare -A AGENT_COLORS
+COLORS=(
+  "\033[1;34m"  # blue
+  "\033[1;32m"  # green
+  "\033[1;33m"  # yellow
+  "\033[1;35m"  # magenta
+  "\033[1;36m"  # cyan
+  "\033[1;31m"  # red
+  "\033[1;37m"  # white
+  "\033[1;38;5;208m"  # orange
+)
+RESET="\033[0m"
+COLOR_INDEX=0
+
+get_color() {
+  local agent="$1"
+  if [[ -z "${AGENT_COLORS[$agent]+x}" ]]; then
+    AGENT_COLORS[$agent]="${COLORS[$COLOR_INDEX]}"
+    COLOR_INDEX=$(( (COLOR_INDEX + 1) % ${#COLORS[@]} ))
+  fi
+  echo -e "${AGENT_COLORS[$agent]}"
+}
+
+# ── Parse arguments ───────────────────────────────────────────
+FOLLOW=false
+AGENT_ID=""
+
+for arg in "$@"; do
+  case "$arg" in
+    -f|--follow) FOLLOW=true ;;
+    -*) echo "Unknown option: $arg" >&2; exit 1 ;;
+    *) AGENT_ID="$arg" ;;
+  esac
+done
+
+# ── Single agent mode ────────────────────────────────────────
+if [[ -n "$AGENT_ID" ]]; then
+  LOG_FILE="$LOGS_DIR/$AGENT_ID.log"
+  if [[ ! -f "$LOG_FILE" ]]; then
+    echo "No log file found: $LOG_FILE" >&2
+    exit 1
+  fi
+  COLOR=$(get_color "$AGENT_ID")
+  TAG="${COLOR}[$AGENT_ID]${RESET}"
+  if $FOLLOW; then
+    tail -f -n 50 "$LOG_FILE" | while IFS= read -r line; do
+      echo -e "$TAG $line"
+    done
+  else
+    tail -n 50 "$LOG_FILE" | while IFS= read -r line; do
+      echo -e "$TAG $line"
+    done
+  fi
+  exit 0
+fi
+
+# ── All agents mode ──────────────────────────────────────────
+LOG_FILES=("$LOGS_DIR"/*.log)
+
+if [[ ! -e "${LOG_FILES[0]}" ]]; then
+  echo "No log files found in $LOGS_DIR" >&2
+  exit 1
+fi
+
+if $FOLLOW; then
+  # Use tail -f on all files and prefix each line with the agent ID
+  tail -f -n 10 "${LOG_FILES[@]}" 2>/dev/null | while IFS= read -r line; do
+    # tail -f outputs "==> path <==\n" headers when switching files
+    if [[ "$line" =~ ^==\>\ (.+)\ \<==$ ]]; then
+      filepath="${BASH_REMATCH[1]}"
+      current_agent="$(basename "$filepath" .log)"
+      continue
+    fi
+    if [[ -z "$line" ]]; then
+      continue
+    fi
+    COLOR=$(get_color "${current_agent:-unknown}")
+    echo -e "${COLOR}[${current_agent:-unknown}]${RESET} $line"
+  done
+else
+  # Show last 20 lines per agent, interleaved by file
+  for log_file in "${LOG_FILES[@]}"; do
+    agent="$(basename "$log_file" .log)"
+    COLOR=$(get_color "$agent")
+    TAG="${COLOR}[$agent]${RESET}"
+    tail -n 20 "$log_file" | while IFS= read -r line; do
+      echo -e "$TAG $line"
+    done
+  done
+fi


### PR DESCRIPTION
**@worker-02**

## Summary
- Move agent logs from `/tmp/agent-kernel-<id>.log` to `agent-kernel/logs/<id>.log` for persistence across reboots
- Add `agent-kernel/logs/view.sh` — color-coded log viewer with per-agent colors
- Viewer supports: all-agents interleaved, single-agent, and `-f` follow mode
- Log files are gitignored; `view.sh` is tracked

## Test plan
- [ ] Run `manage.py apply` and verify cron commands point to `agent-kernel/logs/`
- [ ] Run `manage.py add test-job 5m "hello" && manage.py logs test-job` to confirm new log path works
- [ ] Run `./agent-kernel/logs/view.sh` with sample log files to verify color output
- [ ] Run `./agent-kernel/logs/view.sh <agent-id>` for single-agent mode
- [ ] Run `./agent-kernel/logs/view.sh -f` for follow mode
- [ ] Verify `agent-kernel/logs/*.log` files are gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
