### PR TITLE
LLM integration: Claude API with GitHub tool definitions

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -5,6 +5,7 @@ description = "Forge CLI command center"
 requires-python = ">=3.11"
 dependencies = [
     "textual>=3.0.0",
+    "anthropic>=0.40.0",
 ]
 
 [project.scripts]

--- a/apps/cli/src/forge/chat.py
+++ b/apps/cli/src/forge/chat.py
@@ -1,7 +1,13 @@
+"""Chat pane with LLM-powered responses."""
+
+from __future__ import annotations
+
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Input, Static
 from textual.widget import Widget
+
+from forge.llm import LLMError, stream_response
 
 
 class ChatMessage(Static):
@@ -14,6 +20,12 @@ class ChatMessage(Static):
 class ChatPane(Widget):
     """Chat interface with scrollable history and text input."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._messages: list[dict] = []
+        self._current_response: ChatMessage | None = None
+        self._current_text: str = ""
+
     def compose(self) -> ComposeResult:
         yield VerticalScroll(id="chat-history")
         yield Input(placeholder="Type a message...", id="chat-input")
@@ -25,5 +37,46 @@ class ChatPane(Widget):
         event.input.clear()
         history = self.query_one("#chat-history", VerticalScroll)
         history.mount(ChatMessage("You", text))
-        history.mount(ChatMessage("Forge", text))
         history.scroll_end(animate=False)
+
+        self._messages.append({"role": "user", "content": text})
+        self._send_to_llm()
+
+    @property
+    def _history(self) -> VerticalScroll:
+        return self.query_one("#chat-history", VerticalScroll)
+
+    def _send_to_llm(self) -> None:
+        """Start streaming a response from the LLM."""
+        self._current_text = ""
+        self._current_response = ChatMessage("Forge", "...")
+        self._history.mount(self._current_response)
+        self._history.scroll_end(animate=False)
+
+        self.run_worker(self._stream_worker(), exclusive=True, group="llm")
+
+    async def _stream_worker(self) -> None:
+        """Worker coroutine that streams LLM response chunks."""
+        try:
+            async for chunk in stream_response(self._messages):
+                self._current_text += chunk
+                if self._current_response:
+                    self._current_response.update(
+                        f"[bold]Forge:[/bold] {self._current_text}"
+                    )
+                    self._history.scroll_end(animate=False)
+        except LLMError as exc:
+            self._current_text = str(exc)
+            if self._current_response:
+                self._current_response.update(
+                    f"[bold]Forge:[/bold] [red]{self._current_text}[/red]"
+                )
+        except Exception as exc:
+            self._current_text = f"Error: {exc}"
+            if self._current_response:
+                self._current_response.update(
+                    f"[bold]Forge:[/bold] [red]{self._current_text}[/red]"
+                )
+
+        self._messages.append({"role": "assistant", "content": self._current_text})
+        self._current_response = None

--- a/apps/cli/src/forge/llm.py
+++ b/apps/cli/src/forge/llm.py
@@ -1,0 +1,109 @@
+"""LLM client for Forge CLI — Claude API integration with tool use."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import AsyncIterator
+
+import anthropic
+
+from forge.tools import TOOL_DEFINITIONS, execute_tool
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+CONTEXTS_DIR = Path(__file__).resolve().parents[4] / "contexts"
+
+
+class LLMError(Exception):
+    """Raised when the LLM client encounters a configuration error."""
+
+
+def _load_system_prompt() -> str:
+    """Build the system prompt from context files."""
+    parts = ["You are Forge, an autonomous agent orchestration assistant."]
+    if CONTEXTS_DIR.is_dir():
+        for md in sorted(CONTEXTS_DIR.glob("*.md")):
+            parts.append(f"\n\n--- {md.stem} ---\n{md.read_text()}")
+    return "".join(parts)
+
+
+def _get_client() -> anthropic.AsyncAnthropic:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise LLMError(
+            "ANTHROPIC_API_KEY is not set. "
+            "Export it in your shell: export ANTHROPIC_API_KEY=sk-..."
+        )
+    return anthropic.AsyncAnthropic(api_key=api_key)
+
+
+async def stream_response(
+    messages: list[dict],
+) -> AsyncIterator[str]:
+    """Send messages to Claude and yield text chunks.
+
+    Handles the tool-use loop: when Claude requests tool calls, this function
+    executes them, feeds results back, and continues streaming until a final
+    text response is produced.
+    """
+    client = _get_client()
+    model = os.environ.get("FORGE_MODEL", DEFAULT_MODEL)
+    system = _load_system_prompt()
+
+    working_messages = list(messages)
+
+    while True:
+        collected_text = ""
+        tool_calls: list[dict] = []
+
+        async with client.messages.stream(
+            model=model,
+            max_tokens=4096,
+            system=system,
+            messages=working_messages,
+            tools=TOOL_DEFINITIONS,
+        ) as stream:
+            async for event in stream:
+                if event.type == "content_block_start":
+                    if event.content_block.type == "tool_use":
+                        tool_calls.append({
+                            "id": event.content_block.id,
+                            "name": event.content_block.name,
+                            "input_json": "",
+                        })
+                elif event.type == "content_block_delta":
+                    if event.delta.type == "text_delta":
+                        collected_text += event.delta.text
+                        yield event.delta.text
+                    elif event.delta.type == "input_json_delta":
+                        if tool_calls:
+                            tool_calls[-1]["input_json"] += event.delta.partial_json
+
+        if not tool_calls:
+            break
+
+        # Build the assistant message content blocks
+        assistant_content: list[dict] = []
+        if collected_text:
+            assistant_content.append({"type": "text", "text": collected_text})
+        for tc in tool_calls:
+            assistant_content.append({
+                "type": "tool_use",
+                "id": tc["id"],
+                "name": tc["name"],
+                "input": json.loads(tc["input_json"]) if tc["input_json"] else {},
+            })
+        working_messages.append({"role": "assistant", "content": assistant_content})
+
+        # Execute tools and build tool results
+        tool_results = []
+        for tc in tool_calls:
+            input_data = json.loads(tc["input_json"]) if tc["input_json"] else {}
+            result = execute_tool(tc["name"], input_data)
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tc["id"],
+                "content": result,
+            })
+        working_messages.append({"role": "user", "content": tool_results})

