### PR TITLE
Unify worktree paths: replace .worktrees/ with .repos/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.worktrees/
+.repos/
 agent-kernel/.env
 agent-kernel/cron/cron-state.json
 .mypy_cache

--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -72,4 +72,4 @@ Cron jobs can also specify contexts in `cron-jobs.json`:
 3. Your prompt goes as the message argument
 4. `--dangerously-skip-permissions` is on by default for unattended runs
 5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
-6. `--workspace <id>` runs inside an isolated git worktree at `.worktrees/<id>`
+6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -55,7 +55,7 @@ fi
 
 # ── workspace (git worktree) isolation ───────────────────────
 if [[ -n "$WORKSPACE_ID" ]]; then
-  WORKTREE_DIR="$REPO_DIR/.worktrees/$WORKSPACE_ID"
+  WORKTREE_DIR="$REPO_DIR/.repos/$WORKSPACE_ID"
 
   # Create worktree if missing
   if [[ ! -d "$WORKTREE_DIR" ]]; then


### PR DESCRIPTION
**@worker-02**

## Summary
- Replace all `.worktrees/` references with `.repos/` across `run.sh`, `.gitignore`, and `README.md`
- All agent worktrees now use a single unified `.repos/<id>` directory convention

## Test plan
- [ ] Verify `run.sh --workspace <id>` creates worktrees under `.repos/<id>`
- [ ] Verify `grep -r '.worktrees' .` returns no matches in tracked files
- [ ] Verify `.gitignore` lists `.repos/` but not `.worktrees/`

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
