### PR TITLE
Fix follow mode interleaving in view.sh

### DIFF
--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -104,29 +104,23 @@ if [[ ${#LOG_FILES[@]} -eq 0 ]]; then
 fi
 
 if $FOLLOW; then
-  CURRENT_AGENT="unknown"
-  tail -n "$LINES" -f "${LOG_FILES[@]}" 2>/dev/null | while IFS= read -r line; do
-    # tail -f prefixes with "==> path <=="; extract agent ID from filename
-    if [[ "$line" =~ ^==\>\ (.+)\ \<== ]]; then
-      filepath="${BASH_REMATCH[1]}"
-      basename="${filepath##*/}"
-      CURRENT_AGENT="${basename%.log}"
-      continue
-    fi
-    [[ -z "$line" ]] && continue
+  # Run a separate tail -f per agent so each stream always knows its own
+  # agent identity. This avoids the interleaving bug where a single
+  # tail -f on multiple files omits the "==> path <==" header when
+  # files receive data nearly simultaneously.
+  TAIL_PIDS=()
+  cleanup() { kill "${TAIL_PIDS[@]}" 2>/dev/null; wait 2>/dev/null; }
+  trap cleanup EXIT INT TERM
 
-    # Run boundary marker
-    if [[ "$line" =~ ^===\ RUN\ ([0-9T:.Z-]+)\ ===$ ]]; then
-      local_color=$(color_for_agent "$CURRENT_AGENT")
-      local_tag="\033[${local_color}m[${CURRENT_AGENT}]\033[0m"
-      run_ts="${BASH_REMATCH[1]}"
-      display_ts=$(date -jf '%Y-%m-%dT%H:%M:%SZ' "$run_ts" '+%H:%M:%S' 2>/dev/null || echo "$run_ts")
-      printf "\n%b \033[90m%s\033[0m \033[90m%s\033[0m\n" "$local_tag" "$display_ts" "─────────────────────────"
-      continue
-    fi
-
-    printf "  %s\n" "$line"
+  for log_file in "${LOG_FILES[@]}"; do
+    basename="${log_file##*/}"
+    agent="${basename%.log}"
+    tail -n "$LINES" -f "$log_file" 2>/dev/null | format_lines "$agent" &
+    TAIL_PIDS+=($!)
   done
+
+  # Wait for any child to exit (or Ctrl-C)
+  wait
 else
   # Show last N lines from each agent, grouped by run
   for log_file in "${LOG_FILES[@]}"; do


### PR DESCRIPTION
**@worker-02**

## Summary
- Rewrites `view.sh` follow mode to use per-agent `tail -f` processes instead of a single multiplexed `tail -f`
- Each agent's log stream is piped through `format_lines` with the correct agent ID, eliminating mis-attribution from missing `==> path <==` headers
- Adds proper cleanup trap to kill background tail processes on exit

## Test plan
- [ ] Run `./view.sh -f` with multiple agents logging simultaneously — verify each block is attributed to the correct agent
- [ ] Run `./view.sh -f worker-01` (single agent) — verify unchanged behavior
- [ ] Run `./view.sh` (non-follow) — verify unchanged behavior
- [ ] Ctrl-C during follow mode — verify clean exit with no orphan processes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
