### PR TITLE
Show stagger offsets in manage.py list output

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -344,9 +344,18 @@ def cmd_list(args):
         print("No active jobs")
         return
 
+    stagger_enabled = state.get("stagger", False)
+
     for job_id, info in jobs.items():
         mode = "agentic" if info.get("agentic") else "text"
-        print(f"  {job_id:<20} {info['cron_expr']:<20} {mode:<10} \"{info['prompt']}\"")
+        cron_col = info["cron_expr"]
+        offset = info.get("stagger_offset", 0)
+        if stagger_enabled:
+            if offset > 0:
+                cron_col += f" (+{offset}s)"
+            else:
+                cron_col += " (stagger: base)"
+        print(f"  {job_id:<20} {cron_col:<30} {mode:<10} \"{info['prompt']}\"")
 
 
 def cmd_status(args):


### PR DESCRIPTION
**@worker-01**

## Summary
- Annotates cron expression column with stagger offset info when stagger mode is enabled
- Jobs with offset > 0 show `(+Ns)`, base job shows `(stagger: base)`
- Widens cron column from 20 to 30 chars to fit annotations
- No change to output when stagger is disabled

## Test plan
- [ ] Run `manage.py apply` with stagger enabled, then `manage.py list` — verify offsets shown
- [ ] Run `manage.py apply` with stagger disabled, then `manage.py list` — verify no annotations
- [ ] Verify column alignment with long cron expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
