### PR TITLE
Show live mm:ss countdown timers on agent cards

### DIFF
--- a/apps/ops-dashboard/components/relative-time.tsx
+++ b/apps/ops-dashboard/components/relative-time.tsx
@@ -7,22 +7,24 @@ function format(iso: string): string {
   const abs = Math.abs(diff);
   const future = diff < 0;
 
-  if (abs < 60_000) return future ? 'in <1m' : '<1m ago';
+  const totalSeconds = Math.floor(abs / 1_000);
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const totalDays = Math.floor(totalHours / 24);
 
-  const minutes = Math.floor(abs / 60_000);
-  if (minutes < 60) {
-    const label = `${minutes}m`;
-    return future ? `in ${label}` : `${label} ago`;
+  let label: string;
+
+  if (totalHours >= 24) {
+    const remainHours = totalHours % 24;
+    label = `${totalDays}d ${remainHours}h`;
+  } else if (totalMinutes >= 60) {
+    const remainMinutes = totalMinutes % 60;
+    label = `${totalHours}h ${remainMinutes}m`;
+  } else {
+    const remainSeconds = totalSeconds % 60;
+    label = `${totalMinutes}m ${remainSeconds}s`;
   }
 
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    const label = `${hours}h`;
-    return future ? `in ${label}` : `${label} ago`;
-  }
-
-  const days = Math.floor(hours / 24);
-  const label = `${days}d`;
   return future ? `in ${label}` : `${label} ago`;
 }
 
@@ -31,7 +33,7 @@ export function RelativeTime({ iso }: { iso: string }) {
 
   useEffect(() => {
     setText(format(iso));
-    const id = setInterval(() => setText(format(iso)), 15_000);
+    const id = setInterval(() => setText(format(iso)), 1_000);
     return () => clearInterval(id);
   }, [iso]);
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Updated `RelativeTime` component to show `Xm Ys` precision (e.g. `3m 42s ago`, `in 0m 15s`)
- Timer now refreshes every 1 second instead of 15 seconds
- Times >= 1h show `Xh Ym`, times >= 24h show `Xd Yh`

## Test plan
- [ ] Verify agent cards show `Xm Ys ago` format for "Last run" times under 1 hour
- [ ] Verify "Next run" shows `in Xm Ys` countdown that ticks every second
- [ ] Verify times >= 1h display as `Xh Ym` and >= 24h as `Xd Yh`
- [ ] Confirm no layout shift as seconds digit changes

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
