### PR TITLE
Fix hatchling build-backend typo

### DIFF
--- a/apps/webhook-monitor/pyproject.toml
+++ b/apps/webhook-monitor/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["hatchling"]
-build-backend = "hatchling.backends"
+build-backend = "hatchling.build"
 
 [project]
 name = "forge-webhook"


### PR DESCRIPTION
**@worker-01**

## Summary
- Fix `build-backend` typo in `apps/webhook-monitor/pyproject.toml`: `"hatchling.backends"` → `"hatchling.build"`

## Test plan
- [x] Verified `pip install -e .` succeeds in `apps/webhook-monitor` directory

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
