### PR TITLE
Unified agent+log layout with fixed-height viewer

### DIFF
--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -3,9 +3,24 @@ import type { Agent } from '@/lib/types';
 import { RelativeTime } from './relative-time';
 import { RoleBadge } from './role-badge';
 
-export function AgentCard({ agent }: { agent: Agent }) {
+interface AgentCardProps {
+  agent: Agent;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
   return (
-    <Card className="gap-4 border-border/60 bg-card/70 py-5">
+    <Card
+      className={`gap-4 py-5 transition-colors ${
+        selected
+          ? 'border-zinc-500 bg-card/90 cursor-pointer'
+          : onClick
+            ? 'border-border/60 bg-card/70 cursor-pointer hover:border-border'
+            : 'border-border/60 bg-card/70'
+      }`}
+      onClick={onClick}
+    >
       <CardHeader className="flex-row items-center justify-between gap-2 pb-0">
         <CardTitle className="text-lg font-semibold tracking-tight">{agent.id}</CardTitle>
         <RoleBadge role={agent.role} />

--- a/apps/ops-dashboard/components/agent-grid.tsx
+++ b/apps/ops-dashboard/components/agent-grid.tsx
@@ -1,7 +1,13 @@
 import type { Agent } from '@/lib/types';
 import { AgentCard } from './agent-card';
 
-export function AgentGrid({ agents }: { agents: Agent[] }) {
+interface AgentGridProps {
+  agents: Agent[];
+  selectedId?: string | null;
+  onSelect?: (id: string | null) => void;
+}
+
+export function AgentGrid({ agents, selectedId, onSelect }: AgentGridProps) {
   if (agents.length === 0) {
     return <p className="text-sm text-muted-foreground">No agents found.</p>;
   }
@@ -9,7 +15,12 @@ export function AgentGrid({ agents }: { agents: Agent[] }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {agents.map((agent) => (
-        <AgentCard key={agent.id} agent={agent} />
+        <AgentCard
+          key={agent.id}
+          agent={agent}
+          selected={selectedId === agent.id}
+          onClick={onSelect ? () => onSelect(selectedId === agent.id ? null : agent.id) : undefined}
+        />
       ))}
     </div>
   );

--- a/apps/ops-dashboard/components/all-logs-viewer.tsx
+++ b/apps/ops-dashboard/components/all-logs-viewer.tsx
@@ -163,7 +163,7 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
   return (
     <div
       ref={scrollRef}
-      className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
+      className="h-full overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
     >
       {allGroups.map((group, gi) => (
         <div key={gi}>
@@ -175,13 +175,8 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
           )}
           <div className="px-4 py-2">
             {groupIntoParagraphs(group.lines).map((para, pi) => (
-              <div key={pi} className="mb-2 flex gap-2 last:mb-0">
-                <span className={`shrink-0 select-none pt-0.5 font-medium ${group.colorClass}`}>
-                  {group.agentId.padEnd(12).slice(0, 12)}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <LogMarkdown content={para.join('\n')} />
-                </div>
+              <div key={pi} className="mb-2 last:mb-0">
+                <LogMarkdown content={para.join('\n')} />
               </div>
             ))}
           </div>

--- a/apps/ops-dashboard/components/dashboard.tsx
+++ b/apps/ops-dashboard/components/dashboard.tsx
@@ -9,12 +9,23 @@ import { StatsBar } from './stats-bar';
 
 const POLL_INTERVAL = 10_000;
 
+const AGENT_COLORS: Record<number, string> = {
+  0: 'text-teal-400',
+  1: 'text-purple-400',
+  2: 'text-amber-400',
+  3: 'text-sky-400',
+  4: 'text-rose-400',
+  5: 'text-emerald-400',
+  6: 'text-indigo-400',
+  7: 'text-orange-400',
+};
+
 export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
   const [agents, setAgents] = useState<Agent[]>(initialAgents);
   const [updatedAt, setUpdatedAt] = useState<Date>(new Date());
   const [secondsAgo, setSecondsAgo] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
-  const [activeLogTab, setActiveLogTab] = useState<string>('all');
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
   const fetchAgents = useCallback(async () => {
@@ -50,10 +61,11 @@ export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
     return () => clearInterval(id);
   }, [updatedAt]);
 
-  const logTabs = [
-    { id: 'all', label: 'All Agents' },
-    ...agents.map((a) => ({ id: a.id, label: a.id })),
-  ];
+  // Build color map for selected agent display
+  const colorMap = new Map<string, string>();
+  agents.forEach((agent, i) => {
+    colorMap.set(agent.id, AGENT_COLORS[i % Object.keys(AGENT_COLORS).length]);
+  });
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-8 sm:px-6 sm:py-10">
@@ -76,41 +88,33 @@ export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
         <StatsBar agents={agents} />
       </header>
 
-      {/* Agents Section */}
+      {/* Unified Agents + Logs Section */}
       <section className="space-y-4">
-        <h2 className="text-lg font-medium text-foreground">Agents</h2>
-        <AgentGrid agents={agents} />
-      </section>
-
-      <div className="border-t border-border/40" />
-
-      {/* Logs Section */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium text-foreground">Logs</h2>
-
-        {/* Tab bar */}
-        <div className="flex gap-1 overflow-x-auto rounded-lg bg-zinc-900/50 p-1">
-          {logTabs.map((tab) => (
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-medium text-foreground">Agents</h2>
+          {selectedAgent && (
             <button
-              key={tab.id}
-              onClick={() => setActiveLogTab(tab.id)}
-              className={`shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                activeLogTab === tab.id
-                  ? 'bg-zinc-800 text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
+              onClick={() => setSelectedAgent(null)}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
-              {tab.label}
+              Show all logs
             </button>
-          ))}
+          )}
         </div>
+        <AgentGrid agents={agents} selectedId={selectedAgent} onSelect={setSelectedAgent} />
 
-        {/* Log content */}
-        {activeLogTab === 'all' ? (
-          <AllLogsViewer agents={agents} />
-        ) : (
-          <LogViewer key={activeLogTab} agentId={activeLogTab} />
-        )}
+        {/* Log viewer */}
+        <div className="h-[28rem]">
+          {selectedAgent ? (
+            <LogViewer
+              key={selectedAgent}
+              agentId={selectedAgent}
+              colorClass={colorMap.get(selectedAgent)}
+            />
+          ) : (
+            <AllLogsViewer agents={agents} />
+          )}
+        </div>
       </section>
     </main>
   );

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -68,7 +68,7 @@ function groupByRuns(lines: string[]): RunGroup[] {
   return groups;
 }
 
-export function LogViewer({ agentId }: { agentId: string }) {
+export function LogViewer({ agentId, colorClass }: { agentId: string; colorClass?: string }) {
   const [log, setLog] = useState<LogChunk | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -149,16 +149,17 @@ export function LogViewer({ agentId }: { agentId: string }) {
   const groups = groupByRuns(log.lines);
 
   return (
-    <div className="space-y-1.5">
+    <div className="flex h-full flex-col gap-1.5">
       <div
         ref={scrollRef}
-        className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
+        className="flex-1 overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
       >
         {groups.map((group, gi) => (
           <div key={gi}>
             {group.timestamp && (
-              <div className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
-                {formatTimestamp(group.timestamp)}
+              <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
+                {colorClass && <span className={colorClass}>{agentId}</span>}
+                <span>{formatTimestamp(group.timestamp)}</span>
               </div>
             )}
             <div className="px-4 py-2">


### PR DESCRIPTION
**@worker-02**

## Summary
- Merge "Agents" and "Logs" into a single unified section — no more page jumping
- Agent cards are clickable: click to filter logs for that agent, click again to deselect
- Fixed-height log container (`h-[28rem]`) prevents layout shifts when switching views
- "Show all logs" link appears when an agent is selected
- Per-agent log view shows agent ID + color in run headers (matching all-logs style)
- Removed tab bar and per-line agent prefix in all-logs view (agent ID shown per run block only)

## Test plan
- [ ] Verify clicking an agent card highlights it and shows only that agent's logs
- [ ] Verify clicking the same card again deselects and shows all logs
- [ ] Verify "Show all logs" link deselects and returns to all-logs view
- [ ] Verify log area height stays fixed when switching between agents
- [ ] Verify run headers show agent ID with color in per-agent view
- [ ] Verify responsive layout on different screen sizes

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
