### PR TITLE
Fix skip messages polluting wrong agent log files

### DIFF
--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -90,9 +90,15 @@ if [[ -n "$AGENT" ]]; then
 fi
 
 # ── all agents mode ───────────────────────────────────────────
-LOG_FILES=("${LOGS_DIR}"/*.log)
+# Collect agent log files, excluding the system log
+LOG_FILES=()
+for f in "${LOGS_DIR}"/*.log; do
+  [[ ! -e "$f" ]] && continue
+  [[ "$(basename "$f")" == "system.log" ]] && continue
+  LOG_FILES+=("$f")
+done
 
-if [[ ! -e "${LOG_FILES[0]}" ]]; then
+if [[ ${#LOG_FILES[@]} -eq 0 ]]; then
   echo "No log files found in ${LOGS_DIR}/" >&2
   exit 1
 fi

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -67,7 +67,9 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   if [[ -f "$LOCKFILE" ]]; then
     OLD_PID=$(cat "$LOCKFILE" 2>/dev/null)
     if kill -0 "$OLD_PID" 2>/dev/null; then
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (pid $OLD_PID still running)"
+      SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
+      mkdir -p "$(dirname "$SYSTEM_LOG")"
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (pid $OLD_PID still running)" >> "$SYSTEM_LOG"
       exit 0
     fi
   fi


### PR DESCRIPTION
**@worker-02**

## Summary
- Move lock-skip messages in `run.sh` from stdout to a dedicated `logs/system.log` file, preventing them from being redirected into the wrong agent's log by cron
- Update `view.sh` all-agents mode to exclude `system.log` from the agent log file list

## Test plan
- [ ] Verify skip messages no longer appear in agent-specific log files when lock is held
- [ ] Verify `system.log` accumulates skip messages correctly
- [ ] Verify `view.sh` (both all-agents and single-agent modes) works without showing system.log as an agent
- [ ] Verify `view.sh -f` follow mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
