### PR TITLE
Add event-to-agent triggering with rule-based matching

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/config.py
+++ b/apps/webhook-monitor/src/forge_webhook/config.py
@@ -12,4 +12,6 @@ def get_config() -> dict:
         "secret": secret,
         "port": int(os.environ.get("FORGE_WEBHOOK_PORT", "8471")),
         "events_file": os.environ.get("FORGE_EVENTS_FILE", "./events.jsonl"),
+        "trigger_rules_file": os.environ.get("FORGE_TRIGGER_RULES", ""),
+        "repo_dir": os.environ.get("FORGE_REPO_DIR", ""),
     }

--- a/apps/webhook-monitor/src/forge_webhook/main.py
+++ b/apps/webhook-monitor/src/forge_webhook/main.py
@@ -7,10 +7,12 @@ from fastapi import FastAPI, Header, HTTPException, Request
 from .config import get_config
 from .normalize import normalize_event
 from .storage import append_event
+from .trigger import evaluate_triggers, load_rules
 
 app = FastAPI(title="Forge Webhook Monitor")
 
 _config: dict | None = None
+_trigger_rules: list[dict] | None = None
 
 
 def _get_config() -> dict:
@@ -18,6 +20,15 @@ def _get_config() -> dict:
     if _config is None:
         _config = get_config()
     return _config
+
+
+def _get_trigger_rules() -> list[dict]:
+    global _trigger_rules
+    if _trigger_rules is None:
+        config = _get_config()
+        rules_file = config.get("trigger_rules_file", "")
+        _trigger_rules = load_rules(rules_file) if rules_file else []
+    return _trigger_rules
 
 
 def _verify_signature(payload: bytes, signature: str | None, secret: str) -> None:
@@ -56,6 +67,12 @@ async def webhook(
         return {"status": "ignored", "event": x_github_event}
 
     append_event(config["events_file"], event)
+
+    rules = _get_trigger_rules()
+    repo_dir = config.get("repo_dir", "")
+    if rules and repo_dir:
+        evaluate_triggers(event, rules, repo_dir)
+
     return {"status": "accepted", "event_type": event["event_type"]}
 
 

--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -1,0 +1,109 @@
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("forge_webhook.trigger")
+
+
+def load_rules(rules_path: str) -> list[dict]:
+    path = Path(rules_path)
+    if not path.exists():
+        logger.warning("Trigger rules file not found: %s", rules_path)
+        return []
+    with open(path) as f:
+        data = json.load(f)
+    rules = data.get("rules", [])
+    logger.info("Loaded %d trigger rules from %s", len(rules), rules_path)
+    return rules
+
+
+def _matches_rule(event: dict, rule: dict) -> bool:
+    if event["event_type"] != rule["event_type"]:
+        return False
+
+    match = rule.get("match", {})
+    if "labels_contain" in match:
+        required_label = match["labels_contain"]
+        if required_label not in event.get("labels", []):
+            return False
+
+    return True
+
+
+def _is_agent_running(repo_dir: str, workspace_id: str) -> bool:
+    lockfile = Path(repo_dir) / ".worktrees" / workspace_id / ".agent.lock"
+    if not lockfile.exists():
+        return False
+
+    try:
+        pid = int(lockfile.read_text().strip())
+    except (ValueError, OSError):
+        return False
+
+    try:
+        import signal
+        import os
+
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def _invoke_agent(repo_dir: str, rule: dict, event: dict) -> None:
+    workspace = rule["agent"]
+    context = rule.get("context", "")
+    issue_num = event.get("number", "unknown")
+    event_type = event["event_type"]
+
+    prompt = f"Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large."
+    if "worker" in workspace:
+        prompt = (
+            f"Triggered by {event_type} on issue #{issue_num}. "
+            f"Find and claim a ready issue, then implement it."
+        )
+
+    cmd = [
+        str(Path(repo_dir) / "agent-kernel" / "run.sh"),
+        "--agentic",
+        "--workspace", workspace,
+    ]
+    if context:
+        cmd.extend(["--context", context])
+    cmd.append(prompt)
+
+    logger.info("Invoking agent: %s (workspace=%s, issue=#%s)", " ".join(cmd[:5]), workspace, issue_num)
+    subprocess.Popen(
+        cmd,
+        cwd=repo_dir,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def evaluate_triggers(event: dict, rules: list[dict], repo_dir: str) -> None:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for rule in rules:
+        if not _matches_rule(event, rule):
+            continue
+
+        agent = rule.get("agent", "unknown")
+
+        if _is_agent_running(repo_dir, agent):
+            logger.info(
+                "[%s] trigger matched rule (agent=%s, event=%s) — skipped: agent already running",
+                ts, agent, event["event_type"],
+            )
+            continue
+
+        logger.info(
+            "[%s] trigger fired (agent=%s, event=%s, issue=#%s)",
+            ts, agent, event["event_type"], event.get("number", "?"),
+        )
+        _invoke_agent(repo_dir, rule, event)

--- a/apps/webhook-monitor/trigger-rules.json
+++ b/apps/webhook-monitor/trigger-rules.json
@@ -1,0 +1,18 @@
+{
+  "rules": [
+    {
+      "event_type": "issue.labeled",
+      "match": { "labels_contain": "status:ready-for-work" },
+      "action": "run_agent",
+      "agent": "worker-01",
+      "context": "contexts/WORKER.md"
+    },
+    {
+      "event_type": "issue.labeled",
+      "match": { "labels_contain": "status:ready-for-planning" },
+      "action": "run_agent",
+      "agent": "planner-01",
+      "context": "contexts/PLANNER.md"
+    }
+  ]
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- Add event-to-agent triggering module that matches normalized webhook events against configurable rules
- Rules loaded from `trigger-rules.json` with label-based filtering (e.g., `status:ready-for-work` → invoke worker agent)
- Agent invocation via `agent-kernel/run.sh` subprocess with lock file deduplication to prevent re-triggering running agents
- Two default rules: worker for `ready-for-work`, planner for `ready-for-planning`

## Test plan
- [ ] Set `FORGE_TRIGGER_RULES` and `FORGE_REPO_DIR` env vars and verify rules load on startup
- [ ] Send a webhook event with `issue.labeled` containing `status:ready-for-work` label — verify agent invocation is triggered
- [ ] Verify lock file check prevents duplicate agent runs
- [ ] Verify unmatched events produce no triggers
- [ ] Verify missing/empty rules file gracefully returns empty rules list

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
