### PR TITLE
Add agent state indicators: running, idle, overdue

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -137,6 +137,13 @@ def _load_agents(repo_root: Path) -> list[dict]:
 
         running = _is_agent_running(repo_root, agent_id, repo)
 
+        if running:
+            agent_state = "running"
+        elif until == "overdue":
+            agent_state = "overdue"
+        else:
+            agent_state = "idle"
+
         agents.append({
             "id": agent_id,
             "role": role,
@@ -145,6 +152,7 @@ def _load_agents(repo_root: Path) -> list[dict]:
             "since": since,
             "until": until,
             "running": running,
+            "state": agent_state,
         })
 
     return agents
@@ -177,11 +185,17 @@ class StatusPanel(Widget):
             content.update("No agents configured.")
             return
 
+        state_markup = {
+            "running": "[bold green]● RUNNING[/bold green]",
+            "overdue": "[bold red]● OVERDUE[/bold red]",
+            "idle": "[dim]○ idle[/dim]",
+        }
+
         lines: list[str] = []
         for a in agents:
-            status = "  [bold green]\\[RUNNING][/bold green]" if a["running"] else ""
+            indicator = state_markup.get(a["state"], "[dim]○ idle[/dim]")
             lines.append(
-                f"[bold]{a['id']}[/bold]  ({a['role']}){status}\n"
+                f"{indicator}  [bold]{a['id']}[/bold]  ({a['role']})\n"
                 f"  repo: {a['repo']}  interval: {a['interval']}\n"
                 f"  last run: {a['since']} ago  next: {a['until']}"
             )


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `state` field ("running", "overdue", "idle") to each agent in `_load_agents()`, derived from lock file PID check and countdown timer
- Render color-coded Rich indicators: `● RUNNING` (green), `● OVERDUE` (red), `○ idle` (dim) as the leading element on each agent line

## Test plan
- [ ] Run the CLI dashboard and verify each agent shows a state indicator
- [ ] Confirm a running agent (with active lock file) shows green `● RUNNING`
- [ ] Confirm an overdue agent (countdown <= 0, not running) shows red `● OVERDUE`
- [ ] Confirm idle agents show dim `○ idle`
- [ ] Verify no crashes with missing/stale/invalid lock files

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
