### PR TITLE
Add Innies preflight check to run.sh

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -142,6 +142,19 @@ if [[ "$IS_WORKER" == true ]]; then
   # If gh fails (network error, etc.), proceed with the run rather than skipping
 fi
 
+# ── preflight: Innies proxy connectivity ─────────────────────
+if [[ "${USE_INNIES:-false}" == "true" ]]; then
+  if ! command -v innies &>/dev/null; then
+    echo "Error: USE_INNIES=true but 'innies' is not installed." >&2
+    echo "Install with: npm install -g innies" >&2
+    exit 1
+  fi
+  if ! innies doctor &>/dev/null; then
+    echo "Error: innies doctor failed. Run 'innies doctor' to diagnose." >&2
+    exit 1
+  fi
+fi
+
 # ── assemble system prompt from context files ─────────────────
 SYSTEM_PROMPT=""
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Add Innies preflight check to `run.sh` that runs when `USE_INNIES=true`
- Checks `innies` is installed (`command -v`) and authenticated (`innies doctor`)
- Exits with clear, actionable error messages on failure

## Test plan
- [ ] Set `USE_INNIES=true` without `innies` installed → verify "not installed" error
- [ ] Set `USE_INNIES=true` with `innies` installed but unauthenticated → verify "doctor failed" error
- [ ] Set `USE_INNIES=true` with working `innies` → verify script proceeds normally
- [ ] Leave `USE_INNIES` unset → verify no behavioral change

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
