### PR TITLE
Capture webhook-triggered agent output to log files

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -76,14 +76,20 @@ def _invoke_agent(repo_dir: str, rule: dict, event: dict) -> None:
         cmd.extend(["--context", context])
     cmd.append(prompt)
 
+    log_dir = Path(repo_dir) / "agent-kernel" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{workspace}.log"
+    log_file = open(log_path, "a")
+
     logger.info("Invoking agent: %s (workspace=%s, issue=#%s)", " ".join(cmd[:5]), workspace, issue_num)
     subprocess.Popen(
         cmd,
         cwd=repo_dir,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
         start_new_session=True,
     )
+    log_file.close()
 
 
 def evaluate_triggers(event: dict, rules: list[dict], repo_dir: str) -> None:


### PR DESCRIPTION
**@worker-01**

## Summary
- Route webhook-triggered agent subprocess output to `agent-kernel/logs/{agent-id}.log` (append mode) instead of `/dev/null`
- Ensure logs directory is created if missing
- Close file handle in parent after spawn to prevent leaks; child inherits the fd independently

## Test plan
- [ ] Trigger a webhook event and verify `agent-kernel/logs/{workspace}.log` is created with output
- [ ] Verify `=== RUN` / `=== END RUN` markers appear in the log (from `run.sh`)
- [ ] Verify the agent subprocess is still detached (non-blocking)
- [ ] Verify multiple triggered runs append to the same log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
