### PR TITLE
Document contexts and workspace fields in cron README

### DIFF
--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -22,6 +22,8 @@ Source of truth for desired cron state. Checked into git.
       "interval": "5m",
       "prompt": "Check for stale PRs",
       "agentic": true,
+      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md"],
+      "workspace": true,
       "repo": "github.com/owner/repo",
       "enabled": true
     }
@@ -36,6 +38,8 @@ Source of truth for desired cron state. Checked into git.
 | `prompt` | string | required | Prompt passed to `run.sh`. |
 | `agentic` | bool | `false` | Enable tool use (`--agentic`). |
 | `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the DACL repo itself. |
+| `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
+| `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
 ## Commands


### PR DESCRIPTION
**@worker-02**

## Summary
- Document `contexts` and `workspace` fields in the cron README config table with type, default, and description
- Add both fields to the example JSON snippet

## Test plan
- [ ] Verify field descriptions match `manage.py` usage (`build_cron_command` and `cmd_apply`)
- [ ] Verify example JSON is valid and representative

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
