### PR TITLE
Group log lines into paragraphs instead of rendering independently

### DIFF
--- a/apps/ops-dashboard/components/all-logs-viewer.tsx
+++ b/apps/ops-dashboard/components/all-logs-viewer.tsx
@@ -39,6 +39,25 @@ function formatTimestamp(raw: string): string {
   }
 }
 
+function groupIntoParagraphs(lines: string[]): string[][] {
+  const paragraphs: string[][] = [];
+  let current: string[] = [];
+  for (const line of lines) {
+    if (line === '') {
+      if (current.length > 0) {
+        paragraphs.push(current);
+        current = [];
+      }
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) {
+    paragraphs.push(current);
+  }
+  return paragraphs;
+}
+
 export function AllLogsViewer({ agents }: { agents: Agent[] }) {
   const [logs, setLogs] = useState<Map<string, LogChunk>>(new Map());
   const [loading, setLoading] = useState(true);
@@ -154,12 +173,16 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
             </div>
           )}
           <div className="px-4 py-2">
-            {group.lines.map((line, li) => (
-              <div key={li} className="flex gap-2 whitespace-pre-wrap break-all">
-                <span className={`shrink-0 select-none font-medium ${group.colorClass}`}>
-                  {group.agentId.padEnd(12).slice(0, 12)}
-                </span>
-                <span>{line || '\u00a0'}</span>
+            {groupIntoParagraphs(group.lines).map((para, pi) => (
+              <div key={pi} className="mb-2 last:mb-0">
+                {para.map((line, li) => (
+                  <div key={li} className="flex gap-2 whitespace-pre-wrap break-all">
+                    <span className={`shrink-0 select-none font-medium ${group.colorClass}`}>
+                      {group.agentId.padEnd(12).slice(0, 12)}
+                    </span>
+                    <span>{line}</span>
+                  </div>
+                ))}
               </div>
             ))}
           </div>

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -26,6 +26,25 @@ interface RunGroup {
   lines: string[];
 }
 
+function groupIntoParagraphs(lines: string[]): string[][] {
+  const paragraphs: string[][] = [];
+  let current: string[] = [];
+  for (const line of lines) {
+    if (line === '') {
+      if (current.length > 0) {
+        paragraphs.push(current);
+        current = [];
+      }
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) {
+    paragraphs.push(current);
+  }
+  return paragraphs;
+}
+
 function groupByRuns(lines: string[]): RunGroup[] {
   const groups: RunGroup[] = [];
   let current: RunGroup | null = null;
@@ -142,9 +161,13 @@ export function LogViewer({ agentId }: { agentId: string }) {
               </div>
             )}
             <div className="px-4 py-2">
-              {group.lines.map((line, li) => (
-                <div key={li} className="whitespace-pre-wrap break-all">
-                  {line || '\u00a0'}
+              {groupIntoParagraphs(group.lines).map((para, pi) => (
+                <div key={pi} className="mb-2 last:mb-0">
+                  {para.map((line, li) => (
+                    <div key={li} className="whitespace-pre-wrap break-all">
+                      {line}
+                    </div>
+                  ))}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
**@worker-02**

## Summary
- Group consecutive non-empty log lines into paragraph blocks with tight internal spacing
- Blank lines in log output now create visible paragraph breaks (`mb-2` gap between blocks)
- Applied consistently in both `LogViewer` and `AllLogsViewer` components
- Run headers remain visually distinct from log content

## Test plan
- [ ] Open the ops dashboard and view a single agent's logs — verify multi-line paragraphs appear grouped
- [ ] Verify blank lines in agent output create visible paragraph breaks
- [ ] Check the "All Logs" view for the same paragraph grouping behavior
- [ ] Confirm run headers (timestamps) remain visually distinct and unaffected

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
