### PR TITLE
Add target repo badge to dashboard agent cards

### DIFF
--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -26,6 +26,9 @@ export function AgentCard({ agent }: { agent: Agent }) {
               workspace
             </span>
           )}
+          <span className="rounded border border-border/50 bg-background/30 px-1.5 py-0.5 text-muted-foreground">
+            {agent.repo}
+          </span>
         </div>
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div>

--- a/apps/ops-dashboard/lib/data.ts
+++ b/apps/ops-dashboard/lib/data.ts
@@ -13,6 +13,7 @@ type CronJobEntry = {
   contexts?: unknown;
   agentic?: unknown;
   workspace?: unknown;
+  repo?: unknown;
 };
 
 function str(value: unknown, fallback = 'unknown'): string {
@@ -69,6 +70,7 @@ export async function getAgents(): Promise<Agent[]> {
         agentic: Boolean(job.agentic),
         workspace: Boolean(job.workspace),
         contexts,
+        repo: str(job.repo, 'DACL'),
         lastRun,
         nextRun,
       };

--- a/apps/ops-dashboard/lib/types.ts
+++ b/apps/ops-dashboard/lib/types.ts
@@ -5,6 +5,7 @@ export interface Agent {
   agentic: boolean
   workspace: boolean
   contexts: string[]
+  repo: string
   lastRun: string | null
   nextRun: string | null
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `repo` field to the `Agent` type and data layer
- Display target repo as a subtle badge on each agent card
- Defaults to "DACL" when `repo` is not set in cron-jobs.json

## Test plan
- [ ] Verify agent cards show "DACL" badge for existing agents without `repo` field
- [ ] Add a `repo` field to a cron job entry and verify it displays on the card
- [ ] Confirm no layout breakage on existing cards

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
