### PR TITLE
Add live agent log panel with tabbed agent selector

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -1,8 +1,10 @@
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Static
 
 from forge.chat import ChatPane
+from forge.log_panel import LogPanel
 from forge.status_panel import StatusPanel
 
 
@@ -11,12 +13,24 @@ class ForgeApp(App):
 
     CSS_PATH = "layout.tcss"
     TITLE = "Forge"
+    BINDINGS = [
+        Binding("l", "toggle_logs", "Toggle Logs"),
+    ]
 
     def compose(self) -> ComposeResult:
         yield Static(" Forge — Agent Orchestration", id="header-bar")
         with Horizontal(id="main"):
-            yield ChatPane()
+            with Vertical(id="left-col"):
+                yield ChatPane()
+                yield LogPanel()
             yield StatusPanel()
+
+    def on_mount(self) -> None:
+        self.query_one(LogPanel).display = False
+
+    def action_toggle_logs(self) -> None:
+        log_panel = self.query_one(LogPanel)
+        log_panel.display = not log_panel.display
 
 
 def main() -> None:

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -18,10 +18,14 @@ Screen {
     height: 1fr;
 }
 
-ChatPane {
+#left-col {
     width: 3fr;
     height: 1fr;
     border-right: solid #3a3a5c;
+}
+
+ChatPane {
+    height: 1fr;
 }
 
 #chat-history {
@@ -106,5 +110,43 @@ StatusPanel {
 #status-content {
     height: auto;
     padding: 0 1;
+    color: #808090;
+}
+
+/* Log Panel */
+
+LogPanel {
+    height: 1fr;
+    max-height: 50%;
+    border-top: solid #3a3a5c;
+    background: #16162a;
+}
+
+LogPanel TabbedContent {
+    height: 1fr;
+}
+
+LogPanel ContentSwitcher {
+    height: 1fr;
+}
+
+LogPanel TabPane {
+    height: 1fr;
+    padding: 0;
+}
+
+_LogView {
+    height: 1fr;
+}
+
+_LogView VerticalScroll {
+    height: 1fr;
+    background: #1a1a2e;
+    padding: 0 1;
+}
+
+#log-empty {
+    height: auto;
+    padding: 1;
     color: #808090;
 }

