### PR TITLE
LLM integration: Claude API with GitHub tool definitions

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -5,6 +5,7 @@ description = "Forge CLI command center"
 requires-python = ">=3.11"
 dependencies = [
     "textual>=3.0.0",
+    "anthropic>=0.40.0",
 ]
 
 [project.scripts]

--- a/apps/cli/src/forge/chat.py
+++ b/apps/cli/src/forge/chat.py
@@ -2,6 +2,9 @@ from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import Input, Static
 from textual.widget import Widget
+from textual.worker import Worker, WorkerState
+
+from forge.llm import LLMClient, LLMConfigError
 
 
 class ChatMessage(Static):
@@ -14,6 +17,19 @@ class ChatMessage(Static):
 class ChatPane(Widget):
     """Chat interface with scrollable history and text input."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._llm: LLMClient | None = None
+        self._init_error: str | None = None
+
+    def on_mount(self) -> None:
+        try:
+            self._llm = LLMClient()
+        except LLMConfigError as e:
+            self._init_error = str(e)
+            history = self.query_one("#chat-history", VerticalScroll)
+            history.mount(ChatMessage("System", f"[red]{self._init_error}[/red]"))
+
     def compose(self) -> ComposeResult:
         yield VerticalScroll(id="chat-history")
         yield Input(placeholder="Type a message...", id="chat-input")
@@ -25,5 +41,43 @@ class ChatPane(Widget):
         event.input.clear()
         history = self.query_one("#chat-history", VerticalScroll)
         history.mount(ChatMessage("You", text))
-        history.mount(ChatMessage("Forge", text))
         history.scroll_end(animate=False)
+
+        if self._init_error:
+            history.mount(ChatMessage("System", f"[red]{self._init_error}[/red]"))
+            history.scroll_end(animate=False)
+            return
+
+        response_msg = ChatMessage("Forge", "")
+        history.mount(response_msg)
+        history.scroll_end(animate=False)
+
+        self.run_worker(
+            self._stream_response(text, response_msg, history),
+            thread=True,
+        )
+
+    def _stream_response(
+        self,
+        text: str,
+        response_msg: ChatMessage,
+        history: VerticalScroll,
+    ) -> None:
+        """Stream LLM response chunks into the response message widget."""
+        collected = []
+        try:
+            for chunk in self._llm.send_message(text):
+                collected.append(chunk)
+                full_text = "".join(collected)
+                self.app.call_from_thread(
+                    response_msg.update,
+                    f"[bold]Forge:[/bold] {full_text}",
+                )
+                self.app.call_from_thread(history.scroll_end, animate=False)
+        except Exception as e:
+            error_text = f"[red]Error: {e}[/red]"
+            self.app.call_from_thread(
+                response_msg.update,
+                f"[bold]Forge:[/bold] {error_text}",
+            )
+            self.app.call_from_thread(history.scroll_end, animate=False)

--- a/apps/cli/src/forge/llm.py
+++ b/apps/cli/src/forge/llm.py
@@ -1,0 +1,133 @@
+"""Claude API client with context loading and tool-use loop."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import AsyncIterator
+
+import anthropic
+
+from forge.tools import TOOL_DEFINITIONS, execute_tool
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+
+def _find_contexts_dir() -> Path | None:
+    """Locate the contexts/ directory relative to the repo root."""
+    root_env = os.environ.get("FORGE_REPO_ROOT")
+    if root_env:
+        p = Path(root_env) / "contexts"
+        if p.is_dir():
+            return p
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            p = Path(result.stdout.strip()) / "contexts"
+            if p.is_dir():
+                return p
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return None
+
+
+def _load_system_prompt() -> str:
+    """Build a system prompt from context files."""
+    parts = ["You are Forge, an autonomous agent orchestration assistant."]
+
+    contexts_dir = _find_contexts_dir()
+    if contexts_dir:
+        for md_file in sorted(contexts_dir.glob("*.md")):
+            content = md_file.read_text().strip()
+            if content:
+                parts.append(f"--- {md_file.stem} ---\n{content}")
+
+    parts.append(
+        "You have access to GitHub tools. Use them when the user asks about "
+        "issues, pull requests, or repository management."
+    )
+    return "\n\n".join(parts)
+
+
+class LLMClient:
+    """Manages a conversation with Claude including tool use."""
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise LLMConfigError(
+                "ANTHROPIC_API_KEY environment variable is not set. "
+                "Set it to your Anthropic API key to use the chat."
+            )
+        self._client = anthropic.Anthropic(api_key=api_key)
+        self._model = os.environ.get("FORGE_MODEL", DEFAULT_MODEL)
+        self._system_prompt = _load_system_prompt()
+        self._messages: list[dict] = []
+
+    def send_message(self, user_text: str) -> AsyncIterator[str]:
+        """Send a user message and yield streamed text chunks.
+
+        This is a generator that handles the full tool-use loop:
+        1. Send user message to Claude
+        2. If Claude responds with tool_use, execute tools and continue
+        3. Yield text chunks as they arrive
+        """
+        self._messages.append({"role": "user", "content": user_text})
+        yield from self._run_turn()
+
+    def _run_turn(self):
+        """Run one turn of the conversation, handling tool use recursively."""
+        while True:
+            with self._client.messages.stream(
+                model=self._model,
+                max_tokens=4096,
+                system=self._system_prompt,
+                messages=self._messages,
+                tools=TOOL_DEFINITIONS,
+            ) as stream:
+                collected_content = []
+                has_tool_use = False
+
+                for event in stream:
+                    if event.type == "content_block_start":
+                        if event.content_block.type == "text":
+                            pass
+                        elif event.content_block.type == "tool_use":
+                            has_tool_use = True
+                    elif event.type == "content_block_delta":
+                        if event.delta.type == "text_delta":
+                            yield event.delta.text
+
+                response = stream.get_final_message()
+                collected_content = response.content
+
+            self._messages.append({"role": "assistant", "content": collected_content})
+
+            if not has_tool_use or response.stop_reason != "tool_use":
+                break
+
+            tool_results = []
+            for block in collected_content:
+                if block.type == "tool_use":
+                    result = execute_tool(block.name, block.input)
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": block.id,
+                            "content": result,
+                        }
+                    )
+
+            self._messages.append({"role": "user", "content": tool_results})
+
+
+class LLMConfigError(Exception):
+    """Raised when LLM configuration is invalid."""

