### PR TITLE
Fix: add --verbose flag for stream-json output

### DIFF
--- a/apps/cli/src/forge/llm.py
+++ b/apps/cli/src/forge/llm.py
@@ -116,6 +116,7 @@ class LLMClient:
         cmd = [
             "claude",
             "--output-format", "stream-json",
+            "--verbose",
             "--dangerously-skip-permissions",
         ]
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `--verbose` flag to the Claude CLI command in `llm.py` alongside `--output-format stream-json`, fixing the error reported by @ADMIN on PR #270

## Test plan
- [ ] Run `forge` and verify the Claude CLI subprocess starts without the `--verbose` error

Fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