--- a/apps/cli/src/forge/tools.py
+++ b/apps/cli/src/forge/tools.py
@@ -1,0 +1,171 @@
+"""GitHub tool definitions and execution for the Forge LLM."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+TOOL_DEFINITIONS = [
+    {
+        "name": "create_issue",
+        "description": "Create a new GitHub issue.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "title": {"type": "string", "description": "Issue title."},
+                "body": {"type": "string", "description": "Issue body (markdown)."},
+                "labels": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Labels to apply.",
+                },
+            },
+            "required": ["repo", "title", "body"],
+        },
+    },
+    {
+        "name": "list_issues",
+        "description": "List issues in a GitHub repository, optionally filtered by labels and state.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Filter by labels.",
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Filter by state. Defaults to open.",
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "view_issue",
+        "description": "View a specific GitHub issue with its comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "number": {"type": "integer", "description": "Issue number."},
+            },
+            "required": ["repo", "number"],
+        },
+    },
+    {
+        "name": "list_prs",
+        "description": "List pull requests in a GitHub repository.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "merged", "all"],
+                    "description": "Filter by state. Defaults to open.",
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "view_pr",
+        "description": "View a specific pull request with its comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "number": {"type": "integer", "description": "PR number."},
+            },
+            "required": ["repo", "number"],
+        },
+    },
+]
+
+
+def _run_gh(*args: str) -> str:
+    """Run a gh CLI command and return its stdout."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return f"Error: {result.stderr.strip()}"
+    return result.stdout.strip()
+
+
+def execute_tool(name: str, input_data: dict) -> str:
+    """Execute a tool by name with the given input and return the result string."""
+    repo = input_data.get("repo", "")
+
+    if name == "create_issue":
+        cmd = [
+            "issue", "create",
+            "--repo", repo,
+            "--title", input_data["title"],
+            "--body", input_data["body"],
+        ]
+        for label in input_data.get("labels", []):
+            cmd.extend(["--label", label])
+        return _run_gh(*cmd)
+
+    if name == "list_issues":
+        cmd = ["issue", "list", "--repo", repo, "--json", "number,title,state,labels"]
+        for label in input_data.get("labels", []):
+            cmd.extend(["--label", label])
+        state = input_data.get("state", "open")
+        cmd.extend(["--state", state])
+        raw = _run_gh(*cmd)
+        try:
+            issues = json.loads(raw)
+            lines = []
+            for iss in issues:
+                labels = ", ".join(l["name"] for l in iss.get("labels", []))
+                lines.append(f"#{iss['number']} [{iss['state']}] {iss['title']}  ({labels})")
+            return "\n".join(lines) if lines else "No issues found."
+        except (json.JSONDecodeError, KeyError):
+            return raw
+
+    if name == "view_issue":
+        return _run_gh("issue", "view", str(input_data["number"]), "--repo", repo, "--comments")
+
+    if name == "list_prs":
+        cmd = ["pr", "list", "--repo", repo, "--json", "number,title,state"]
+        state = input_data.get("state", "open")
+        cmd.extend(["--state", state])
+        raw = _run_gh(*cmd)
+        try:
+            prs = json.loads(raw)
+            lines = []
+            for pr in prs:
+                lines.append(f"#{pr['number']} [{pr['state']}] {pr['title']}")
+            return "\n".join(lines) if lines else "No pull requests found."
+        except (json.JSONDecodeError, KeyError):
+            return raw
+
+    if name == "view_pr":
+        return _run_gh("pr", "view", str(input_data["number"]), "--repo", repo, "--comments")
+
+    return f"Unknown tool: {name}"


### PR DESCRIPTION
**@worker-01**

## Summary
- Integrate Claude API into the Forge CLI chat interface with streaming responses
- Define 5 GitHub tools (create_issue, list_issues, view_issue, list_prs, view_pr) that wrap `gh` CLI commands
- Implement tool-use loop: Claude can call tools, receive results, and continue responding
- Load context files from `contexts/*.md` into system prompt for orchestration awareness
- Handle missing API key with clear error message instead of crash

## Test plan
- [ ] Set `ANTHROPIC_API_KEY` and run `forge` — verify chat messages get LLM responses
- [ ] Ask the LLM to list issues — verify tool execution and result display
- [ ] Run without `ANTHROPIC_API_KEY` set — verify clear error message appears
- [ ] Set `FORGE_MODEL` env var — verify custom model is used
- [ ] Verify context files are loaded into system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
