### PR TITLE
Replace log run delimiters with card-style Rich formatting

### DIFF
--- a/apps/cli/src/forge/log_panel.py
+++ b/apps/cli/src/forge/log_panel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -15,7 +16,13 @@ from textual.widgets import Static, TabbedContent, TabPane
 
 POLL_INTERVAL = 2
 MAX_LINES = 500
-RUN_SEPARATOR = "─" * 40
+
+_RUN_START_RE = re.compile(r"^=== RUN (\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})Z?) ===$")
+_RUN_END_RE = re.compile(r"^=== END RUN ===$")
+
+CARD_WIDTH = 60
+CARD_BORDER_COLOR = "#6272a4"
+CARD_HEADER_COLOR = "bold cyan"
 
 
 def _find_repo_root() -> Path:
@@ -51,19 +58,41 @@ def _load_agent_ids(repo_root: Path) -> list[str]:
 
 
 def _format_log_content(raw: str) -> str:
-    """Apply visual separators for run markers."""
+    """Format run blocks as card-style Rich markup."""
     lines = raw.splitlines()
     if len(lines) > MAX_LINES:
         lines = lines[-MAX_LINES:]
-    formatted = []
-    for line in lines:
-        stripped = line.strip()
-        if stripped.startswith("=== RUN ") or stripped.startswith("=== END RUN"):
-            formatted.append(f"[bold cyan]{RUN_SEPARATOR}[/bold cyan]")
-            formatted.append(f"[bold cyan]{stripped}[/bold cyan]")
-            formatted.append(f"[bold cyan]{RUN_SEPARATOR}[/bold cyan]")
+
+    formatted: list[str] = []
+    i = 0
+    bc = CARD_BORDER_COLOR
+    hc = CARD_HEADER_COLOR
+    while i < len(lines):
+        stripped = lines[i].strip()
+        m = _RUN_START_RE.match(stripped)
+        if m:
+            time_str = m.group(2)
+            # Collect body lines until END RUN or EOF
+            body_lines: list[str] = []
+            i += 1
+            while i < len(lines):
+                end_stripped = lines[i].strip()
+                if _RUN_END_RE.match(end_stripped):
+                    i += 1
+                    break
+                body_lines.append(lines[i])
+                i += 1
+            # Build card
+            header = f" {time_str} "
+            top = f"[{bc}]╭{'─' * 2}{f'[/{bc}][{hc}]{header}[/{hc}][{bc}]'}{'─' * max(1, CARD_WIDTH - 4 - len(header))}╮[/{bc}]"
+            formatted.append(top)
+            for body_line in body_lines:
+                formatted.append(f"[{bc}]│[/{bc}]  {body_line}")
+            bottom = f"[{bc}]╰{'─' * (CARD_WIDTH - 2)}╯[/{bc}]"
+            formatted.append(bottom)
         else:
-            formatted.append(line)
+            formatted.append(lines[i])
+            i += 1
     return "\n".join(formatted)
 
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Replaces plain-text `=== RUN ... ===` / `=== END RUN ===` delimiters with card-style Rich markup using box-drawing characters (╭/│/╰)
- Cards display a human-readable timestamp header (HH:MM:SS) in bold cyan
- Card borders use themed color (#6272a4) for visual distinction between runs
- Log content outside run blocks displays normally without card styling

## Test plan
- [ ] Launch Forge CLI with agents that have log files containing run blocks
- [ ] Verify run blocks render as bordered cards with timestamp headers
- [ ] Verify log content outside run blocks displays without card styling
- [ ] Verify cards render correctly when a run block has no END RUN marker (EOF)
- [ ] Verify performance is acceptable during rapid log updates

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
