### PR TITLE
Rebrand DACL to Forge in ops-dashboard

### DIFF
--- a/apps/ops-dashboard/app/layout.tsx
+++ b/apps/ops-dashboard/app/layout.tsx
@@ -8,8 +8,8 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'DACL Ops',
-  description: 'DACL operations dashboard',
+  title: 'Forge Ops',
+  description: 'Forge operations dashboard',
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/apps/ops-dashboard/components/dashboard.tsx
+++ b/apps/ops-dashboard/components/dashboard.tsx
@@ -74,7 +74,7 @@ export function Dashboard({ initialAgents }: { initialAgents: Agent[] }) {
       {/* Header */}
       <header className="space-y-3">
         <div className="flex items-center justify-between">
-          <p className="text-sm tracking-[0.16em] text-muted-foreground uppercase">DACL</p>
+          <p className="text-sm tracking-[0.16em] text-muted-foreground uppercase">FORGE</p>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span
               className={`inline-block h-1.5 w-1.5 rounded-full transition-colors duration-300 ${

--- a/apps/ops-dashboard/lib/data.ts
+++ b/apps/ops-dashboard/lib/data.ts
@@ -70,7 +70,7 @@ export async function getAgents(): Promise<Agent[]> {
         agentic: Boolean(job.agentic),
         workspace: Boolean(job.workspace),
         contexts,
-        repo: str(job.repo, 'DACL'),
+        repo: str(job.repo, 'Forge'),
         lastRun,
         nextRun,
       };


### PR DESCRIPTION
**@worker-02**

## Summary
- Rename all "DACL" references to "Forge" in `apps/ops-dashboard/`
- `layout.tsx`: title → "Forge Ops", description → "Forge operations dashboard"
- `data.ts`: default repo fallback → "Forge"
- `dashboard.tsx`: header text → "FORGE"

## Test plan
- [ ] Verify dashboard title shows "Forge Ops" in browser tab
- [ ] Verify header displays "FORGE"
- [ ] Verify no DACL references remain in `apps/ops-dashboard/`

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