--- a/apps/cli/src/forge/tools.py
+++ b/apps/cli/src/forge/tools.py
@@ -1,0 +1,195 @@
+"""GitHub tool definitions for the Claude API tool-use loop."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+TOOL_DEFINITIONS = [
+    {
+        "name": "create_issue",
+        "description": "Create a new GitHub issue in the specified repository.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format (e.g. 'alexjaniak/DACL').",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Issue title.",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Issue body content (markdown).",
+                },
+                "labels": {
+                    "type": "string",
+                    "description": "Comma-separated list of labels to apply.",
+                },
+            },
+            "required": ["repo", "title"],
+        },
+    },
+    {
+        "name": "list_issues",
+        "description": "List issues in a GitHub repository, optionally filtered by labels and state.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "labels": {
+                    "type": "string",
+                    "description": "Comma-separated labels to filter by.",
+                },
+                "state": {
+                    "type": "string",
+                    "description": "Issue state: 'open', 'closed', or 'all'.",
+                    "enum": ["open", "closed", "all"],
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "view_issue",
+        "description": "View a specific GitHub issue including its body and comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "number": {
+                    "type": "integer",
+                    "description": "Issue number.",
+                },
+            },
+            "required": ["repo", "number"],
+        },
+    },
+    {
+        "name": "list_prs",
+        "description": "List pull requests in a GitHub repository.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "state": {
+                    "type": "string",
+                    "description": "PR state: 'open', 'closed', 'merged', or 'all'.",
+                    "enum": ["open", "closed", "merged", "all"],
+                },
+            },
+            "required": ["repo"],
+        },
+    },
+    {
+        "name": "view_pr",
+        "description": "View a specific pull request including its body and comments.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": "Repository in owner/name format.",
+                },
+                "number": {
+                    "type": "integer",
+                    "description": "Pull request number.",
+                },
+            },
+            "required": ["repo", "number"],
+        },
+    },
+]
+
+
+def _run_gh(args: list[str], timeout: int = 30) -> str:
+    """Run a gh CLI command and return its stdout."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return f"Error: {result.stderr.strip()}"
+        return result.stdout.strip()
+    except FileNotFoundError:
+        return "Error: gh CLI is not installed or not on PATH."
+    except subprocess.TimeoutExpired:
+        return "Error: command timed out."
+
+
+def execute_tool(name: str, input_data: dict) -> str:
+    """Execute a GitHub tool by name and return the result as a string."""
+    repo = input_data.get("repo", "")
+    repo_flag = ["-R", repo] if repo else []
+
+    if name == "create_issue":
+        args = ["issue", "create"] + repo_flag
+        args += ["--title", input_data["title"]]
+        if input_data.get("body"):
+            args += ["--body", input_data["body"]]
+        if input_data.get("labels"):
+            for label in input_data["labels"].split(","):
+                args += ["--label", label.strip()]
+        return _run_gh(args)
+
+    if name == "list_issues":
+        args = ["issue", "list"] + repo_flag
+        if input_data.get("labels"):
+            for label in input_data["labels"].split(","):
+                args += ["--label", label.strip()]
+        if input_data.get("state"):
+            args += ["--state", input_data["state"]]
+        args += ["--json", "number,title,state,labels"]
+        output = _run_gh(args)
+        try:
+            issues = json.loads(output)
+            lines = []
+            for issue in issues:
+                labels = ", ".join(l["name"] for l in issue.get("labels", []))
+                label_str = f" [{labels}]" if labels else ""
+                lines.append(f"#{issue['number']} {issue['title']}{label_str}")
+            return "\n".join(lines) if lines else "No issues found."
+        except (json.JSONDecodeError, KeyError):
+            return output
+
+    if name == "view_issue":
+        args = ["issue", "view", str(input_data["number"])] + repo_flag
+        args += ["--comments"]
+        return _run_gh(args)
+
+    if name == "list_prs":
+        args = ["pr", "list"] + repo_flag
+        if input_data.get("state"):
+            args += ["--state", input_data["state"]]
+        args += ["--json", "number,title,state"]
+        output = _run_gh(args)
+        try:
+            prs = json.loads(output)
+            lines = []
+            for pr in prs:
+                lines.append(f"#{pr['number']} {pr['title']} ({pr['state']})")
+            return "\n".join(lines) if lines else "No pull requests found."
+        except (json.JSONDecodeError, KeyError):
+            return output
+
+    if name == "view_pr":
+        args = ["pr", "view", str(input_data["number"])] + repo_flag
+        args += ["--comments"]
+        return _run_gh(args)
+
+    return f"Error: unknown tool '{name}'."


### PR DESCRIPTION
**@worker-02**

## Summary
- Add Claude API integration to the Forge CLI with streaming responses and a full tool-use loop
- Define 5 GitHub tools (create_issue, list_issues, view_issue, list_prs, view_pr) that execute via `gh` CLI
- Load context files from `contexts/*.md` into the system prompt for orchestration awareness
- Model configurable via `FORGE_MODEL` env var (defaults to `claude-sonnet-4-6`), API key via `ANTHROPIC_API_KEY`
- Clear error message when API key is missing (no crash)

Closes #198

## Test plan
- [ ] Set `ANTHROPIC_API_KEY` and run `forge` — verify chat messages are sent to Claude and responses stream in
- [ ] Ask Claude about GitHub issues — verify tool use works end-to-end
- [ ] Unset `ANTHROPIC_API_KEY` — verify clear error message appears in chat
- [ ] Verify context files are loaded into system prompt (ask the LLM about its instructions)
- [ ] Test each tool: create_issue, list_issues, view_issue, list_prs, view_pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
