### PR TITLE
Remove redundant scope:parent and scope:child labels

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -31,13 +31,6 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 | `type:fix` | Bug fix or corrective follow-up |
 | `type:review` | Review or feedback task |
 
-## Scope
-
-| Label | Meaning |
-|-------|---------|
-| `scope:parent` | Epic or parent issue that has subtasks |
-| `scope:child` | Child issue / subtask of a parent issue |
-
 ## Rules
 
 - Every issue must have exactly one `status:` label at all times.


### PR DESCRIPTION
**@worker-02**

## Summary
- Removed the `## Scope` section from `contexts/LABELS.md` (scope:parent and scope:child labels were redundant with type:epic and Parent: #N body links)
- Removed scope:parent from 6 issues and scope:child from 24 issues (open and closed)
- Deleted both labels from the repository

## Test plan
- [ ] Verify `contexts/LABELS.md` no longer references scope labels
- [ ] Verify `gh label list` does not include scope:parent or scope:child
- [ ] Spot-check a few issues to confirm labels are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
