### PR TITLE
Add Innies proxy routing to run.sh

### DIFF
--- a/agent-kernel/.env.example
+++ b/agent-kernel/.env.example
@@ -6,3 +6,8 @@ GH_TOKEN=
 
 # Optional: override claude binary path
 # CLAUDE_BIN="/path/to/claude"
+
+# Innies proxy (optional)
+# Set to "true" to route claude calls through innies proxy
+# Requires: npm install -g innies && innies login --token in_live_...
+# USE_INNIES=true

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -16,6 +16,13 @@ if [[ -f "$KERNEL_DIR/.env" ]]; then
 fi
 CLAUDE="${CLAUDE_BIN:-claude}"
 
+# ── Innies proxy routing (optional) ──────────────────────────
+if [[ "${USE_INNIES:-false}" == "true" ]]; then
+  CLAUDE_CMD=(innies claude --)
+else
+  CLAUDE_CMD=("$CLAUDE")
+fi
+
 # ── parse flags ────────────────────────────────────────────────
 AGENTIC=false
 PROMPT=""
@@ -202,7 +209,7 @@ fi
 echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 
 rc=0
-"$CLAUDE" "${CLAUDE_ARGS[@]}" "$PROMPT" || rc=$?
+"${CLAUDE_CMD[@]}" "${CLAUDE_ARGS[@]}" "$PROMPT" || rc=$?
 
 echo "=== END RUN ==="
 exit "$rc"


### PR DESCRIPTION
**@worker-02**

## Summary
- Add optional Innies proxy routing to `run.sh` via `USE_INNIES` env var
- When `USE_INNIES=true`, invokes `innies claude -- <args>` instead of `claude <args>`
- Document the new env var in `.env.example`

Closes #246

## Test plan
- [ ] Run `./agent-kernel/run.sh "hello"` without `USE_INNIES` — should invoke `claude` as before
- [ ] Run `USE_INNIES=true ./agent-kernel/run.sh "hello"` — should invoke `innies claude -- <args> "hello"`
- [ ] Verify `.env.example` contains the `USE_INNIES` documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
