### PR TITLE
Agent overview grid with cron timing UI

### DIFF
--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -1,4 +1,6 @@
 import { getAgents } from '@/lib/data';
+import { AgentGrid } from '@/components/agent-grid';
+import { StatsBar } from '@/components/stats-bar';
 
 export const dynamic = 'force-dynamic';
 
@@ -6,32 +8,14 @@ export default async function HomePage() {
   const agents = await getAgents();
 
   return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10">
-      <header className="space-y-1.5">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
+      <header className="space-y-3">
         <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
         <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
+        <StatsBar agents={agents} />
       </header>
 
-      <section>
-        <h2 className="mb-3 text-lg font-medium">Agents ({agents.length})</h2>
-        {agents.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No agents found.</p>
-        ) : (
-          <ul className="grid gap-2">
-            {agents.map((agent) => (
-              <li
-                key={agent.id}
-                className="flex items-center justify-between rounded-lg border border-border/80 bg-card/80 px-4 py-3"
-              >
-                <span className="font-medium">{agent.id}</span>
-                <span className="rounded-full border border-border/60 bg-background/40 px-2.5 py-0.5 text-xs text-muted-foreground">
-                  {agent.role}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <AgentGrid agents={agents} />
     </main>
   );
 }

--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { RoleBadge } from '@/components/role-badge';
+import { RelativeTime } from '@/components/relative-time';
+import type { Agent } from '@/lib/types';
+import { Bot, Timer, Zap, FolderGit2 } from 'lucide-react';
+
+export function AgentCard({ agent }: { agent: Agent }) {
+  return (
+    <Card className="gap-0 border-border/60 py-0">
+      <CardHeader className="flex-row items-center justify-between gap-2 py-4">
+        <div className="flex items-center gap-2.5">
+          <Bot className="size-4 text-muted-foreground" />
+          <CardTitle className="font-mono text-sm">{agent.id}</CardTitle>
+        </div>
+        <RoleBadge role={agent.role} />
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3 border-t border-border/40 py-4">
+        <div className="flex items-center justify-between text-xs">
+          <span className="flex items-center gap-1.5 text-muted-foreground">
+            <Timer className="size-3" />
+            Interval
+          </span>
+          <span className="font-mono">{agent.interval}</span>
+        </div>
+
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Last run</span>
+          <span className="font-mono text-muted-foreground">
+            <RelativeTime iso={agent.lastRun} />
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Next run</span>
+          <span className="font-mono text-muted-foreground">
+            <RelativeTime iso={agent.nextRun} fallback="unknown" />
+          </span>
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          {agent.agentic && (
+            <span className="flex items-center gap-1 rounded border border-border/50 bg-background/30 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              <Zap className="size-2.5" /> agentic
+            </span>
+          )}
+          {agent.workspace && (
+            <span className="flex items-center gap-1 rounded border border-border/50 bg-background/30 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              <FolderGit2 className="size-2.5" /> workspace
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ops-dashboard/components/agent-grid.tsx
+++ b/apps/ops-dashboard/components/agent-grid.tsx
@@ -1,0 +1,16 @@
+import { AgentCard } from '@/components/agent-card';
+import type { Agent } from '@/lib/types';
+
+export function AgentGrid({ agents }: { agents: Agent[] }) {
+  if (agents.length === 0) {
+    return <p className="text-sm text-muted-foreground">No agents found.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {agents.map((agent) => (
+        <AgentCard key={agent.id} agent={agent} />
+      ))}
+    </div>
+  );
+}

--- a/apps/ops-dashboard/components/relative-time.tsx
+++ b/apps/ops-dashboard/components/relative-time.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const abs = Math.abs(diff);
+  const future = diff < 0;
+
+  if (abs < 60_000) return future ? 'in <1m' : '<1m ago';
+
+  const minutes = Math.floor(abs / 60_000);
+  if (minutes < 60) return future ? `in ${minutes}m` : `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return future ? `in ${hours}h` : `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return future ? `in ${days}d` : `${days}d ago`;
+}
+
+export function RelativeTime({ iso, fallback = 'never' }: { iso: string | null; fallback?: string }) {
+  const [text, setText] = useState(() => (iso ? formatRelative(iso) : fallback));
+
+  useEffect(() => {
+    if (!iso) return;
+    setText(formatRelative(iso));
+    const id = setInterval(() => setText(formatRelative(iso)), 15_000);
+    return () => clearInterval(id);
+  }, [iso]);
+
+  return <span>{text}</span>;
+}

--- a/apps/ops-dashboard/components/role-badge.tsx
+++ b/apps/ops-dashboard/components/role-badge.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/utils';
+
+const styles: Record<string, string> = {
+  planner: 'border-purple-500/40 bg-purple-500/15 text-purple-300',
+  worker: 'border-teal-500/40 bg-teal-500/15 text-teal-300',
+  unknown: 'border-border/60 bg-background/40 text-muted-foreground',
+};
+
+export function RoleBadge({ role }: { role: string }) {
+  return (
+    <span className={cn('rounded-full border px-2 py-0.5 text-[11px] font-medium leading-none', styles[role] ?? styles.unknown)}>
+      {role}
+    </span>
+  );
+}

--- a/apps/ops-dashboard/components/stats-bar.tsx
+++ b/apps/ops-dashboard/components/stats-bar.tsx
@@ -1,0 +1,23 @@
+import type { Agent } from '@/lib/types';
+
+export function StatsBar({ agents }: { agents: Agent[] }) {
+  const planners = agents.filter((a) => a.role === 'planner').length;
+  const workers = agents.filter((a) => a.role === 'worker').length;
+
+  return (
+    <div className="flex gap-6 text-sm">
+      <span>
+        <span className="text-muted-foreground">Agents </span>
+        <span className="font-medium">{agents.length}</span>
+      </span>
+      <span>
+        <span className="text-muted-foreground">Planners </span>
+        <span className="font-medium text-purple-300">{planners}</span>
+      </span>
+      <span>
+        <span className="text-muted-foreground">Workers </span>
+        <span className="font-medium text-teal-300">{workers}</span>
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- Agent overview grid with responsive 1→2 column layout using shadcn Card
- Each card shows agent ID (monospace), role badge (purple for planner, teal for worker), interval, agentic/workspace flags
- Live-updating relative times for last run and next run (client component, refreshes every 15s)
- Stats bar at top showing total agents, planners count, workers count

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Dashboard renders all agents from cron-jobs.json
- [ ] Role badges are visually distinct (purple vs teal)
- [ ] Relative times update live in-browser
- [ ] Responsive layout: 1 col on mobile, 2 cols on desktop

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
