### PR TITLE
Add Claude Code-inspired terminal styling

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -1,5 +1,6 @@
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
+from textual.widgets import Static
 
 from forge.chat import ChatPane
 from forge.status_panel import StatusPanel
@@ -12,6 +13,7 @@ class ForgeApp(App):
     TITLE = "Forge"
 
     def compose(self) -> ComposeResult:
+        yield Static(" Forge — Agent Orchestration", id="header-bar")
         with Horizontal(id="main"):
             yield ChatPane()
             yield StatusPanel()

--- a/apps/cli/src/forge/chat.py
+++ b/apps/cli/src/forge/chat.py
@@ -2,17 +2,37 @@ from __future__ import annotations
 
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
-from textual.widgets import Input, Static
+from textual.widgets import Input, Markdown, Static
 from textual.widget import Widget
 
 from forge.llm import LLMClient
 
 
-class ChatMessage(Static):
-    """A single message in the chat history."""
+class UserMessage(Static):
+    """A user message in the chat history."""
 
-    def __init__(self, sender: str, text: str) -> None:
-        super().__init__(f"[bold]{sender}:[/bold] {text}")
+    DEFAULT_CSS = ""
+
+    def __init__(self, text: str) -> None:
+        super().__init__(f"> {text}", classes="user-message")
+
+
+class AssistantMessage(Markdown):
+    """An assistant message rendered as markdown."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, text: str = "") -> None:
+        super().__init__(text, classes="assistant-message")
+
+
+class SystemMessage(Static):
+    """A system/error message."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, text: str) -> None:
+        super().__init__(text, classes="system-message")
 
 
 class ChatPane(Widget):
@@ -29,12 +49,12 @@ class ChatPane(Widget):
 
     def compose(self) -> ComposeResult:
         yield VerticalScroll(id="chat-history")
-        yield Input(placeholder="Type a message...", id="chat-input")
+        yield Input(placeholder="> Type a message...", id="chat-input")
 
     def on_mount(self) -> None:
         if self._llm_error:
             history = self.query_one("#chat-history", VerticalScroll)
-            history.mount(ChatMessage("System", self._llm_error))
+            history.mount(SystemMessage(self._llm_error))
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         text = event.value.strip()
@@ -42,23 +62,23 @@ class ChatPane(Widget):
             return
         event.input.clear()
         history = self.query_one("#chat-history", VerticalScroll)
-        history.mount(ChatMessage("You", text))
+        history.mount(UserMessage(text))
         history.scroll_end(animate=False)
 
         if self._llm is None:
-            history.mount(ChatMessage("System", self._llm_error or "LLM not available."))
+            history.mount(SystemMessage(self._llm_error or "LLM not available."))
             history.scroll_end(animate=False)
             return
 
-        response_widget = ChatMessage("Forge", "")
+        response_widget = AssistantMessage()
         history.mount(response_widget)
         history.scroll_end(animate=False)
 
-        collected = []
+        collected: list[str] = []
         async for chunk in self._llm.stream_response(text):
             collected.append(chunk)
-            response_widget.update(f"[bold]Forge:[/bold] {''.join(collected)}")
+            response_widget.update("".join(collected))
             history.scroll_end(animate=False)
 
         if not collected:
-            response_widget.update("[bold]Forge:[/bold] (no response)")
+            response_widget.update("*(no response)*")

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -1,3 +1,19 @@
+/* Forge CLI — Dark theme with Claude Code-inspired styling */
+
+Screen {
+    background: #1a1a2e;
+    color: #e0e0e0;
+}
+
+#header-bar {
+    dock: top;
+    height: 1;
+    background: #6c3fc5;
+    color: #ffffff;
+    text-style: bold;
+    padding: 0 1;
+}
+
 #main {
     height: 1fr;
 }
@@ -5,21 +21,44 @@
 ChatPane {
     width: 3fr;
     height: 1fr;
-    border-right: solid $accent;
+    border-right: solid #3a3a5c;
 }
 
 #chat-history {
     height: 1fr;
     padding: 1;
+    background: #1a1a2e;
 }
 
 #chat-input {
     dock: bottom;
+    background: #16162a;
+    border: tall #3a3a5c;
+    color: #e0e0e0;
 }
 
-ChatMessage {
+.user-message {
     height: auto;
     margin-bottom: 1;
+    padding: 0 1;
+    background: #252545;
+    border-left: thick #6c3fc5;
+    color: #e0e0e0;
+}
+
+.assistant-message {
+    height: auto;
+    margin-bottom: 1;
+    padding: 0 1;
+    color: #d0d0d0;
+}
+
+.system-message {
+    height: auto;
+    margin-bottom: 1;
+    padding: 0 1;
+    color: #ff6b6b;
+    text-style: italic;
 }
 
 StatusPanel {
@@ -27,15 +66,19 @@ StatusPanel {
     height: 1fr;
     padding: 1;
     overflow-y: auto;
+    border: round #3a3a5c;
+    background: #16162a;
 }
 
 #status-header {
     height: auto;
     text-style: bold;
+    color: #6c3fc5;
     margin-bottom: 1;
 }
 
 #status-content {
     height: auto;
     padding: 0 1;
+    color: #808090;
 }

--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -131,7 +131,7 @@ class StatusPanel(Widget):
     tick_count = reactive(0)
 
     def compose(self) -> ComposeResult:
-        yield Static("[bold]Agent Status[/bold]", id="status-header")
+        yield Static("Agent Status", id="status-header")
         yield Static("Loading...", id="status-content")
 
     def on_mount(self) -> None:


### PR DESCRIPTION
**@worker-03**

## Summary
- Add dark theme with Claude Code-inspired color scheme (deep navy background, purple accents)
- Add "Forge" header bar branding at top of application
- Visually distinct message types: user (purple-bordered), assistant (markdown-rendered), system (red italic)
- Styled input area, bordered status panel, and consistent typography

## Test plan
- [ ] Run `forge` CLI and verify dark theme renders correctly
- [ ] Send a message and verify user message has purple left border
- [ ] Verify assistant responses render markdown (bold, code blocks, lists)
- [ ] Verify header bar shows "Forge — Agent Orchestration"
- [ ] Verify status panel has rounded border and colored header

Generated with [Claude Code](https://claude.com/claude-code)
