### PR TITLE
Add 1-second countdown refresh with progress bars

### DIFF
--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -107,10 +107,40 @@ StatusPanel {
     margin-bottom: 1;
 }
 
-#status-content {
+#status-agents {
+    height: 1fr;
+    padding: 0;
+}
+
+.agent-card {
     height: auto;
+    margin-bottom: 1;
     padding: 0 1;
+}
+
+.agent-info {
+    height: auto;
     color: #808090;
+}
+
+.agent-countdown {
+    height: auto;
+    color: #b090e0;
+    margin-top: 0;
+}
+
+.agent-progress {
+    height: 1;
+    margin: 0 1;
+}
+
+.agent-progress Bar {
+    color: #6c3fc5;
+    background: #3a3a5c;
+}
+
+.agent-progress PercentageStatus {
+    display: none;
 }
 
 /* Log Panel */

--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -10,9 +10,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from textual.app import ComposeResult
+from textual.containers import VerticalScroll
 from textual.reactive import reactive
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import ProgressBar, Static
 
 
 def _find_repo_root() -> Path:
@@ -118,6 +119,7 @@ def _load_agents(repo_root: Path) -> list[dict]:
         job_state = state.get(agent_id, {})
         last_run_iso = job_state.get("last_run")
 
+        progress = 0.0
         if last_run_iso:
             try:
                 last_dt = datetime.fromisoformat(last_run_iso)
@@ -126,6 +128,8 @@ def _load_agents(repo_root: Path) -> list[dict]:
                 if secs:
                     next_dt = last_dt + timedelta(seconds=secs)
                     until = _format_delta(next_dt - now)
+                    elapsed = (now - last_dt).total_seconds()
+                    progress = min(elapsed / secs, 1.0)
                 else:
                     until = "—"
             except (ValueError, TypeError):
@@ -145,9 +149,38 @@ def _load_agents(repo_root: Path) -> list[dict]:
             "since": since,
             "until": until,
             "running": running,
+            "progress": progress,
         })
 
     return agents
+
+
+class _AgentCard(Widget):
+    """A single agent's status card with progress bar."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, agent: dict, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._agent = agent
+
+    def compose(self) -> ComposeResult:
+        a = self._agent
+        status = "  [bold green]\\[RUNNING][/bold green]" if a["running"] else ""
+        yield Static(
+            f"[bold]{a['id']}[/bold]  ({a['role']}){status}\n"
+            f"  repo: {a['repo']}  interval: {a['interval']}\n"
+            f"  last run: {a['since']} ago  next: {a['until']}",
+            classes="agent-info",
+        )
+        pct = int(a["progress"] * 100)
+        yield Static(
+            f"  {a['until']}  {pct}%",
+            classes="agent-countdown",
+        )
+        bar = ProgressBar(total=100, show_eta=False, show_percentage=False, classes="agent-progress")
+        bar.advance(pct)
+        yield bar
 
 
 class StatusPanel(Widget):
@@ -157,12 +190,12 @@ class StatusPanel(Widget):
 
     def compose(self) -> ComposeResult:
         yield Static("Agent Status", id="status-header")
-        yield Static("Loading...", id="status-content")
+        yield VerticalScroll(id="status-agents")
 
     def on_mount(self) -> None:
         self._repo_root = _find_repo_root()
         self._refresh_display()
-        self.set_interval(5, self._tick)
+        self.set_interval(1, self._tick)
 
     def _tick(self) -> None:
         self.tick_count += 1
@@ -172,17 +205,12 @@ class StatusPanel(Widget):
 
     def _refresh_display(self) -> None:
         agents = _load_agents(self._repo_root)
-        content = self.query_one("#status-content", Static)
+        container = self.query_one("#status-agents", VerticalScroll)
+        container.remove_children()
+
         if not agents:
-            content.update("No agents configured.")
+            container.mount(Static("No agents configured.", classes="agent-info"))
             return
 
-        lines: list[str] = []
         for a in agents:
-            status = "  [bold green]\\[RUNNING][/bold green]" if a["running"] else ""
-            lines.append(
-                f"[bold]{a['id']}[/bold]  ({a['role']}){status}\n"
-                f"  repo: {a['repo']}  interval: {a['interval']}\n"
-                f"  last run: {a['since']} ago  next: {a['until']}"
-            )
-        content.update("\n\n".join(lines))
+            container.mount(_AgentCard(a, classes="agent-card"))


### PR DESCRIPTION
**@worker-01**

## Summary
- StatusPanel refresh interval changed from 5s to 1s for live countdown feel
- Added `progress` field (float 0.0–1.0) to `_load_agents()` representing elapsed fraction of interval
- Replaced flat `Static` text rendering with per-agent `_AgentCard` widgets containing a Textual `ProgressBar`
- Countdown text and percentage displayed alongside progress bar (e.g., `2m 15s  45%`)
- Progress bar styled with purple accent (`#6c3fc5`) fill and dark track (`#3a3a5c`)

## Test plan
- [ ] Launch CLI and verify StatusPanel ticks every 1 second
- [ ] Verify each agent shows a progress bar filling from 0% to 100%
- [ ] Verify countdown text appears alongside the progress bar
- [ ] Verify purple accent color scheme on progress bars

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
