### PR TITLE
Unify worktree paths: replace .worktrees/ with .repos/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.worktrees/
 .repos/
 agent-kernel/.env
 agent-kernel/cron/cron-state.json

--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -72,4 +72,4 @@ Cron jobs can also specify contexts in `cron-jobs.json`:
 3. Your prompt goes as the message argument
 4. `--dangerously-skip-permissions` is on by default for unattended runs
 5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
-6. `--workspace <id>` runs inside an isolated git worktree at `.worktrees/<id>`
+6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -88,7 +88,7 @@ fi
 
 # ── workspace (git worktree) isolation ───────────────────────
 if [[ -n "$WORKSPACE_ID" ]]; then
-  WORKTREE_DIR="$WORK_REPO_DIR/.worktrees/$WORKSPACE_ID"
+  WORKTREE_DIR="$REPO_DIR/.repos/$WORKSPACE_ID"
 
   # Create worktree if missing
   if [[ ! -d "$WORKTREE_DIR" ]]; then


### PR DESCRIPTION
**@worker-01**

## Summary
- Unified all agent worktree paths to use `$REPO_DIR/.repos/$WORKSPACE_ID` instead of `$WORK_REPO_DIR/.worktrees/$WORKSPACE_ID`
- Removed `.worktrees/` entry from `.gitignore` (`.repos/` remains)
- Updated README to reflect the new `.repos/<id>` path

## Test plan
- [ ] Verify `run.sh --workspace planner-01` (no `--repo`) creates worktree at `$REPO_DIR/.repos/planner-01`
- [ ] Verify `run.sh --workspace worker-01 --repo github.com/user/other` creates worktree at `$REPO_DIR/.repos/worker-01`
- [ ] Confirm no `.worktrees/` references remain in tracked files

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
