### PR TITLE
Add webhook dev setup: tunnel, dev script, and docs

### DIFF
--- a/apps/webhook-monitor/README.md
+++ b/apps/webhook-monitor/README.md
@@ -1,0 +1,78 @@
+# Forge Webhook Monitor
+
+Receives GitHub webhook events, normalizes them, and stores them as JSONL for the Forge event pipeline.
+
+## Setup
+
+### 1. Install the package
+
+```bash
+cd apps/webhook-monitor
+pip install -e .
+```
+
+### 2. Set environment variables
+
+```bash
+export FORGE_WEBHOOK_SECRET="your-secret-here"    # Required
+export FORGE_WEBHOOK_PORT=8471                      # Optional, default 8471
+export FORGE_EVENTS_FILE="./events.jsonl"           # Optional
+export FORGE_WEBHOOK_REPO="owner/repo"              # Required for gh webhook forward
+```
+
+### 3. Start the server
+
+```bash
+forge-webhook
+```
+
+The server listens on `0.0.0.0:$FORGE_WEBHOOK_PORT` and exposes:
+- `POST /webhook` — receives GitHub webhook payloads
+- `GET /health` — health check
+
+## Tunnel Forwarding
+
+GitHub needs a public URL to deliver webhooks. Use the tunnel script to expose your local server.
+
+### Option A: `gh webhook forward` (recommended)
+
+```bash
+gh extension install cli/gh-webhook
+./tunnel.sh
+```
+
+This creates a temporary webhook on your repo automatically — no manual GitHub configuration needed.
+
+### Option B: ngrok
+
+```bash
+brew install ngrok  # or https://ngrok.com/download
+./tunnel.sh
+```
+
+ngrok prints a public URL. You must manually configure the webhook in GitHub (see below).
+
+## GitHub Webhook Configuration (ngrok only)
+
+When using ngrok, you need to manually add the webhook in your repo:
+
+1. Go to **Settings → Webhooks → Add webhook**
+2. **Payload URL**: `https://<ngrok-url>/webhook`
+3. **Content type**: `application/json`
+4. **Secret**: same value as `FORGE_WEBHOOK_SECRET`
+5. **Events**: Select individual events:
+   - Issues
+   - Pull requests
+   - Issue comments
+   - Pull request reviews
+6. Click **Add webhook**
+
+## Quick Start (dev mode)
+
+Start both the server and tunnel together:
+
+```bash
+./dev.sh
+```
+
+Press `Ctrl+C` to stop both processes.

--- a/apps/webhook-monitor/dev.sh
+++ b/apps/webhook-monitor/dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cleanup() {
+    echo "Shutting down..."
+    kill 0 2>/dev/null
+    wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# Start webhook server
+echo "Starting webhook server..."
+forge-webhook &
+SERVER_PID=$!
+
+# Give the server a moment to bind
+sleep 1
+
+# Start tunnel
+echo "Starting tunnel..."
+"$SCRIPT_DIR/tunnel.sh" &
+TUNNEL_PID=$!
+
+echo "Server PID: $SERVER_PID | Tunnel PID: $TUNNEL_PID"
+echo "Press Ctrl+C to stop both."
+
+wait

--- a/apps/webhook-monitor/tunnel.sh
+++ b/apps/webhook-monitor/tunnel.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${FORGE_WEBHOOK_PORT:-8471}"
+
+# Try gh webhook forward first (built into GitHub CLI)
+if command -v gh &>/dev/null && gh webhook forward --help &>/dev/null; then
+    echo "Using gh webhook forward → localhost:$PORT"
+    exec gh webhook forward \
+        --repo="${FORGE_WEBHOOK_REPO:?Set FORGE_WEBHOOK_REPO (owner/repo)}" \
+        --events="issues,pull_request,issue_comment,pull_request_review" \
+        --url="http://localhost:$PORT/webhook" \
+        --secret="${FORGE_WEBHOOK_SECRET:?Set FORGE_WEBHOOK_SECRET}"
+fi
+
+# Fall back to ngrok
+if command -v ngrok &>/dev/null; then
+    echo "Using ngrok → localhost:$PORT"
+    echo "Configure your GitHub webhook with the URL printed below + /webhook"
+    exec ngrok http "$PORT"
+fi
+
+echo "Error: No tunnel tool found." >&2
+echo "Install one of:" >&2
+echo "  gh extension install cli/gh-webhook" >&2
+echo "  brew install ngrok" >&2
+exit 1


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `tunnel.sh` — detects `gh webhook forward` (preferred) or falls back to `ngrok`
- Add `dev.sh` — starts webhook server and tunnel together with signal cleanup
- Add `README.md` — documents setup, tunnel options, GitHub webhook configuration

Closes #215

## Test plan
- [ ] Run `./tunnel.sh` with `gh webhook` extension installed — verify it starts forwarding
- [ ] Run `./tunnel.sh` with only ngrok — verify it starts ngrok
- [ ] Run `./tunnel.sh` with neither — verify error message with install instructions
- [ ] Run `./dev.sh` — verify both server and tunnel start, Ctrl+C stops both
- [ ] Review README for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
