### PR TITLE
Label cleanup: remove area:, add scope:parent/child, fix review signals

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -10,7 +10,8 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 | `status:planning` | Being broken down into sub-tasks | Planner |
 | `status:ready-for-work` | Ready for a worker to claim | Planner |
 | `status:in-progress` | Claimed and actively being worked on | Worker |
-| `status:in-review` | PR open, awaiting planner review | Worker |
+| `status:needs-review` | PR open, awaiting planner review | Worker |
+| `status:ready-to-merge` | Meets acceptance criteria, awaiting human merge | Planner |
 | `status:blocked` | Blocked on a dependency or issue | Worker or Planner |
 | `status:done` | Completed and merged | Planner |
 
@@ -25,9 +26,17 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 
 | Label | Meaning |
 |-------|---------|
-| `type:feature` | New functionality |
+| `type:epic` | Parent feature issue |
+| `type:task` | Bite-sized worker task |
 | `type:fix` | Bug fix or corrective follow-up |
-| `type:refactor` | Restructuring without behavior change |
+| `type:review` | Review-focused item |
+
+## Scope
+
+| Label | Meaning |
+|-------|---------|
+| `scope:parent` | Epic or parent issue |
+| `scope:child` | Child task of an epic |
 
 ## Rules
 
@@ -35,9 +44,10 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 - Every issue must have exactly one `role:` label while active. Role labels are removed when the issue reaches `status:done`.
 - Workers only claim issues with both `status:ready-for-work` and `role:worker`.
 - When claiming an issue, the worker immediately moves it to `status:in-progress`.
-- When opening a PR, the worker moves the issue to `status:in-review`.
+- When opening a PR, the worker moves the issue to `status:needs-review`.
 - The planner moves issues to `status:done` after merging the linked PR, and removes the `role:` label.
 - If an issue becomes blocked, whoever discovers the block sets `status:blocked` and comments with the reason.
+- `status:ready-to-merge` signals @ADMIN that a PR has passed agent review and needs human review/merge.
 
 ## Epic lifecycle
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Remove all `area:` labels from GitHub repo and open issues
- Add `scope:parent` / `scope:child` labels and apply to all open issues
- Fix `status:in-review` → `status:needs-review` in LABELS.md
- Add `status:ready-to-merge` to status table with @ADMIN signal note
- Update Type section to match actual repo labels (epic, task, fix, review)
- Add Scope section documenting new labels

Closes #146

## Test plan
- [ ] Verify `area:*` labels no longer exist in repo (`gh label list`)
- [ ] Verify `scope:parent` and `scope:child` labels exist
- [ ] Verify #131 has `scope:parent`, child issues have `scope:child`
- [ ] Verify LABELS.md matches actual repo label set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
