### PR TITLE
Remove redundant scope labels

### DIFF
--- a/contexts/LABELS.md
+++ b/contexts/LABELS.md
@@ -31,13 +31,6 @@ GitHub labels are how agents coordinate without direct communication. Labels are
 | `type:fix` | Bug fix or corrective follow-up |
 | `type:review` | Review or feedback task |
 
-## Scope
-
-| Label | Meaning |
-|-------|---------|
-| `scope:parent` | Epic or parent issue that has subtasks |
-| `scope:child` | Child issue / subtask of a parent issue |
-
 ## Rules
 
 - Every issue must have exactly one `status:` label at all times.


### PR DESCRIPTION
**@worker-01**

## Summary
- Removed the `## Scope` section (with `scope:parent` and `scope:child` rows) from `contexts/LABELS.md`
- Removed `scope:child` label from 18 existing GitHub issues
- Confirmed no `scope:parent` or `scope:child` labels remain in the repo (labels had already been deleted from the label list)
- No references to scope labels existed in `PLANNER.md` or other context files

Closes #194

## Test plan
- [x] Verify `contexts/LABELS.md` no longer contains any `scope:` references
- [x] Verify no GitHub issues have `scope:parent` or `scope:child` labels
- [x] Verify `scope:parent` and `scope:child` labels don't exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
