### PR TITLE
Rebrand DACL to Forge in agent-kernel

### DIFF
--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -37,7 +37,7 @@ Source of truth for desired cron state. Checked into git.
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
 | `agentic` | bool | `false` | Enable tool use (`--agentic`). |
-| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the DACL repo itself. |
+| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
 | `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |

--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -15,7 +15,7 @@ REPO_DIR = os.path.dirname(KERNEL_DIR)
 JOBS_FILE = os.path.join(SCRIPT_DIR, "cron-jobs.json")
 STATE_FILE = os.path.join(SCRIPT_DIR, "cron-state.json")
 LOGS_DIR = os.path.join(KERNEL_DIR, "logs")
-TAG_PREFIX = "# DACL:agent-kernel"
+TAG_PREFIX = "# Forge:agent-kernel"
 
 
 # ── helpers ────────────────────────────────────────────────────

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -63,7 +63,7 @@ fi
 
 # ── resolve target repo ──────────────────────────────────────
 # When --repo is provided, the worktree is created under the target repo
-# instead of DACL's own repo. Context files still resolve from DACL's REPO_DIR.
+# instead of Forge's own repo. Context files still resolve from Forge's REPO_DIR.
 WORK_REPO_DIR="$REPO_DIR"
 
 if [[ -n "$TARGET_REPO" ]]; then
@@ -71,7 +71,7 @@ if [[ -n "$TARGET_REPO" ]]; then
     # Absolute local path — use directly
     WORK_REPO_DIR="$TARGET_REPO"
   elif [[ "$TARGET_REPO" == github.com/* ]]; then
-    # GitHub URL — clone into .repos/ under DACL root
+    # GitHub URL — clone into .repos/ under Forge root
     LOCAL_CLONE="$REPO_DIR/.repos/$TARGET_REPO"
     if [[ -d "$LOCAL_CLONE/.git" ]]; then
       git -C "$LOCAL_CLONE" pull --ff-only 2>/dev/null || true


### PR DESCRIPTION
**@worker-01**

## Summary
- Rename all "DACL" references to "Forge" in `agent-kernel/` directory
- Updates `TAG_PREFIX` in `cron/manage.py`, comments in `run.sh`, and docs in `cron/README.md`
- String/comment changes only — no functional changes

## Test plan
- [ ] Verify no "DACL" references remain in `agent-kernel/` (`grep -r DACL agent-kernel/`)
- [ ] Confirm `TAG_PREFIX` is `"# Forge:agent-kernel"`
- [ ] Verify `run.sh` and `README.md` reference "Forge"

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
