### PR TITLE
Structured streaming: stream-json output format for LLMClient

### DIFF
--- a/apps/cli/src/forge/chat.py
+++ b/apps/cli/src/forge/chat.py
@@ -6,10 +6,10 @@ from typing import Iterator
 
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
-from textual.widgets import Input, Markdown, Static
+from textual.widgets import Collapsible, Input, Markdown, Static
 from textual.widget import Widget
 
-from forge.llm import LLMClient
+from forge.llm import LLMClient, StreamChunk
 
 
 class UserMessage(Static):
@@ -19,6 +19,33 @@ class UserMessage(Static):
 
     def __init__(self, text: str) -> None:
         super().__init__(f"> {text}", classes="user-message")
+
+
+class ThinkingBlock(Static):
+    """A thinking block rendered with dimmed italic styling."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, text: str = "") -> None:
+        super().__init__(text, classes="thinking-block")
+
+
+class ToolCallBlock(Collapsible):
+    """A collapsible block showing a tool call name and input."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, tool_name: str, tool_input: str = "") -> None:
+        self._tool_input_widget = Static(tool_input, classes="tool-input")
+        super().__init__(
+            self._tool_input_widget,
+            title=f"Tool: {tool_name}",
+            classes="tool-call-block",
+            collapsed=True,
+        )
+
+    def update_input(self, text: str) -> None:
+        self._tool_input_widget.update(text)
 
 
 class AssistantMessage(Markdown):
@@ -74,30 +101,68 @@ class ChatPane(Widget):
             history.scroll_end(animate=False)
             return
 
-        response_widget = AssistantMessage()
-        history.mount(response_widget)
-        history.scroll_end(animate=False)
-
-        collected: list[str] = []
-
-        def _run_stream(llm: LLMClient, message: str) -> Iterator[str]:
-            return llm.stream_response(message)
-
         loop = asyncio.get_running_loop()
         stream = await loop.run_in_executor(
-            None, partial(_run_stream, self._llm, text)
+            None, partial(self._llm.stream_response, text)
         )
 
-        def _next_chunk(it: Iterator[str]) -> str | None:
+        def _next_chunk(it: Iterator[StreamChunk]) -> StreamChunk | None:
             return next(it, None)
+
+        text_parts: list[str] = []
+        thinking_parts: list[str] = []
+        tool_input_parts: list[str] = []
+        text_widget: AssistantMessage | None = None
+        thinking_widget: ThinkingBlock | None = None
+        current_tool: ToolCallBlock | None = None
+        has_content = False
 
         while True:
             chunk = await loop.run_in_executor(None, _next_chunk, stream)
             if chunk is None:
                 break
-            collected.append(chunk)
-            response_widget.update("".join(collected))
+
+            if chunk.type == "thinking":
+                has_content = True
+                if thinking_widget is None:
+                    thinking_widget = ThinkingBlock()
+                    await history.mount(thinking_widget)
+                thinking_parts.append(chunk.content)
+                thinking_widget.update("".join(thinking_parts))
+
+            elif chunk.type == "text":
+                has_content = True
+                if text_widget is None:
+                    thinking_widget = None
+                    thinking_parts.clear()
+                    text_widget = AssistantMessage()
+                    await history.mount(text_widget)
+                text_parts.append(chunk.content)
+                text_widget.update("".join(text_parts))
+
+            elif chunk.type == "tool_use":
+                has_content = True
+                if chunk.tool_name:
+                    text_widget = None
+                    text_parts.clear()
+                    thinking_widget = None
+                    thinking_parts.clear()
+                    tool_input_parts.clear()
+                    current_tool = ToolCallBlock(chunk.tool_name)
+                    await history.mount(current_tool)
+                elif chunk.tool_input and current_tool is not None:
+                    tool_input_parts.append(chunk.tool_input)
+                    current_tool.update_input("".join(tool_input_parts))
+
+            elif chunk.type == "error":
+                has_content = True
+                await history.mount(SystemMessage(chunk.content))
+
+            elif chunk.type == "result":
+                has_content = True
+
             history.scroll_end(animate=False)
 
-        if not collected:
-            response_widget.update("*(no response)*")
+        if not has_content:
+            await history.mount(AssistantMessage("*(no response)*"))
+            history.scroll_end(animate=False)

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -61,6 +61,32 @@ ChatPane {
     text-style: italic;
 }
 
