### PR TITLE
Persistent logs + pretty log viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 agent-kernel/.env
 agent-kernel/cron/cron-state.json
 .mypy_cache
+agent-kernel/logs/*
+!agent-kernel/logs/view.sh
 .claude

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -61,7 +61,7 @@ If the state file gets deleted or out of sync, just run `apply` — it reconverg
 
 ## Logs
 
-Each job logs to `/tmp/agent-kernel-<id>.log`. View with:
+Each job logs to `agent-kernel/logs/<id>.log` (persistent, gitignored). View with:
 
 ```bash
 # Show last 50 lines for a specific job
@@ -72,4 +72,22 @@ Each job logs to `/tmp/agent-kernel-<id>.log`. View with:
 
 # Show last N lines
 ./agent-kernel/cron/manage.py logs <id> -n 100
+```
+
+### Pretty log viewer
+
+Color-coded, multi-agent log viewer:
+
+```bash
+# Tail all agent logs interleaved
+./agent-kernel/logs/view.sh
+
+# Tail a specific agent
+./agent-kernel/logs/view.sh worker-01
+
+# Follow live (all agents)
+./agent-kernel/logs/view.sh -f
+
+# Follow a specific agent live
+./agent-kernel/logs/view.sh -f worker-01
 ```

--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -14,6 +14,7 @@ KERNEL_DIR = os.path.dirname(SCRIPT_DIR)
 REPO_DIR = os.path.dirname(KERNEL_DIR)
 JOBS_FILE = os.path.join(SCRIPT_DIR, "cron-jobs.json")
 STATE_FILE = os.path.join(SCRIPT_DIR, "cron-state.json")
+LOGS_DIR = os.path.join(KERNEL_DIR, "logs")
 TAG_PREFIX = "# DACL:agent-kernel"
 
 
@@ -30,14 +31,14 @@ def parse_interval(interval):
 
 
 def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False):
-    cmd = f"cd {REPO_DIR} && ./agent-kernel/run.sh"
+    cmd = f"mkdir -p {LOGS_DIR} && cd {REPO_DIR} && ./agent-kernel/run.sh"
     if agentic:
         cmd += " --agentic"
     if workspace:
         cmd += f" --workspace {job_id}"
     for ctx in (contexts or []):
         cmd += f" --context {ctx}"
-    cmd += f' "{prompt}" >> /tmp/agent-kernel-{job_id}.log 2>&1'
+    cmd += f' "{prompt}" >> {LOGS_DIR}/{job_id}.log 2>&1'
     return cmd
 
 
@@ -199,7 +200,7 @@ def cmd_add(args):
     save_state(state)
 
     print(f"Added cron job '{args.id}' ({args.interval}): {cron_expr}")
-    print(f"  Log: /tmp/agent-kernel-{args.id}.log")
+    print(f"  Log: {LOGS_DIR}/{args.id}.log")
 
 
 def cmd_remove(args):
@@ -238,7 +239,7 @@ def cmd_logs(args):
         print(f"No active job with id '{job_id}'", file=sys.stderr)
         sys.exit(1)
 
-    log_path = f"/tmp/agent-kernel-{job_id}.log"
+    log_path = os.path.join(LOGS_DIR, f"{job_id}.log")
     if not os.path.exists(log_path):
         print(f"No log file found at {log_path}")
         return

--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Pretty log viewer for agent-kernel logs.
+# Usage:
+#   ./view.sh              — tail all agent logs interleaved
+#   ./view.sh worker-01    — tail a specific agent's log
+#   ./view.sh -f           — follow all agents live
+#   ./view.sh -f worker-01 — follow a specific agent live
+
+set -euo pipefail
+
+LOGS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── color palette ──────────────────────────────────────────────
+# Assign colors by agent ID. Cycles through a fixed palette.
+COLORS=(
+  "34"  # blue
+  "32"  # green
+  "33"  # yellow
+  "35"  # magenta
+  "36"  # cyan
+  "91"  # bright red
+  "92"  # bright green
+  "93"  # bright yellow
+  "94"  # bright blue
+  "95"  # bright magenta
+)
+
+color_for_agent() {
+  local agent="$1"
+  local hash=0
+  for (( i=0; i<${#agent}; i++ )); do
+    hash=$(( (hash + $(printf '%d' "'${agent:$i:1}")) % ${#COLORS[@]} ))
+  done
+  echo "${COLORS[$hash]}"
+}
+
+# ── parse args ─────────────────────────────────────────────────
+FOLLOW=false
+AGENT=""
+LINES=50
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--follow) FOLLOW=true; shift ;;
+    -n)          LINES="$2"; shift 2 ;;
+    -*)          echo "Usage: $0 [-f] [-n lines] [agent-id]" >&2; exit 1 ;;
+    *)           AGENT="$1"; shift ;;
+  esac
+done
+
+# ── single agent mode ─────────────────────────────────────────
+if [[ -n "$AGENT" ]]; then
+  LOG_FILE="${LOGS_DIR}/${AGENT}.log"
+  if [[ ! -f "$LOG_FILE" ]]; then
+    echo "No log file found: ${LOG_FILE}" >&2
+    exit 1
+  fi
+
+  COLOR=$(color_for_agent "$AGENT")
+  TAG="\033[${COLOR}m[${AGENT}]\033[0m"
+
+  if $FOLLOW; then
+    tail -n "$LINES" -f "$LOG_FILE" | while IFS= read -r line; do
+      ts=$(date '+%H:%M:%S')
+      printf "\033[90m%s\033[0m %b %s\n" "$ts" "$TAG" "$line"
+    done
+  else
+    tail -n "$LINES" "$LOG_FILE" | while IFS= read -r line; do
+      ts=$(date '+%H:%M:%S')
+      printf "\033[90m%s\033[0m %b %s\n" "$ts" "$TAG" "$line"
+    done
+  fi
+  exit 0
+fi
+
+# ── all agents mode ───────────────────────────────────────────
+LOG_FILES=("${LOGS_DIR}"/*.log)
+
+if [[ ! -e "${LOG_FILES[0]}" ]]; then
+  echo "No log files found in ${LOGS_DIR}/" >&2
+  exit 1
+fi
+
+if $FOLLOW; then
+  # Use tail -f on all log files, prefix each line with the agent tag
+  tail -n "$LINES" -f "${LOG_FILES[@]}" 2>/dev/null | while IFS= read -r line; do
+    # tail -f prefixes with "==> path <=="; extract agent ID from filename
+    if [[ "$line" =~ ^==\>\ (.+)\ \<== ]]; then
+      filepath="${BASH_REMATCH[1]}"
+      basename="${filepath##*/}"
+      CURRENT_AGENT="${basename%.log}"
+      continue
+    fi
+    [[ -z "$line" ]] && continue
+    COLOR=$(color_for_agent "${CURRENT_AGENT:-unknown}")
+    TAG="\033[${COLOR}m[${CURRENT_AGENT:-unknown}]\033[0m"
+    ts=$(date '+%H:%M:%S')
+    printf "\033[90m%s\033[0m %b %s\n" "$ts" "$TAG" "$line"
+  done
+else
+  # Show last N lines from each agent
+  for log_file in "${LOG_FILES[@]}"; do
+    basename="${log_file##*/}"
+    agent="${basename%.log}"
+    COLOR=$(color_for_agent "$agent")
+    TAG="\033[${COLOR}m[${agent}]\033[0m"
+
+    tail -n "$LINES" "$log_file" | while IFS= read -r line; do
+      ts=$(date '+%H:%M:%S')
+      printf "\033[90m%s\033[0m %b %s\n" "$ts" "$TAG" "$line"
+    done
+  done
+fi


### PR DESCRIPTION
**@worker-01**

## Summary
- Move agent logs from `/tmp/agent-kernel-<id>.log` to persistent `agent-kernel/logs/<id>.log`
- Add color-coded `view.sh` script supporting all-agents, single-agent, and follow modes
- Update `manage.py` (build_cron_command, cmd_logs, cmd_add) to use new log paths
- Update `cron/README.md` with new log location and viewer documentation

## Test plan
- [ ] Run `./agent-kernel/cron/manage.py apply` and verify crontab uses new log paths
- [ ] Run `./agent-kernel/cron/manage.py logs <id>` and verify it reads from `agent-kernel/logs/`
- [ ] Run `./agent-kernel/logs/view.sh` with and without agent ID arg
- [ ] Run `./agent-kernel/logs/view.sh -f` for live follow mode
- [ ] Verify `agent-kernel/logs/*.log` files are gitignored but `view.sh` is tracked

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
