### PR TITLE
Dashboard: live auto-refresh & styling polish

### DIFF
--- a/apps/ops-dashboard/app/page.tsx
+++ b/apps/ops-dashboard/app/page.tsx
@@ -1,5 +1,4 @@
-import { AgentGrid } from '@/components/agent-grid';
-import { StatsBar } from '@/components/stats-bar';
+import { Dashboard } from '@/components/dashboard';
 import { getAgents } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -7,15 +6,5 @@ export const dynamic = 'force-dynamic';
 export default async function HomePage() {
   const agents = await getAgents();
 
-  return (
-    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
-      <header className="space-y-3">
-        <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
-        <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
-        <StatsBar agents={agents} />
-      </header>
-
-      <AgentGrid agents={agents} />
-    </main>
-  );
+  return <Dashboard initialAgents={agents} />;
 }

--- a/apps/ops-dashboard/components/dashboard.tsx
+++ b/apps/ops-dashboard/components/dashboard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Agent, DashboardData } from '@/lib/types';
+import { AgentGrid } from './agent-grid';
+import { StatsBar } from './stats-bar';
+
+const POLL_INTERVAL_MS = 10_000;
+
+function formatElapsed(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ago`;
+}
+
+export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
+  const [agents, setAgents] = useState(initialAgents);
+  const [updatedAt, setUpdatedAt] = useState(Date.now());
+  const [elapsed, setElapsed] = useState('just now');
+  const [refreshing, setRefreshing] = useState(false);
+  const mountedRef = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const res = await fetch('/api/agents');
+      if (!res.ok) return;
+      const data: DashboardData = await res.json();
+      if (!mountedRef.current) return;
+      setAgents(data.agents);
+      setUpdatedAt(Date.now());
+    } catch {
+      // Silently ignore — stale data is fine
+    } finally {
+      if (mountedRef.current) setRefreshing(false);
+    }
+  }, []);
+
+  // Poll every 10s
+  useEffect(() => {
+    mountedRef.current = true;
+    const id = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  // Update elapsed timer every 5s
+  useEffect(() => {
+    setElapsed('just now');
+    const id = setInterval(() => {
+      setElapsed(formatElapsed(Date.now() - updatedAt));
+    }, 5_000);
+    return () => clearInterval(id);
+  }, [updatedAt]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-8 sm:px-6 sm:py-10">
+      <header className="space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-xs tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground" aria-live="polite">
+            <span
+              className={`inline-block h-1.5 w-1.5 rounded-full transition-colors duration-300 ${
+                refreshing ? 'bg-sky-400' : 'bg-emerald-500/80'
+              }`}
+            />
+            Updated {elapsed}
+          </div>
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight">Ops Dashboard</h1>
+        <StatsBar agents={agents} />
+      </header>
+
+      <div
+        className={`transition-opacity duration-300 ${refreshing ? 'opacity-90' : 'opacity-100'}`}
+      >
+        <AgentGrid agents={agents} />
+      </div>
+    </main>
+  );
+}

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -61,7 +61,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (loading) {
     return (
-      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+      <div className="flex h-32 items-center justify-center rounded-md bg-background/60 text-xs text-muted-foreground">
         Loading logs…
       </div>
     );
@@ -69,7 +69,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (error) {
     return (
-      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+      <div className="flex h-32 items-center justify-center rounded-md bg-background/60 text-xs text-muted-foreground">
         {error}
       </div>
     );
@@ -77,7 +77,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (!log || log.lines.length === 0) {
     return (
-      <div className="flex h-32 items-center justify-center rounded-md bg-zinc-950 text-xs text-muted-foreground">
+      <div className="flex h-32 items-center justify-center rounded-md bg-background/60 text-xs text-muted-foreground">
         No logs available
       </div>
     );
@@ -87,7 +87,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
     <div className="space-y-1">
       <div
         ref={scrollRef}
-        className="max-h-64 overflow-y-auto rounded-md bg-zinc-950 p-3 font-mono text-[11px] leading-relaxed text-zinc-300"
+        className="max-h-64 overflow-y-auto rounded-md bg-background/60 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground"
       >
         {log.lines.map((line, i) => (
           <div key={i} className="whitespace-pre-wrap break-all">


### PR DESCRIPTION
**@worker-02**

## Summary
- Add client-side auto-refresh that polls `/api/agents` every 10 seconds without page reload
- Show "Last updated" indicator with green/blue status dot and relative time
- Subtle opacity transition during refresh for visual feedback
- Align log viewer backgrounds to theme colors (replace `bg-zinc-950` with `bg-background/60`)
- SSR initial load preserved; client component takes over for polling

## Test plan
- [ ] Verify agent data auto-refreshes every ~10 seconds without full page reload
- [ ] Confirm "Updated X ago" indicator is visible and updates correctly
- [ ] Check status dot turns blue during fetch, green when idle
- [ ] Verify log viewer backgrounds match the dark theme
- [ ] Test responsive layout at mobile/tablet/desktop breakpoints
- [ ] Run `npm run build` — should succeed with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
