### PR TITLE
Unified agent+log layout with fixed-height viewer

### DIFF
--- a/apps/ops-dashboard/components/agent-card.tsx
+++ b/apps/ops-dashboard/components/agent-card.tsx
@@ -1,11 +1,27 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 import type { Agent } from '@/lib/types';
 import { RelativeTime } from './relative-time';
 import { RoleBadge } from './role-badge';
 
-export function AgentCard({ agent }: { agent: Agent }) {
+export function AgentCard({
+  agent,
+  selected = false,
+  onClick,
+}: {
+  agent: Agent;
+  selected?: boolean;
+  onClick?: () => void;
+}) {
   return (
-    <Card className="gap-4 border-border/60 bg-card/70 py-5">
+    <Card
+      className={cn(
+        'gap-4 border-border/60 bg-card/70 py-5 transition-colors',
+        onClick && 'cursor-pointer hover:border-zinc-500/60',
+        selected && 'border-zinc-400 bg-card/90 ring-1 ring-zinc-400/30',
+      )}
+      onClick={onClick}
+    >
       <CardHeader className="flex-row items-center justify-between gap-2 pb-0">
         <CardTitle className="text-lg font-semibold tracking-tight">{agent.id}</CardTitle>
         <RoleBadge role={agent.role} />

--- a/apps/ops-dashboard/components/agent-grid.tsx
+++ b/apps/ops-dashboard/components/agent-grid.tsx
@@ -1,16 +1,31 @@
 import type { Agent } from '@/lib/types';
 import { AgentCard } from './agent-card';
 
-export function AgentGrid({ agents }: { agents: Agent[] }) {
+export function AgentGrid({
+  agents,
+  selectedId,
+  onSelect,
+}: {
+  agents: Agent[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
   if (agents.length === 0) {
     return <p className="text-sm text-muted-foreground">No agents found.</p>;
   }
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {agents.map((agent) => (
-        <AgentCard key={agent.id} agent={agent} />
-      ))}
+    <div className="space-y-3">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            selected={selectedId === agent.id}
+            onClick={() => onSelect(selectedId === agent.id ? null : agent.id)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/ops-dashboard/components/all-logs-viewer.tsx
+++ b/apps/ops-dashboard/components/all-logs-viewer.tsx
@@ -118,7 +118,7 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
 
   if (loading) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
+      <div className="flex h-full items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         Loading logs…
       </div>
     );
@@ -154,7 +154,7 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
 
   if (allGroups.length === 0) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
+      <div className="flex h-full items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         No logs available
       </div>
     );
@@ -163,16 +163,14 @@ export function AllLogsViewer({ agents }: { agents: Agent[] }) {
   return (
     <div
       ref={scrollRef}
-      className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
+      className="h-full overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
     >
       {allGroups.map((group, gi) => (
         <div key={gi}>
-          {group.timestamp && (
-            <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
-              <span className={group.colorClass}>{group.agentId}</span>
-              <span>{formatTimestamp(group.timestamp)}</span>
-            </div>
-          )}
+          <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
+            <span className={group.colorClass}>{group.agentId}</span>
+            {group.timestamp && <span>{formatTimestamp(group.timestamp)}</span>}
+          </div>
           <div className="px-4 py-2">
             {groupIntoParagraphs(group.lines).map((para, pi) => (
               <div key={pi} className="mb-2 flex gap-2 last:mb-0">

--- a/apps/ops-dashboard/components/dashboard.tsx
+++ b/apps/ops-dashboard/components/dashboard.tsx
@@ -9,12 +9,23 @@ import { StatsBar } from './stats-bar';
 
 const POLL_INTERVAL = 10_000;
 
+const AGENT_COLORS: Record<number, string> = {
+  0: 'text-teal-400',
+  1: 'text-purple-400',
+  2: 'text-amber-400',
+  3: 'text-sky-400',
+  4: 'text-rose-400',
+  5: 'text-emerald-400',
+  6: 'text-indigo-400',
+  7: 'text-orange-400',
+};
+
 export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
   const [agents, setAgents] = useState<Agent[]>(initialAgents);
   const [updatedAt, setUpdatedAt] = useState<Date>(new Date());
   const [secondsAgo, setSecondsAgo] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
-  const [activeLogTab, setActiveLogTab] = useState<string>('all');
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
   const fetchAgents = useCallback(async () => {
@@ -50,10 +61,13 @@ export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
     return () => clearInterval(id);
   }, [updatedAt]);
 
-  const logTabs = [
-    { id: 'all', label: 'All Agents' },
-    ...agents.map((a) => ({ id: a.id, label: a.id })),
-  ];
+  // Build agent color map
+  const colorMap = new Map<string, string>();
+  agents.forEach((agent, i) => {
+    colorMap.set(agent.id, AGENT_COLORS[i % Object.keys(AGENT_COLORS).length]);
+  });
+
+  const selectedColor = selectedAgent ? colorMap.get(selectedAgent) : undefined;
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-8 sm:px-6 sm:py-10">
@@ -76,41 +90,48 @@ export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
         <StatsBar agents={agents} />
       </header>
 
-      {/* Agents Section */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium text-foreground">Agents</h2>
-        <AgentGrid agents={agents} />
-      </section>
+      {/* Unified Agents + Logs Section */}
+      <section className="space-y-6">
+        <AgentGrid
+          agents={agents}
+          selectedId={selectedAgent}
+          onSelect={setSelectedAgent}
+        />
 
-      <div className="border-t border-border/40" />
-
-      {/* Logs Section */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium text-foreground">Logs</h2>
-
-        {/* Tab bar */}
-        <div className="flex gap-1 overflow-x-auto rounded-lg bg-zinc-900/50 p-1">
-          {logTabs.map((tab) => (
+        {/* Log viewer label */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-medium text-foreground">
+            {selectedAgent ? (
+              <>
+                Logs &mdash;{' '}
+                <span className={selectedColor}>{selectedAgent}</span>
+              </>
+            ) : (
+              'Logs — All Agents'
+            )}
+          </h2>
+          {selectedAgent && (
             <button
-              key={tab.id}
-              onClick={() => setActiveLogTab(tab.id)}
-              className={`shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                activeLogTab === tab.id
-                  ? 'bg-zinc-800 text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
+              onClick={() => setSelectedAgent(null)}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
-              {tab.label}
+              Show all
             </button>
-          ))}
+          )}
         </div>
 
-        {/* Log content */}
-        {activeLogTab === 'all' ? (
-          <AllLogsViewer agents={agents} />
-        ) : (
-          <LogViewer key={activeLogTab} agentId={activeLogTab} />
-        )}
+        {/* Fixed-height log content */}
+        <div className="h-[28rem]">
+          {selectedAgent ? (
+            <LogViewer
+              key={selectedAgent}
+              agentId={selectedAgent}
+              colorClass={selectedColor}
+            />
+          ) : (
+            <AllLogsViewer agents={agents} />
+          )}
+        </div>
       </section>
     </main>
   );

--- a/apps/ops-dashboard/components/log-viewer.tsx
+++ b/apps/ops-dashboard/components/log-viewer.tsx
@@ -68,7 +68,7 @@ function groupByRuns(lines: string[]): RunGroup[] {
   return groups;
 }
 
-export function LogViewer({ agentId }: { agentId: string }) {
+export function LogViewer({ agentId, colorClass }: { agentId: string; colorClass?: string }) {
   const [log, setLog] = useState<LogChunk | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -124,7 +124,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (loading) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
+      <div className="flex h-full items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         Loading logs…
       </div>
     );
@@ -132,7 +132,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (error) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
+      <div className="flex h-full items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         {error}
       </div>
     );
@@ -140,7 +140,7 @@ export function LogViewer({ agentId }: { agentId: string }) {
 
   if (!log || log.lines.length === 0) {
     return (
-      <div className="flex h-48 items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
+      <div className="flex h-full items-center justify-center rounded-lg bg-zinc-950/80 text-sm text-muted-foreground">
         No logs available
       </div>
     );
@@ -149,16 +149,17 @@ export function LogViewer({ agentId }: { agentId: string }) {
   const groups = groupByRuns(log.lines);
 
   return (
-    <div className="space-y-1.5">
+    <div className="flex h-full flex-col gap-1.5">
       <div
         ref={scrollRef}
-        className="max-h-[28rem] overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
+        className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-zinc-950/80 font-mono text-[13px] leading-relaxed text-zinc-300"
       >
         {groups.map((group, gi) => (
           <div key={gi}>
             {group.timestamp && (
-              <div className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
-                {formatTimestamp(group.timestamp)}
+              <div className="sticky top-0 z-10 flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/95 px-4 py-2 text-xs font-medium text-zinc-400">
+                {colorClass && <span className={colorClass}>{agentId}</span>}
+                <span>{formatTimestamp(group.timestamp)}</span>
               </div>
             )}
             <div className="px-4 py-2">


### PR DESCRIPTION
**@worker-01**

## Summary
- Merged separate "Agents" and "Logs" sections into a single unified dashboard section
- Agent cards are clickable — clicking selects an agent and shows its logs; clicking again deselects
- Log viewer has a fixed height (`h-[28rem]`) preventing layout shifts when switching between agents
- "All Agents" log view is the default; "Show all" button returns to it from per-agent view
- Agent ID displayed per run block header (not per line) in both All Agents and per-agent views
- Added selected state styling on agent cards (ring + brighter border)

Closes #147

## Test plan
- [ ] Verify agent cards are clickable and show selected state
- [ ] Verify clicking a selected card deselects it (returns to All Agents view)
- [ ] Verify "Show all" button appears when an agent is selected and works
- [ ] Verify log viewer height stays fixed when switching between agents
- [ ] Verify agent ID appears in run block headers, not per line
- [ ] Verify responsive layout on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
