### PR TITLE
Add --verbose flag to stream-json CLI invocation

### DIFF
--- a/apps/cli/src/forge/llm.py
+++ b/apps/cli/src/forge/llm.py
@@ -116,6 +116,7 @@ class LLMClient:
         cmd = [
             "claude",
             "--output-format", "stream-json",
+            "--verbose",
             "--dangerously-skip-permissions",
         ]
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Add missing `--verbose` flag to the `claude` CLI invocation in `llm.py`, fixing the error: `When using --print, --output-format=stream-json requires --verbose`

## Test plan
- [ ] Verify `python3 -m py_compile apps/cli/src/forge/llm.py` passes
- [ ] Verify no `--print` flag remains in `apps/cli/src/forge/`
- [ ] Verify `claude` CLI stream-json mode works with `--verbose` flag

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
