### PR TITLE
Add preflight check to skip idle worker runs

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -114,6 +114,34 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   trap 'rm -f "$LOCKFILE"' EXIT
 fi
 
+# ── preflight: skip idle worker runs ─────────────────────────
+IS_WORKER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *WORKER.md ]]; then
+    IS_WORKER=true
+    break
+  fi
+done
+
+if [[ "$IS_WORKER" == true ]]; then
+  GH_ARGS=(issue list --label "status:ready-for-work" --label "role:worker" --json number --jq 'length')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  AVAILABLE=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$AVAILABLE" == "0" ]]; then
+    echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+    echo "No issues with status:ready-for-work + role:worker — skipping run"
+    echo "=== END RUN ==="
+    exit 0
+  fi
+  # If gh fails (network error, etc.), proceed with the run rather than skipping
+fi
+
 # ── assemble system prompt from context files ─────────────────
 SYSTEM_PROMPT=""
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Add preflight check in `run.sh` that detects worker roles (via `WORKER.md` in contexts) and queries `gh issue list` before invoking Claude
- Skips the run with a clean log message when no `status:ready-for-work` + `role:worker` issues exist
- Fails open on `gh` errors (network issues, auth problems) to avoid blocking legitimate runs
- Planner runs are completely unaffected

## Test plan
- [ ] Run with worker context and no available issues → should exit early with "skipping" message
- [ ] Run with worker context and available issues → should proceed normally
- [ ] Run with planner context → should proceed normally (no preflight check)
- [ ] Simulate `gh` failure (e.g., bad auth) → should proceed normally (fail-open)
- [ ] Verify skip output has `=== RUN ... ===` / `=== END RUN ===` markers

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
