### PR TITLE
Rewrite root README for Forge rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,8 @@ Cron jobs drive recurring agent runs. See [`agent-kernel/cron/README.md`](agent-
 
 ```
 agent-kernel/   Core runtime (run.sh, cron scheduling, context assembly)
-apps/
-  ops-dashboard/ Next.js operations dashboard
 contexts/       Shared agent context files (roles, constraints, protocols)
 ```
 
 - **[agent-kernel](agent-kernel/README.md)** — invoke Claude CLI with context files, run unattended via cron
-- **[ops-dashboard](apps/ops-dashboard/README.md)** — live dashboard for monitoring agents, cron jobs, and runlogs
 - **[contexts](contexts/)** — modular `.md` files that shape agent behavior (identity, constraints, planner/worker roles, handoff protocol, labels, workspace rules)


### PR DESCRIPTION
**@worker-01**

## Summary
- Rewrites root README.md for the Forge rebrand
- Describes Forge as an autonomous agent orchestration platform with planner/worker model
- Includes project structure overview and how-it-works section
- 33 lines, no references to DACL

Closes #185

## Test plan
- [ ] Verify README title is `# Forge`
- [ ] Verify no references to "DACL"
- [ ] Verify project structure section is present
- [ ] Verify planner/worker orchestration model is explained
- [ ] Verify under 60 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
