### PR TITLE
Define epic issue lifecycle with planning intake and role removal

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -6,6 +6,7 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 
 | Label | Meaning | Set by |
 |-------|---------|--------|
+| `status:ready-for-planning` | Awaiting planner to scope and break down | Human or Planner |
 | `status:planning` | Being broken down into sub-tasks | Planner |
 | `status:ready-for-work` | Ready for a worker to claim | Planner |
 | `status:in-progress` | Claimed and actively being worked on | Worker |
@@ -31,9 +32,35 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 ## Rules
 
 - Every issue must have exactly one `status:` label at all times.
-- Every issue must have exactly one `role:` label.
+- Every issue must have exactly one `role:` label while active. Role labels are removed when the issue reaches `status:done`.
 - Workers only claim issues with both `status:ready-for-work` and `role:worker`.
 - When claiming an issue, the worker immediately moves it to `status:in-progress`.
 - When opening a PR, the worker moves the issue to `status:in-review`.
-- The planner moves issues to `status:done` after merging the linked PR.
+- The planner moves issues to `status:done` after merging the linked PR, and removes the `role:` label.
 - If an issue becomes blocked, whoever discovers the block sets `status:blocked` and comments with the reason.
+
+## Epic lifecycle
+
+Epics follow a specific flow from creation to completion:
+
+| Stage | Labels on epic | Labels on subtasks |
+|-------|---------------|-------------------|
+| Created by human | `type:epic`, `status:ready-for-planning`, `role:planner` | — |
+| Planner picks it up | `type:epic`, `status:planning`, `role:planner` | — |
+| Planner creates subtasks | `type:epic`, `status:planning`, `role:planner` | `status:ready-for-work`, `role:worker` |
+| Worker completes subtask | (unchanged) | `status:done` (`role:worker` removed) |
+| `@ADMIN` feedback received | (unchanged) | Planner creates new `status:ready-for-work` fix tasks |
+| All subtasks done | `type:epic`, `status:done` (`role:planner` removed) | `status:done` |
+
+Epic issue body format:
+
+```markdown
+## Summary
+<description>
+
+## Subtasks
+- [ ] #101 — Subtask description
+- [ ] #102 — Another subtask
+```
+
+Each child issue must include `Parent: #N` in its body to link back to the epic.

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -44,12 +44,27 @@ The human admin leaves feedback on PRs and issues using `@ADMIN` as a signal. Th
 - Look for `@ADMIN` (case-sensitive) in comment bodies on open PRs and issues.
 - A comment is "addressed" once you've replied acknowledging it. Don't re-process comments you've already acknowledged.
 
+## Epic intake
+
+- Look for issues labeled `status:ready-for-planning` and `role:planner` — these are your intake queue.
+- When you pick up an epic, move it to `status:planning`.
+- Break the epic into concrete subtasks, each as a separate GitHub issue.
+- Each child issue must include `Parent: #N` in its body (where N is the epic issue number).
+- Maintain a subtask checklist in the epic body using the format:
+  ```markdown
+  ## Subtasks
+  - [ ] #101 — Subtask description
+  - [ ] #102 — Another subtask
+  ```
+- Check off subtasks as they are completed. When all subtasks are done, move the epic to `status:done` and remove the `role:planner` label.
+- **ADMIN feedback loop:** When `@ADMIN` comments arrive on an epic's PR or issues, create new fix tasks as subtasks of the epic (see "Processing `@ADMIN` comments" above). Add them to the epic's subtask checklist before marking the epic done.
+
 ## Issue creation
 
 - Label issues per `LABELS.md`. A worker-ready issue needs `status:ready-for-work` and `role:worker`.
 - Every issue must have acceptance criteria a worker can verify independently.
 - Specify the target branch for the worker's PR.
-- Keep label state accurate. After merging, move to `status:done`. If blocked, set `status:blocked` with a comment.
+- Keep label state accurate. After merging, move to `status:done` and remove the `role:` label. If blocked, set `status:blocked` with a comment.
 
 ## Merge authority
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `status:ready-for-planning` to LABELS.md and document epic lifecycle flow with label transitions
- Document role label removal convention when issues reach `status:done`
- Add epic intake section to PLANNER.md with subtask checklist and `Parent: #N` conventions

Closes #117

## Test plan
- [ ] Verify `status:ready-for-planning` label exists in the repo
- [ ] Verify LABELS.md documents full lifecycle including role removal on completion
- [ ] Verify PLANNER.md includes epic intake and subtask checklist conventions
- [ ] Verify PLANNER.md includes `Parent: #N` convention for child issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
