### PR TITLE
Add lock-file-based agent activity indicators to StatusPanel

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -62,6 +62,28 @@ def _format_delta(delta: timedelta) -> str:
     return f"{secs}s"
 
 
+def _is_agent_running(repo_root: Path, agent_id: str, repo: str) -> bool:
+    """Check if an agent is currently running by inspecting its lock file.
+
+    Returns True only if the lock file exists and the PID inside is alive.
+    """
+    if repo and repo.startswith("github.com/"):
+        worktree_base = repo_root / ".repos" / repo
+    else:
+        worktree_base = repo_root
+
+    lockfile = worktree_base / ".worktrees" / agent_id / ".agent.lock"
+    if not lockfile.exists():
+        return False
+
+    try:
+        pid = int(lockfile.read_text().strip())
+        os.kill(pid, 0)
+        return True
+    except (ValueError, OSError):
+        return False
+
+
 def _load_agents(repo_root: Path) -> list[dict]:
     """Load agent info from cron-jobs.json merged with cron-state.json."""
     cron_dir = repo_root / "agent-kernel" / "cron"
@@ -113,6 +135,8 @@ def _load_agents(repo_root: Path) -> list[dict]:
             since = "no data"
             until = "—"
 
+        running = _is_agent_running(repo_root, agent_id, repo)
+
         agents.append({
             "id": agent_id,
             "role": role,
@@ -120,6 +144,7 @@ def _load_agents(repo_root: Path) -> list[dict]:
             "interval": interval,
             "since": since,
             "until": until,
+            "running": running,
         })
 
     return agents
@@ -154,8 +179,9 @@ class StatusPanel(Widget):
 
         lines: list[str] = []
         for a in agents:
+            status = "  [bold green]\\[RUNNING][/bold green]" if a["running"] else ""
             lines.append(
-                f"[bold]{a['id']}[/bold]  ({a['role']})\n"
+                f"[bold]{a['id']}[/bold]  ({a['role']}){status}\n"
                 f"  repo: {a['repo']}  interval: {a['interval']}\n"
                 f"  last run: {a['since']} ago  next: {a['until']}"
             )


### PR DESCRIPTION
**@worker-02**

## Summary
- Add lock-file-based run detection to `StatusPanel` in the Forge CLI
- Check `.agent.lock` files during each 5-second poll tick to detect actively running agents
- Display `[RUNNING]` indicator in green next to agents with a live PID in their lock file
- Handle stale lock files gracefully (dead PIDs are treated as not running)

Closes #237

## Test plan
- [ ] Start an agent run manually (`python3 agent-kernel/cron/manage.py run worker-01`) and verify `[RUNNING]` appears in the StatusPanel
- [ ] Verify indicator disappears after the agent run completes and the lock file is cleaned up
- [ ] Create a stale lock file with a dead PID and verify it does NOT show `[RUNNING]`
- [ ] Verify agents without lock files show no indicator (current behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
