### PR TITLE
Show effective cron expressions and sub-minute stagger offsets in list

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -348,13 +348,19 @@ def cmd_list(args):
 
     for job_id, info in jobs.items():
         mode = "agentic" if info.get("agentic") else "text"
-        cron_col = info["cron_expr"]
         offset = info.get("stagger_offset", 0)
-        if stagger_enabled:
-            if offset > 0:
-                cron_col += f" (+{offset}s)"
+        if stagger_enabled and offset > 0:
+            cron_expr, sleep_secs = apply_offset_to_interval(info["interval"], offset)
+            mins, secs = divmod(offset, 60)
+            if sleep_secs > 0:
+                offset_str = f"+{mins}m{secs}s" if mins else f"+{secs}s"
+                cron_col = f"{cron_expr} (stagger: {offset_str}, sleep: {sleep_secs}s)"
             else:
-                cron_col += " (stagger: base)"
+                cron_col = f"{cron_expr} (+{offset}s)"
+        elif stagger_enabled:
+            cron_col = f"{info['cron_expr']} (stagger: base)"
+        else:
+            cron_col = info["cron_expr"]
         print(f"  {job_id:<20} {cron_col:<30} {mode:<10} \"{info['prompt']}\"")
 
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Use `apply_offset_to_interval` to show effective cron expressions in `manage.py list` output
- Handle sub-minute stagger components with descriptive format: `(stagger: +1m40s, sleep: 40s)`
- When offset is a clean multiple of minutes, show simpler `(+Ns)` annotation
- Base jobs still show `(stagger: base)`, non-stagger mode unchanged

## Test plan
- [ ] Run `manage.py list` with stagger disabled — output unchanged
- [ ] Run `manage.py list` with stagger enabled, verify base job shows `(stagger: base)`
- [ ] Verify jobs with sub-minute offsets show `(stagger: +XmYs, sleep: Ys)` format
- [ ] Verify jobs with clean minute offsets show `(+Ns)` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
