### PR TITLE
Agent overview grid with cron timing UI

### DIFF
--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -1,3 +1,5 @@
+import { AgentGrid } from '@/components/agent-grid';
+import { StatsBar } from '@/components/stats-bar';
 import { getAgents } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -6,32 +8,14 @@ export default async function HomePage() {
   const agents = await getAgents();
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10">
-      <header className="space-y-1.5">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
+      <header className="space-y-3">
         <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
         <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
+        <StatsBar agents={agents} />
       </header>
 
-      <section>
-        <h2 className="mb-3 text-lg font-medium">Agents ({agents.length})</h2>
-        {agents.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No agents found.</p>
-        ) : (
-          <ul className="grid gap-2">
-            {agents.map((agent) => (
-              <li
-                key={agent.id}
-                className="flex items-center justify-between rounded-lg border border-border/80 bg-card/80 px-4 py-3"
-              >
-                <span className="font-medium">{agent.id}</span>
-                <span className="rounded-full border border-border/60 bg-background/40 px-2.5 py-0.5 text-xs text-muted-foreground">
-                  {agent.role}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <AgentGrid agents={agents} />
     </main>
   );
 }

--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Agent } from '@/lib/types';
+import { RelativeTime } from './relative-time';
+import { RoleBadge } from './role-badge';
+
+export function AgentCard({ agent }: { agent: Agent }) {
+  return (
+    <Card className="gap-4 border-border/60 bg-card/70 py-4">
+      <CardHeader className="flex-row items-center justify-between gap-2 pb-0">
+        <CardTitle className="text-base tracking-tight">{agent.id}</CardTitle>
+        <RoleBadge role={agent.role} />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="rounded border border-border/50 bg-background/30 px-1.5 py-0.5">
+            {agent.interval}
+          </span>
+          {agent.agentic && (
+            <span className="rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-amber-300">
+              agentic
+            </span>
+          )}
+          {agent.workspace && (
+            <span className="rounded border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 text-sky-300">
+              workspace
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <div>
+            <span className="text-muted-foreground">Last run </span>
+            <span className="text-foreground">
+              {agent.lastRun ? <RelativeTime iso={agent.lastRun} /> : 'never'}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Next run </span>
+            <span className="text-foreground">
+              {agent.nextRun ? <RelativeTime iso={agent.nextRun} /> : 'unknown'}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ops-dashboard/components/agent-grid.tsx
+++ b/apps/ops-dashboard/components/agent-grid.tsx
@@ -1,0 +1,16 @@
+import type { Agent } from '@/lib/types';
+import { AgentCard } from './agent-card';
+
+export function AgentGrid({ agents }: { agents: Agent[] }) {
+  if (agents.length === 0) {
+    return <p className="text-sm text-muted-foreground">No agents found.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {agents.map((agent) => (
+        <AgentCard key={agent.id} agent={agent} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ops-dashboard/components/relative-time.tsx
+++ b/apps/ops-dashboard/components/relative-time.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+function format(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const abs = Math.abs(diff);
+  const future = diff < 0;
+
+  if (abs < 60_000) return future ? 'in <1m' : '<1m ago';
+
+  const minutes = Math.floor(abs / 60_000);
+  if (minutes < 60) {
+    const label = `${minutes}m`;
+    return future ? `in ${label}` : `${label} ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const label = `${hours}h`;
+    return future ? `in ${label}` : `${label} ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  const label = `${days}d`;
+  return future ? `in ${label}` : `${label} ago`;
+}
+
+export function RelativeTime({ iso }: { iso: string }) {
+  const [text, setText] = useState(() => format(iso));
+
+  useEffect(() => {
+    setText(format(iso));
+    const id = setInterval(() => setText(format(iso)), 15_000);
+    return () => clearInterval(id);
+  }, [iso]);
+
+  return (
+    <time dateTime={iso} title={new Date(iso).toLocaleString()}>
+      {text}
+    </time>
+  );
+}

--- a/apps/ops-dashboard/components/role-badge.tsx
+++ b/apps/ops-dashboard/components/role-badge.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+import type { Agent } from '@/lib/types';
+
+const styles: Record<Agent['role'], string> = {
+  planner: 'border-purple-500/40 bg-purple-500/15 text-purple-300',
+  worker: 'border-teal-500/40 bg-teal-500/15 text-teal-300',
+  unknown: 'border-border/60 bg-background/40 text-muted-foreground',
+};
+
+export function RoleBadge({ role }: { role: Agent['role'] }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
+        styles[role],
+      )}
+    >
+      {role}
+    </span>
+  );
+}

--- a/apps/ops-dashboard/components/stats-bar.tsx
+++ b/apps/ops-dashboard/components/stats-bar.tsx
@@ -1,0 +1,20 @@
+import type { Agent } from '@/lib/types';
+
+export function StatsBar({ agents }: { agents: Agent[] }) {
+  const planners = agents.filter((a) => a.role === 'planner').length;
+  const workers = agents.filter((a) => a.role === 'worker').length;
+
+  return (
+    <div className="flex gap-6 text-sm text-muted-foreground">
+      <span>
+        <span className="font-medium text-foreground">{agents.length}</span> agents
+      </span>
+      <span>
+        <span className="font-medium text-purple-300">{planners}</span> planners
+      </span>
+      <span>
+        <span className="font-medium text-teal-300">{workers}</span> workers
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- Builds the agent overview grid UI with card components showing agent ID, role badge, interval, and agentic/workspace flags
- Adds live-updating relative time display (client component) for last run and next run
- Adds stats bar with agent/planner/worker counts
- Responsive layout (1 col mobile, 2 cols desktop), dark theme with role-specific colors

## Test plan
- [ ] `npm run build` passes
- [ ] Dashboard loads and shows all agents from cron-jobs.json
- [ ] Role badges show distinct colors (purple=planner, teal=worker)
- [ ] Last/next run times update live every 15s
- [ ] Layout is responsive at different breakpoints

Closes #100

Generated with [Claude Code](https://claude.com/claude-code)
