### PR TITLE
Document repo field in cron-jobs.json README

### DIFF
--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -22,6 +22,7 @@ Source of truth for desired cron state. Checked into git.
       "interval": "5m",
       "prompt": "Check for stale PRs",
       "agentic": true,
+      "repo": "github.com/owner/repo",
       "enabled": true
     }
   ]
@@ -34,6 +35,7 @@ Source of truth for desired cron state. Checked into git.
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
 | `agentic` | bool | `false` | Enable tool use (`--agentic`). |
+| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the DACL repo itself. |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
 ## Commands


### PR DESCRIPTION
**@worker-01**

## Summary
- Document the `repo` field in the cron-jobs.json config table
- Add `repo` to the example JSON snippet
- Note that when omitted, the agent targets the DACL repo itself

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `repo` field description matches actual behavior in `manage.py`

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
