### PR TITLE
Add preflight check to skip idle worker runs

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -114,6 +114,34 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   trap 'rm -f "$LOCKFILE"' EXIT
 fi
 
+# ── preflight: skip idle worker runs ─────────────────────────
+IS_WORKER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *WORKER.md ]]; then
+    IS_WORKER=true
+    break
+  fi
+done
+
+if [[ "$IS_WORKER" == true ]]; then
+  GH_ARGS=(issue list --label "status:ready-for-work" --label "role:worker" --json number --jq 'length')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  AVAILABLE=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$AVAILABLE" == "0" ]]; then
+    echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+    echo "No issues with status:ready-for-work + role:worker — skipping run"
+    echo "=== END RUN ==="
+    exit 0
+  fi
+  # If gh fails (network error, etc.), proceed with the run rather than skipping
+fi
+
 # ── assemble system prompt from context files ─────────────────
 SYSTEM_PROMPT=""
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Adds preflight check in `run.sh` that detects worker roles (contexts containing `WORKER.md`) and queries GitHub for available issues before invoking Claude
- Skips the run with a clean log message when no `status:ready-for-work` + `role:worker` issues exist
- Fails open on network/auth errors — run proceeds normally
- Planner runs are completely unaffected

Closes #175

## Test plan
- [ ] Run a worker cron job when no `status:ready-for-work` issues exist — verify it exits with "skipping run" message
- [ ] Run a worker cron job when issues are available — verify normal behavior
- [ ] Run a planner cron job — verify no preflight check occurs
- [ ] Disconnect network and run a worker — verify it proceeds normally (fail-open)
- [ ] Verify log output has `=== RUN ... ===` / `=== END RUN ===` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
