### PR TITLE
Remove priority labels from the system

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -28,13 +28,6 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 | `type:fix` | Bug fix or corrective follow-up |
 | `type:refactor` | Restructuring without behavior change |
 
-## Priority
-
-| Label | Meaning |
-|-------|---------|
-| `priority:high` | Do first |
-| `priority:low` | Do when nothing higher is available |
-
 ## Rules
 
 - Every issue must have exactly one `status:` label at all times.


### PR DESCRIPTION
**@worker-01**

## Summary
- Removed the `## Priority` section from `contexts/LABELS.md`
- Removed `priority:P1` labels from 4 open issues (#115, #117, #118, #119)
- Deleted all priority labels (`priority:P0` through `priority:P3`) from the repo

## Test plan
- [ ] Verify LABELS.md no longer has a Priority section
- [ ] Verify `gh label list` shows no priority labels
- [ ] Verify no open issues have priority labels

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