+.thinking-block {
+    height: auto;
+    margin-bottom: 1;
+    padding: 0 1;
+    color: #808090;
+    text-style: italic;
+}
+
+.tool-call-block {
+    height: auto;
+    margin-bottom: 1;
+    padding: 0 1;
+    color: #808090;
+}
+
+.tool-call-block > CollapsibleTitle {
+    color: #b090e0;
+    text-style: bold;
+}
+
+.tool-input {
+    height: auto;
+    padding: 0 1;
+    color: #606070;
+}
+
 StatusPanel {
     width: 1fr;
     height: 1fr;

--- a/apps/cli/src/forge/llm.py
+++ b/apps/cli/src/forge/llm.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 
@@ -34,6 +36,61 @@ SYSTEM_PROMPT = (
 )
 
 
+@dataclass
+class StreamChunk:
+    """A structured chunk from the Claude CLI stream-json output."""
+
+    type: str  # "text", "tool_use", "thinking", "result", "error"
+    content: str
+    tool_name: str = ""
+    tool_input: str = ""
+
+
+def _parse_stream_event(data: dict) -> StreamChunk | None:
+    """Parse a single stream-json event into a StreamChunk."""
+    event_type = data.get("type", "")
+
+    if event_type == "content_block_start":
+        block = data.get("content_block", {})
+        block_type = block.get("type", "")
+        if block_type == "tool_use":
+            return StreamChunk(
+                type="tool_use",
+                content="",
+                tool_name=block.get("name", "unknown"),
+            )
+        if block_type == "thinking":
+            return StreamChunk(type="thinking", content=block.get("thinking", ""))
+        if block_type == "text":
+            return StreamChunk(type="text", content=block.get("text", ""))
+        return None
+
+    if event_type == "content_block_delta":
+        delta = data.get("delta", {})
+        delta_type = delta.get("type", "")
+        if delta_type == "text_delta":
+            return StreamChunk(type="text", content=delta.get("text", ""))
+        if delta_type == "thinking_delta":
+            return StreamChunk(type="thinking", content=delta.get("thinking", ""))
+        if delta_type == "input_json_delta":
+            return StreamChunk(
+                type="tool_use",
+                content="",
+                tool_input=delta.get("partial_json", ""),
+            )
+        return None
+
+    if event_type == "result":
+        return StreamChunk(type="result", content=data.get("result", ""))
+
+    if event_type == "error":
+        err = data.get("error", {})
+        msg = err.get("message", "") if isinstance(err, dict) else str(err)
+        return StreamChunk(type="error", content=msg)
+
+    return None
+
+
 class LLMClient:
     def __init__(self) -> None:
         if not shutil.which("claude"):
@@ -49,8 +106,8 @@ class LLMClient:
                 "ANTHROPIC_API_KEY to use the Forge chat interface."
             )
 
-    def stream_response(self, user_text: str) -> Iterator[str]:
-        """Spawn claude CLI and yield stdout lines as they arrive.
+    def stream_response(self, user_text: str) -> Iterator[StreamChunk]:
+        """Spawn claude CLI with stream-json output and yield structured chunks.
 
         Runs the subprocess in the calling thread. The caller (chat.py)
         is responsible for running this in a worker thread so the TUI
@@ -58,7 +115,7 @@ class LLMClient:
         """
         cmd = [
             "claude",
-            "--print",
+            "--output-format", "stream-json",
             "--dangerously-skip-permissions",
         ]
 
@@ -76,7 +133,17 @@ class LLMClient:
 
         try:
             for line in iter(proc.stdout.readline, ""):
-                yield line
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    yield StreamChunk(type="error", content=f"Malformed JSON: {line}")
+                    continue
+                chunk = _parse_stream_event(data)
+                if chunk is not None:
+                    yield chunk
         finally:
             proc.stdout.close()
             proc.wait()
@@ -85,6 +152,6 @@ class LLMClient:
             stderr = proc.stderr.read().strip()
             proc.stderr.close()
             if stderr:
-                yield f"\n[error] Claude CLI failed: {stderr}"
+                yield StreamChunk(type="error", content=f"Claude CLI failed: {stderr}")
         else:
             proc.stderr.close()


### PR DESCRIPTION
**@worker-01**

## Summary
- Replace `--print` flag with `--output-format stream-json` in LLMClient for structured streaming output
- Parse JSON stream into typed `StreamChunk` dataclasses (`text`, `tool_use`, `thinking`, `result`, `error`)
- Render tool calls as collapsible blocks with tool name and streamed input
- Render thinking tokens with dimmed italic styling
- Add graceful error handling for malformed JSON lines and subprocess failures

## Test plan
- [ ] Run Forge TUI and send a chat message — verify text streams incrementally
- [ ] Trigger a tool-using response — verify collapsible tool call block appears with name and input
- [ ] Verify thinking tokens (if model returns them) display with italic/dimmed styling
- [ ] Send malformed input to verify error messages display gracefully
- [ ] Verify subprocess failures surface as system messages

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
