### PR TITLE
Add webhook dev setup: tunnel, dev script, and docs

### DIFF
--- a/apps/webhook-monitor/README.md
+++ b/apps/webhook-monitor/README.md
@@ -1,0 +1,72 @@
+# Forge Webhook Monitor
+
+Receives GitHub webhook events and stores them as normalized JSONL for the Forge event system.
+
+## Prerequisites
+
+- Python 3.11+
+- A tunnel tool: `gh webhook forward` (GitHub CLI) or [ngrok](https://ngrok.com/download)
+
+## Setup
+
+### 1. Install the webhook server
+
+```bash
+cd apps/webhook-monitor
+pip install -e .
+```
+
+### 2. Set environment variables
+
+```bash
+export FORGE_WEBHOOK_SECRET="<your-secret>"    # Required
+export FORGE_WEBHOOK_PORT=8471                  # Optional, default 8471
+export FORGE_EVENTS_FILE="./events.jsonl"       # Optional, default ./events.jsonl
+export FORGE_REPO="owner/repo"                  # Required for gh webhook forward
+```
+
+Generate a secret with: `openssl rand -hex 32`
+
+### 3. Start the server
+
+```bash
+forge-webhook
+```
+
+The server listens on `0.0.0.0:$FORGE_WEBHOOK_PORT` and exposes:
+
+- `POST /webhook` — receives GitHub events
+- `GET /health` — health check
+
+### 4. Start the tunnel
+
+```bash
+./tunnel.sh
+```
+
+The script tries `gh webhook forward` first, then falls back to `ngrok`.
+
+**With `gh webhook forward`**: The tunnel configures the webhook automatically — no manual GitHub setup needed. Requires `FORGE_REPO` to be set.
+
+**With `ngrok`**: Copy the public URL from ngrok's output and configure the webhook manually (see below).
+
+### 5. (ngrok only) Configure the GitHub repo webhook
+
+1. Go to your repo → **Settings** → **Webhooks** → **Add webhook**
+2. **Payload URL**: `<ngrok-url>/webhook`
+3. **Content type**: `application/json`
+4. **Secret**: The value of `FORGE_WEBHOOK_SECRET`
+5. **Events**: Select individual events:
+   - Issues
+   - Pull requests
+   - Issue comments
+   - Pull request reviews
+6. Save
+
+## Quick start (both server + tunnel)
+
+```bash
+./dev.sh
+```
+
+Starts the webhook server and tunnel in parallel. Press `Ctrl+C` to stop both.

--- a/apps/webhook-monitor/dev.sh
+++ b/apps/webhook-monitor/dev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Validate required env vars
+if [ -z "${FORGE_WEBHOOK_SECRET:-}" ]; then
+    echo "Error: FORGE_WEBHOOK_SECRET must be set" >&2
+    exit 1
+fi
+
+cleanup() {
+    echo "Shutting down..."
+    kill 0 2>/dev/null
+    wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# Start the webhook server
+echo "Starting webhook server..."
+forge-webhook &
+SERVER_PID=$!
+
+# Brief pause to let the server bind
+sleep 1
+
+# Start the tunnel
+echo "Starting tunnel..."
+"$SCRIPT_DIR/tunnel.sh" &
+TUNNEL_PID=$!
+
+echo "Server PID: $SERVER_PID | Tunnel PID: $TUNNEL_PID"
+echo "Press Ctrl+C to stop both."
+
+wait

--- a/apps/webhook-monitor/tunnel.sh
+++ b/apps/webhook-monitor/tunnel.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${FORGE_WEBHOOK_PORT:-8471}"
+
+# Prefer gh webhook forward (built into GitHub CLI)
+if command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -q "webhook"; then
+    echo "Using gh webhook forward → localhost:$PORT"
+    exec gh webhook forward --repo="$FORGE_REPO" --events="issues,pull_request,issue_comment,pull_request_review" --url="http://localhost:$PORT/webhook" --secret="$FORGE_WEBHOOK_SECRET"
+fi
+
+if command -v gh &>/dev/null && gh webhook forward --help &>/dev/null 2>&1; then
+    echo "Using gh webhook forward → localhost:$PORT"
+    exec gh webhook forward --repo="$FORGE_REPO" --events="issues,pull_request,issue_comment,pull_request_review" --url="http://localhost:$PORT/webhook" --secret="$FORGE_WEBHOOK_SECRET"
+fi
+
+# Fall back to ngrok
+if command -v ngrok &>/dev/null; then
+    echo "Using ngrok → localhost:$PORT"
+    echo "Once running, configure the public URL in your GitHub repo webhook settings."
+    exec ngrok http "$PORT"
+fi
+
+echo "Error: No tunnel tool found." >&2
+echo "Install one of:" >&2
+echo "  - GitHub CLI webhook extension: gh extension install cli/gh-webhook" >&2
+echo "  - ngrok: https://ngrok.com/download" >&2
+exit 1


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `tunnel.sh` — tries `gh webhook forward` first, falls back to `ngrok`, errors if neither available
- Add `dev.sh` — starts webhook server and tunnel in parallel with cleanup on exit
- Add `README.md` — documents server install, env vars, tunnel setup, GitHub webhook config (events: Issues, PRs, Issue comments, PR reviews), and quick start

Closes #215

## Test plan
- [ ] Run `./tunnel.sh` with `gh` CLI installed — verify it invokes `gh webhook forward`
- [ ] Run `./tunnel.sh` without `gh` webhook extension but with `ngrok` — verify fallback
- [ ] Run `./tunnel.sh` with neither tool — verify error message
- [ ] Run `./dev.sh` — verify server and tunnel start, Ctrl+C stops both
- [ ] Verify README instructions are accurate against existing server code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