--- a/apps/cli/src/forge/log_panel.py
+++ b/apps/cli/src/forge/log_panel.py
@@ -1,0 +1,152 @@
+"""Live agent log panel — real-time tailing of agent log files."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static, TabbedContent, TabPane
+
+POLL_INTERVAL = 2
+MAX_LINES = 500
+RUN_SEPARATOR = "─" * 40
+
+
+def _find_repo_root() -> Path:
+    env_root = os.environ.get("FORGE_REPO_ROOT")
+    if env_root:
+        return Path(env_root)
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def _load_agent_ids(repo_root: Path) -> list[str]:
+    jobs_path = repo_root / "agent-kernel" / "cron" / "cron-jobs.json"
+    if not jobs_path.exists():
+        return []
+    try:
+        with open(jobs_path) as f:
+            config = json.load(f)
+        return [
+            job["id"]
+            for job in config.get("jobs", [])
+            if job.get("enabled", True)
+        ]
+    except (json.JSONDecodeError, KeyError, OSError):
+        return []
+
+
+def _format_log_content(raw: str) -> str:
+    """Apply visual separators for run markers."""
+    lines = raw.splitlines()
+    if len(lines) > MAX_LINES:
+        lines = lines[-MAX_LINES:]
+    formatted = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("=== RUN ") or stripped.startswith("=== END RUN"):
+            formatted.append(f"[bold cyan]{RUN_SEPARATOR}[/bold cyan]")
+            formatted.append(f"[bold cyan]{stripped}[/bold cyan]")
+            formatted.append(f"[bold cyan]{RUN_SEPARATOR}[/bold cyan]")
+        else:
+            formatted.append(line)
+    return "\n".join(formatted)
+
+
+class _LogView(Widget):
+    """Scrollable log view for a single agent."""
+
+    tick_count = reactive(0)
+
+    def __init__(self, agent_id: str, log_path: Path, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._agent_id = agent_id
+        self._log_path = log_path
+        self._last_size = 0
+        self._auto_scroll = True
+
+    def compose(self) -> ComposeResult:
+        yield VerticalScroll(
+            Static("Waiting for logs...", id=f"log-text-{self._agent_id}"),
+            id=f"log-scroll-{self._agent_id}",
+        )
+
+    def on_mount(self) -> None:
+        self._refresh_log()
+        self.set_interval(POLL_INTERVAL, self._tick)
+
+    def _tick(self) -> None:
+        self.tick_count += 1
+
+    def watch_tick_count(self) -> None:
+        self._refresh_log()
+
+    def _refresh_log(self) -> None:
+        if not self._log_path.exists():
+            return
+
+        try:
+            size = self._log_path.stat().st_size
+        except OSError:
+            return
+
+        if size == self._last_size:
+            return
+        self._last_size = size
+
+        try:
+            raw = self._log_path.read_text(errors="replace")
+        except OSError:
+            return
+
+        content = _format_log_content(raw)
+        text_widget = self.query_one(f"#log-text-{self._agent_id}", Static)
+        text_widget.update(content)
+
+        if self._auto_scroll:
+            scroll = self.query_one(f"#log-scroll-{self._agent_id}", VerticalScroll)
+            scroll.scroll_end(animate=False)
+
+    def on_vertical_scroll_scroll_up(self) -> None:
+        self._auto_scroll = False
+
+    def on_vertical_scroll_scroll_down(self) -> None:
+        scroll = self.query_one(f"#log-scroll-{self._agent_id}", VerticalScroll)
+        if scroll.scroll_offset.y >= scroll.max_scroll_y:
+            self._auto_scroll = True
+
+
+class LogPanel(Widget):
+    """Tabbed log panel showing real-time agent output."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._repo_root = _find_repo_root()
+
+    def compose(self) -> ComposeResult:
+        agent_ids = _load_agent_ids(self._repo_root)
+        logs_dir = self._repo_root / "agent-kernel" / "logs"
+
+        if not agent_ids:
+            yield Static("No agents configured.", id="log-empty")
+            return
+
+        with TabbedContent():
+            for agent_id in agent_ids:
+                log_path = logs_dir / f"{agent_id}.log"
+                with TabPane(agent_id, id=f"tab-{agent_id}"):
+                    yield _LogView(agent_id, log_path)


### PR DESCRIPTION
**@worker-01**

## Summary
- New `LogPanel` widget in `apps/cli/src/forge/log_panel.py` with tabbed agent log viewer
- Polls log files at `agent-kernel/logs/{agent-id}.log` every 2 seconds for new content
- Agent selector via `TabbedContent` — one tab per enabled agent from `cron-jobs.json`
- Auto-scrolls to bottom; scrolling up pauses auto-scroll, scrolling back to bottom resumes it
- `=== RUN <timestamp> ===` and `=== END RUN ===` markers rendered as bold cyan visual separators
- Integrated into `ForgeApp` as a toggleable bottom panel below `ChatPane` (press `l` to toggle)
- Hidden by default; max height capped at 50% of the left column

Closes #238

## Test plan
- [ ] Run `forge` CLI and press `l` to toggle log panel visibility
- [ ] Verify agent tabs appear for each enabled agent in `cron-jobs.json`
- [ ] Write test content to `agent-kernel/logs/<agent-id>.log` and verify it appears within 2 seconds
- [ ] Verify run markers (`=== RUN ... ===`) are visually distinct
- [ ] Scroll up in the log view and verify auto-scroll pauses
- [ ] Scroll back to bottom and verify auto-scroll resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
