### PR TITLE
Unify log tab formatting between All Agents and per-agent views

### DIFF
--- a/apps/ops-dashboard/components/all-logs-viewer.tsx
+++ b/apps/ops-dashboard/components/all-logs-viewer.tsx
@@ -16,11 +16,11 @@ const AGENT_COLORS: Record<number, string> = {
   7: 'text-orange-400',
 };
 
-interface TaggedLine {
+interface RunGroup {
   agentId: string;
   colorClass: string;
-  text: string;
-  isRunHeader: boolean;
+  timestamp: string;
+  lines: string[];
 }
 
 function formatTimestamp(raw: string): string {
@@ -110,24 +110,29 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
     colorMap.set(agent.id, AGENT_COLORS[i % Object.keys(AGENT_COLORS).length]);
   });
 
-  // Interleave: show each agent's logs sequentially (grouped by agent)
-  const taggedLines: TaggedLine[] = [];
+  // Group lines by runs, per agent (same structure as LogViewer)
+  const allGroups: RunGroup[] = [];
   for (const agent of agents) {
     const chunk = logs.get(agent.id);
     if (!chunk || chunk.lines.length === 0) continue;
     const color = colorMap.get(agent.id) ?? 'text-zinc-400';
+    let current: RunGroup | null = null;
+
     for (const line of chunk.lines) {
       const match = line.match(RUN_HEADER_RE);
-      taggedLines.push({
-        agentId: agent.id,
-        colorClass: color,
-        text: match ? formatTimestamp(match[1]) : line,
-        isRunHeader: !!match,
-      });
+      if (match) {
+        current = { agentId: agent.id, colorClass: color, timestamp: match[1], lines: [] };
+        allGroups.push(current);
+      } else if (current) {
+        current.lines.push(line);
+      } else {
+        current = { agentId: agent.id, colorClass: color, timestamp: '', lines: [line] };
+        allGroups.push(current);
+      }
     }
   }
 
-  if (taggedLines.length === 0) {
+  if (allGroups.length === 0) {
     return (
       <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         No logs available
@@ -138,23 +143,31 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
   return (
     <div
       ref={scrollRef}
-      className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 px-4 py-3 font-mono text-[13px] leading-relaxed text-zinc-300"
+      className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
     >
-      {taggedLines.map((tl, i) =>
-        tl.isRunHeader ? (
-          <div key={i} className="mt-3 mb-1 border-t border-zinc-800 pt-2 text-xs text-zinc-500">
-            <span className={`font-medium ${tl.colorClass}`}>{tl.agentId}</span>
-            <span className="ml-2">{tl.text}</span>
+      {allGroups.map((group, gi) => (
+        <div key={gi}>
+          {group.timestamp && (
+            <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
+              <span className={group.colorClass}>{group.agentId}</span>
+              <span>{formatTimestamp(group.timestamp)}</span>
+            </div>
+          )}
+          <div className="px-4 py-2">
+            {group.lines.map((line, li) => (
+              <div key={li} className="flex gap-2 whitespace-pre-wrap break-all">
+                <span className={`shrink-0 select-none font-medium ${group.colorClass}`}>
+                  {group.agentId.padEnd(12).slice(0, 12)}
+                </span>
+                <span>{line || '\u00a0'}</span>
+              </div>
+            ))}
           </div>
-        ) : (
-          <div key={i} className="flex gap-2 whitespace-pre-wrap break-all">
-            <span className={`shrink-0 select-none font-medium ${tl.colorClass}`}>
-              {tl.agentId.padEnd(12).slice(0, 12)}
-            </span>
-            <span>{tl.text || '\u00a0'}</span>
-          </div>
-        )
-      )}
+          {gi < allGroups.length - 1 && group.timestamp && (
+            <div className="border-b border-zinc-800/50" />
+          )}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
**@worker-01**

## Summary
- Restructures `AllLogsViewer` to use the same run-group rendering pattern as `LogViewer`
- Both views now share: sticky timestamp headers, `px-4 py-2` content padding, `border-b border-zinc-800/50` dividers between groups
- The only visual difference is the agent ID color tag prefix on each line in `AllLogsViewer`

## Test plan
- [ ] Verify per-agent log tabs render identically to before (no changes to `LogViewer`)
- [ ] Verify All Agents tab now shows sticky timestamp headers instead of inline dividers
- [ ] Verify agent ID color tags still appear on each line in All Agents view
- [ ] Verify spacing and padding match between both tab types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
