### PR TITLE
Add live refresh & styling polish

### DIFF
--- a/apps/ops-dashboard/app/globals.css
+++ b/apps/ops-dashboard/app/globals.css
@@ -21,4 +21,5 @@
 body {
   @apply min-h-screen bg-background text-foreground antialiased;
   background-image: radial-gradient(circle at top, oklch(0.28 0.05 264) 0%, oklch(0.15 0.03 264) 52%);
+  background-attachment: fixed;
 }

--- a/apps/ops-dashboard/app/layout.tsx
+++ b/apps/ops-dashboard/app/layout.tsx
@@ -8,7 +8,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Ops Dashboard',
+  title: 'DACL Ops',
   description: 'DACL operations dashboard',
 };
 

--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -1,5 +1,4 @@
-import { AgentGrid } from '@/components/agent-grid';
-import { StatsBar } from '@/components/stats-bar';
+import { Dashboard } from '@/components/dashboard';
 import { getAgents } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -7,15 +6,5 @@ export const dynamic = 'force-dynamic';
 export default async function HomePage() {
   const agents = await getAgents();
 
-  return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
-      <header className="space-y-3">
-        <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
-        <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
-        <StatsBar agents={agents} />
-      </header>
-
-      <AgentGrid agents={agents} />
-    </main>
-  );
+  return <Dashboard initialAgents={agents} />;
 }

--- a/apps/ops-dashboard/components/agent-grid.tsx
+++ b/apps/ops-dashboard/components/agent-grid.tsx
@@ -7,7 +7,7 @@ export function AgentGrid({ agents }: { agents: Agent[] }) {
   }
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {agents.map((agent) => (
         <AgentCard key={agent.id} agent={agent} />
       ))}

--- a/apps/ops-dashboard/components/dashboard.tsx
+++ b/apps/ops-dashboard/components/dashboard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Agent, DashboardData } from '@/lib/types';
+import { AgentGrid } from './agent-grid';
+import { StatsBar } from './stats-bar';
+
+const POLL_INTERVAL = 10_000;
+
+export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
+  const [agents, setAgents] = useState<Agent[]>(initialAgents);
+  const [updatedAt, setUpdatedAt] = useState<Date>(new Date());
+  const [secondsAgo, setSecondsAgo] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const mountedRef = useRef(true);
+
+  const fetchAgents = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const res = await fetch('/api/agents');
+      if (!mountedRef.current) return;
+      if (!res.ok) return;
+      const data: DashboardData = await res.json();
+      setAgents(data.agents);
+      setUpdatedAt(new Date());
+      setSecondsAgo(0);
+    } catch {
+      // silently ignore fetch errors
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, []);
+
+  // Poll for agent data
+  useEffect(() => {
+    mountedRef.current = true;
+    const id = setInterval(fetchAgents, POLL_INTERVAL);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
+  }, [fetchAgents]);
+
+  // Tick the "seconds ago" counter every second
+  useEffect(() => {
+    const id = setInterval(() => {
+      setSecondsAgo(Math.floor((Date.now() - updatedAt.getTime()) / 1000));
+    }, 1_000);
+    return () => clearInterval(id);
+  }, [updatedAt]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
+      <header className="space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span
+              className={`inline-block h-1.5 w-1.5 rounded-full transition-colors duration-300 ${
+                refreshing ? 'bg-emerald-400' : 'bg-emerald-600'
+              }`}
+            />
+            <span>
+              Updated {secondsAgo < 2 ? 'just now' : `${secondsAgo}s ago`}
+            </span>
+          </div>
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
+        <StatsBar agents={agents} />
+      </header>
+
+      <div className="border-t border-border/40" />
+
+      <AgentGrid agents={agents} />
+    </main>
+  );
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- Add global auto-refresh: polls `/api/agents` every 10 seconds without full page reload
- Add live "Updated Xs ago" indicator with status dot in header
- Polish styling: 3-column responsive grid at lg, header divider, fixed background gradient
- Update page title to "DACL Ops"

## Test plan
- [ ] Verify agent data refreshes every ~10s (watch network tab)
- [ ] Verify "Updated" indicator counts up and resets on refresh
- [ ] Verify responsive layout: 1 col mobile, 2 col tablet, 3 col desktop
- [ ] Verify `npm run build` succeeds with no warnings
- [ ] Verify dark theme is consistent and polished

🤖 Generated with [Claude Code](https://claude.com/claude-code)
