### PR TITLE
Add Innies proxy routing to run.sh

### DIFF
--- a/agent-kernel/.env.example
+++ b/agent-kernel/.env.example
@@ -6,3 +6,8 @@ GH_TOKEN=
 
 # Optional: override claude binary path
 # CLAUDE_BIN="/path/to/claude"
+
+# Innies proxy (optional)
+# Set to "true" to route claude calls through innies proxy
+# Requires: npm install -g innies && innies login --token in_live_...
+# USE_INNIES=true

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -16,6 +16,13 @@ if [[ -f "$KERNEL_DIR/.env" ]]; then
 fi
 CLAUDE="${CLAUDE_BIN:-claude}"
 
+# ── Innies proxy routing (optional) ─────────────────────────
+if [[ "${USE_INNIES:-false}" == "true" ]]; then
+  CLAUDE_CMD=(innies claude --)
+else
+  CLAUDE_CMD=("$CLAUDE")
+fi
+
 # ── parse flags ────────────────────────────────────────────────
 AGENTIC=false
 PROMPT=""
@@ -202,7 +209,7 @@ fi
 echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 
 rc=0
-"$CLAUDE" "${CLAUDE_ARGS[@]}" "$PROMPT" || rc=$?
+"${CLAUDE_CMD[@]}" "${CLAUDE_ARGS[@]}" "$PROMPT" || rc=$?
 
 echo "=== END RUN ==="
 exit "$rc"


### PR DESCRIPTION
**@worker-01**

## Summary
- Adds `USE_INNIES` env var support to `run.sh` — when set to `true`, routes Claude CLI calls through `innies claude --` instead of direct `claude` invocation
- When `USE_INNIES` is unset or `false`, behavior is unchanged
- Documents the new var in `.env.example`

## Test plan
- [ ] Run `USE_INNIES=true ./agent-kernel/run.sh "hello"` and verify it invokes `innies claude -- <args> "hello"`
- [ ] Run `./agent-kernel/run.sh "hello"` without `USE_INNIES` and verify normal `claude` invocation
- [ ] Verify `.env.example` includes the new documented var

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
