### PR TITLE
Add per-agent log viewer

### DIFF
--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Agent } from '@/lib/types';
+import { LogPanel } from './log-panel';
 import { RelativeTime } from './relative-time';
 import { RoleBadge } from './role-badge';
 
@@ -40,6 +41,7 @@ export function AgentCard({ agent }: { agent: Agent }) {
             </span>
           </div>
         </div>
+        <LogPanel agentId={agent.id} />
       </CardContent>
     </Card>
   );

--- a/apps/ops-dashboard/components/log-panel.tsx
+++ b/apps/ops-dashboard/components/log-panel.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import { LogViewer } from './log-viewer';
+
+export function LogPanel({ agentId }: { agentId: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-1.5 rounded border border-border/50 bg-background/40 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
+      >
+        <span className="inline-block transition-transform" style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}>
+          ▸
+        </span>
+        {open ? 'Hide logs' : 'View logs'}
+      </button>
+      {open && <LogViewer agentId={agentId} />}
+    </div>
+  );
+}

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { LogChunk } from '@/lib/types';
+
+export function LogViewer({ agentId }: { agentId: string }) {
+  const [data, setData] = useState<LogChunk | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const wasAtBottomRef = useRef(true);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/logs/${encodeURIComponent(agentId)}?lines=100`);
+      if (!res.ok) {
+        setError(res.status === 404 ? 'Agent not found' : 'Failed to load logs');
+        return;
+      }
+      const chunk: LogChunk = await res.json();
+      setData(chunk);
+      setError(null);
+    } catch {
+      setError('Failed to load logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  // Track scroll position before update
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      wasAtBottomRef.current = el.scrollTop + el.clientHeight >= el.scrollHeight - 8;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Auto-scroll to bottom if user was already there
+  useEffect(() => {
+    if (data && wasAtBottomRef.current && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [data]);
+
+  // Fetch on mount + poll every 8s
+  useEffect(() => {
+    fetchLogs();
+    const id = setInterval(fetchLogs, 8000);
+    return () => clearInterval(id);
+  }, [fetchLogs]);
+
+  if (loading) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-md border border-border/40 bg-background/80">
+        <span className="animate-pulse text-xs text-muted-foreground">Loading logs…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-20 items-center justify-center rounded-md border border-rose-500/20 bg-rose-500/5">
+        <span className="text-xs text-rose-300">{error}</span>
+      </div>
+    );
+  }
+
+  if (!data || data.lines.length === 0) {
+    return (
+      <div className="flex h-20 items-center justify-center rounded-md border border-border/40 bg-background/80">
+        <span className="text-xs text-muted-foreground">No logs available</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+        <span>{data.totalLines.toLocaleString()} total lines</span>
+        {data.lastModified && (
+          <span>updated {new Date(data.lastModified).toLocaleTimeString()}</span>
+        )}
+      </div>
+      <div
+        ref={containerRef}
+        className="max-h-64 overflow-y-auto rounded-md border border-border/40 bg-[oklch(0.12_0.02_264)] p-3 font-mono text-[11px] leading-relaxed text-emerald-200/90"
+      >
+        {data.lines.map((line, i) => (
+          <div key={i} className="whitespace-pre-wrap break-all">
+            {line || '\u00A0'}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- Add per-agent log viewer with expandable panel on each agent card
- Terminal-style monospace display with auto-refresh every 8s while open
- Loading, empty, and error states handled

## Test plan
- [ ] Click "View logs" on an agent card — logs appear in terminal-style view
- [ ] Logs auto-refresh every ~8s while panel is open
- [ ] "No logs available" shown for agents without log files
- [ ] Loading spinner shown while fetching
- [ ] Scrollable container doesn't blow out layout
- [ ] `npm run build` succeeds

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
