### PR TITLE
Add per-agent log viewer with auto-refresh

### DIFF
--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Agent } from '@/lib/types';
+import { LogPanel } from './log-panel';
 import { RelativeTime } from './relative-time';
 import { RoleBadge } from './role-badge';
 
@@ -40,6 +41,7 @@ export function AgentCard({ agent }: { agent: Agent }) {
             </span>
           </div>
         </div>
+        <LogPanel agentId={agent.id} />
       </CardContent>
     </Card>
   );

--- a/apps/ops-dashboard/components/log-panel.tsx
+++ b/apps/ops-dashboard/components/log-panel.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import { LogViewer } from './log-viewer';
+
+export function LogPanel({ agentId }: { agentId: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span className="inline-block transition-transform" style={{ transform: open ? 'rotate(90deg)' : 'none' }}>
+          ▶
+        </span>
+        {open ? 'Hide logs' : 'View logs'}
+      </button>
+      {open && <LogViewer agentId={agentId} />}
+    </div>
+  );
+}

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { LogChunk } from '@/lib/types';
+
+export function LogViewer({ agentId }: { agentId: string }) {
+  const [log, setLog] = useState<LogChunk | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isAtBottomRef = useRef(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function fetchLogs() {
+      try {
+        const res = await fetch(`/api/logs/${encodeURIComponent(agentId)}?lines=100`);
+        if (!active) return;
+        if (!res.ok) {
+          setError(res.status === 404 ? 'Agent not found' : 'Failed to load logs');
+          setLoading(false);
+          return;
+        }
+        const data: LogChunk = await res.json();
+        setLog(data);
+        setError(null);
+      } catch {
+        if (active) setError('Failed to load logs');
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    fetchLogs();
+    const interval = setInterval(fetchLogs, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [agentId]);
+
+  // Track whether user is scrolled to bottom
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    function onScroll() {
+      if (!el) return;
+      isAtBottomRef.current = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;
+    }
+    el.addEventListener('scroll', onScroll);
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Auto-scroll to bottom on new content if user was at bottom
+  useEffect(() => {
+    if (log && isAtBottomRef.current && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [log]);
+
+  if (loading) {
+    return (
+      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+        Loading logs…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+        {error}
+      </div>
+    );
+  }
+
+  if (!log || log.lines.length === 0) {
+    return (
+      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+        No logs available
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div
+        ref={scrollRef}
+        className="max-h-64 overflow-y-auto rounded-md bg-zinc-950 p-3 font-mono text-[11px] leading-relaxed text-zinc-300"
+      >
+        {log.lines.map((line, i) => (
+          <div key={i} className="whitespace-pre-wrap break-all">
+            {line || '\u00a0'}
+          </div>
+        ))}
+      </div>
+      <p className="text-right text-[10px] text-muted-foreground">
+        {log.totalLines.toLocaleString()} total lines
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `log-viewer.tsx` client component that fetches from `/api/logs/[agentId]`, renders terminal-style output, and auto-refreshes every 5 seconds
- Add `log-panel.tsx` expandable wrapper with toggle button on each agent card
- Integrate log panel into `agent-card.tsx`

## Test plan
- [ ] Click "View logs" on an agent card — logs appear in dark terminal-style panel
- [ ] Verify auto-refresh updates content every 5 seconds without scroll jumps
- [ ] Verify empty state shows "No logs available" for agents without log files
- [ ] Verify loading state shows while fetching
- [ ] Verify scrollable container doesn't blow out layout
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
