### PR TITLE
Label cleanup: remove area:, add scope:parent/child, clarify review signal

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -11,6 +11,7 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 | `status:ready-for-work` | Ready for a worker to claim | Planner |
 | `status:in-progress` | Claimed and actively being worked on | Worker |
 | `status:needs-review` | PR open, awaiting planner review | Worker |
+| `status:ready-to-merge` | Meets acceptance criteria, awaiting @ADMIN merge | Planner |
 | `status:blocked` | Blocked on a dependency or issue | Worker or Planner |
 | `status:done` | Completed and merged | Planner |
 
@@ -25,9 +26,17 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 
 | Label | Meaning |
 |-------|---------|
-| `type:feature` | New functionality |
+| `type:epic` | Multi-task parent issue |
+| `type:task` | Standard work item |
 | `type:fix` | Bug fix or corrective follow-up |
-| `type:refactor` | Restructuring without behavior change |
+| `type:review` | Review or feedback task |
+
+## Scope
+
+| Label | Meaning |
+|-------|---------|
+| `scope:parent` | Epic or parent issue that has subtasks |
+| `scope:child` | Child issue / subtask of a parent issue |
 
 ## Rules
 
@@ -38,6 +47,7 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 - When opening a PR, the worker moves the issue to `status:needs-review`.
 - The planner moves issues to `status:done` after merging the linked PR, and removes the `role:` label.
 - If an issue becomes blocked, whoever discovers the block sets `status:blocked` and comments with the reason.
+- `status:ready-to-merge` signals @ADMIN that a PR has passed review and needs human review/merge.
 
 ## Epic lifecycle
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Remove `area:` labels from repo and all open issues; add `scope:parent`/`scope:child` labels
- Update LABELS.md: replace `status:in-review` → `status:needs-review`, add `status:ready-to-merge`, add Scope section, add @ADMIN merge signal rule
- Fix `status:in-review` reference in WORKER.md

## Test plan
- [ ] Verify `area:*` labels no longer exist in repo
- [ ] Verify `scope:parent` and `scope:child` labels exist with correct colors
- [ ] Verify open epic/parent issues have `scope:parent`, child issues have `scope:child`
- [ ] Verify LABELS.md reflects all current repo labels accurately

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
