### PR TITLE
Replace webhook monitor env vars with config.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ agent-kernel/cron/cron-state.json
 agent-kernel/logs/*
 !agent-kernel/logs/view.sh
 .claude
+apps/webhook-monitor/config.toml

--- a/apps/webhook-monitor/README.md
+++ b/apps/webhook-monitor/README.md
@@ -16,16 +16,40 @@ cd apps/webhook-monitor
 pip install -e .
 ```
 
-### 2. Set environment variables
+### 2. Configure
+
+Copy the example config and fill in your values:
 
 ```bash
-export FORGE_WEBHOOK_SECRET="<your-secret>"    # Required
-export FORGE_WEBHOOK_PORT=8471                  # Optional, default 8471
-export FORGE_EVENTS_FILE="./events.jsonl"       # Optional, default ./events.jsonl
-export FORGE_REPO="owner/repo"                  # Required for gh webhook forward
+cp config.example.toml config.toml
 ```
 
-Generate a secret with: `openssl rand -hex 32`
+Edit `config.toml`:
+
+```toml
+[webhook]
+secret = "your-secret-here"   # Required — generate with: openssl rand -hex 32
+port = 8471
+events_file = "./events.jsonl"
+
+[trigger]
+rules_file = "./trigger-rules.json"
+
+[repo]
+name = "owner/repo"           # Required for gh webhook forward
+dir = "/path/to/repo"         # Absolute path to repo root
+```
+
+Environment variables still override config file values for CI/deploy:
+
+| Env var | Overrides |
+|---------|-----------|
+| `FORGE_WEBHOOK_SECRET` | `webhook.secret` |
+| `FORGE_WEBHOOK_PORT` | `webhook.port` |
+| `FORGE_EVENTS_FILE` | `webhook.events_file` |
+| `FORGE_TRIGGER_RULES` | `trigger.rules_file` |
+| `FORGE_REPO_DIR` | `repo.dir` |
+| `FORGE_REPO` | `repo.name` (tunnel.sh only) |
 
 ### 3. Start the server
 
@@ -33,7 +57,7 @@ Generate a secret with: `openssl rand -hex 32`
 forge-webhook
 ```
 
-The server listens on `0.0.0.0:$FORGE_WEBHOOK_PORT` and exposes:
+The server listens on `0.0.0.0:<port>` and exposes:
 
 - `POST /webhook` — receives GitHub events
 - `GET /health` — health check
@@ -46,7 +70,7 @@ The server listens on `0.0.0.0:$FORGE_WEBHOOK_PORT` and exposes:
 
 The script tries `gh webhook forward` first, then falls back to `ngrok`.
 
-**With `gh webhook forward`**: The tunnel configures the webhook automatically — no manual GitHub setup needed. Requires `FORGE_REPO` to be set.
+**With `gh webhook forward`**: The tunnel configures the webhook automatically — no manual GitHub setup needed. Requires `repo.name` to be set in config.toml (or `FORGE_REPO` env var).
 
 **With `ngrok`**: Copy the public URL from ngrok's output and configure the webhook manually (see below).
 
@@ -55,7 +79,7 @@ The script tries `gh webhook forward` first, then falls back to `ngrok`.
 1. Go to your repo → **Settings** → **Webhooks** → **Add webhook**
 2. **Payload URL**: `<ngrok-url>/webhook`
 3. **Content type**: `application/json`
-4. **Secret**: The value of `FORGE_WEBHOOK_SECRET`
+4. **Secret**: The value of `webhook.secret` from your config
 5. **Events**: Select individual events:
    - Issues
    - Pull requests

--- a/apps/webhook-monitor/config.example.toml
+++ b/apps/webhook-monitor/config.example.toml
@@ -1,0 +1,11 @@
+[webhook]
+secret = ""           # Required — set this or use FORGE_WEBHOOK_SECRET env var
+port = 8471
+events_file = "./events.jsonl"
+
+[trigger]
+rules_file = "./trigger-rules.json"
+
+[repo]
+name = ""             # owner/repo — used by tunnel.sh for gh webhook forward
+dir = ""              # absolute path to repo root — used for agent triggering

--- a/apps/webhook-monitor/dev.sh
+++ b/apps/webhook-monitor/dev.sh
@@ -3,12 +3,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Validate required env vars
-if [ -z "${FORGE_WEBHOOK_SECRET:-}" ]; then
-    echo "Error: FORGE_WEBHOOK_SECRET must be set" >&2
-    exit 1
-fi
-
 cleanup() {
     echo "Shutting down..."
     kill 0 2>/dev/null

--- a/apps/webhook-monitor/src/forge_webhook/config.py
+++ b/apps/webhook-monitor/src/forge_webhook/config.py
@@ -1,17 +1,37 @@
 import os
 import sys
+import tomllib
+from pathlib import Path
+
+
+def _load_toml() -> dict:
+    """Load config.toml from working directory, then package directory as fallback."""
+    candidates = [
+        Path.cwd() / "config.toml",
+        Path(__file__).resolve().parent.parent.parent / "config.toml",
+    ]
+    for path in candidates:
+        if path.is_file():
+            with open(path, "rb") as f:
+                return tomllib.load(f)
+    return {}
 
 
 def get_config() -> dict:
-    secret = os.environ.get("FORGE_WEBHOOK_SECRET")
+    toml = _load_toml()
+    webhook = toml.get("webhook", {})
+    trigger = toml.get("trigger", {})
+    repo = toml.get("repo", {})
+
+    secret = os.environ.get("FORGE_WEBHOOK_SECRET") or webhook.get("secret") or ""
     if not secret:
-        print("Error: FORGE_WEBHOOK_SECRET environment variable is required", file=sys.stderr)
+        print("Error: webhook secret is required — set webhook.secret in config.toml or FORGE_WEBHOOK_SECRET env var", file=sys.stderr)
         sys.exit(1)
 
     return {
         "secret": secret,
-        "port": int(os.environ.get("FORGE_WEBHOOK_PORT", "8471")),
-        "events_file": os.environ.get("FORGE_EVENTS_FILE", "./events.jsonl"),
-        "trigger_rules_file": os.environ.get("FORGE_TRIGGER_RULES", ""),
-        "repo_dir": os.environ.get("FORGE_REPO_DIR", ""),
+        "port": int(os.environ.get("FORGE_WEBHOOK_PORT", "") or webhook.get("port", 8471)),
+        "events_file": os.environ.get("FORGE_EVENTS_FILE", "") or webhook.get("events_file", "./events.jsonl"),
+        "trigger_rules_file": os.environ.get("FORGE_TRIGGER_RULES", "") or trigger.get("rules_file", ""),
+        "repo_dir": os.environ.get("FORGE_REPO_DIR", "") or repo.get("dir", ""),
     }

--- a/apps/webhook-monitor/tunnel.sh
+++ b/apps/webhook-monitor/tunnel.sh
@@ -1,7 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 PORT="${FORGE_WEBHOOK_PORT:-8471}"
+
+# Read repo name from config.toml if FORGE_REPO is not set
+if [ -z "${FORGE_REPO:-}" ]; then
+    for cfg in "./config.toml" "$SCRIPT_DIR/config.toml"; do
+        if [ -f "$cfg" ]; then
+            FORGE_REPO="$(python3 -c "import tomllib; print(tomllib.load(open('$cfg','rb')).get('repo',{}).get('name',''))" 2>/dev/null)" || true
+            [ -n "$FORGE_REPO" ] && break
+        fi
+    done
+fi
+
+# Read secret from config.toml if FORGE_WEBHOOK_SECRET is not set
+if [ -z "${FORGE_WEBHOOK_SECRET:-}" ]; then
+    for cfg in "./config.toml" "$SCRIPT_DIR/config.toml"; do
+        if [ -f "$cfg" ]; then
+            FORGE_WEBHOOK_SECRET="$(python3 -c "import tomllib; print(tomllib.load(open('$cfg','rb')).get('webhook',{}).get('secret',''))" 2>/dev/null)" || true
+            [ -n "$FORGE_WEBHOOK_SECRET" ] && break
+        fi
+    done
+fi
 
 # Prefer gh webhook forward (built into GitHub CLI)
 if command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -q "webhook"; then


### PR DESCRIPTION
**@worker-01**

## Summary
- Replace environment-variable-only configuration in webhook monitor with `config.toml` file using Python stdlib `tomllib`
- Env vars still override config file values for backwards compatibility
- Simplify `dev.sh` by removing the `FORGE_WEBHOOK_SECRET` pre-check (server validates on startup)
- Update `tunnel.sh` to read `repo.name` and `webhook.secret` from `config.toml` as fallback

## Test plan
- [ ] Copy `config.example.toml` to `config.toml`, fill in secret and repo name, run `forge-webhook` — should start without env vars
- [ ] Set `FORGE_WEBHOOK_SECRET` env var with no config.toml — should still work (backwards compat)
- [ ] Set both env var and config.toml with different values — env var should win
- [ ] Run `./dev.sh` without pre-exporting `FORGE_WEBHOOK_SECRET` — should start if config.toml has the secret
- [ ] Run `./tunnel.sh` without `FORGE_REPO` env var — should read from config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
