### PR TITLE
Fix agent status panel flickering on refresh

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -207,6 +207,7 @@ class StatusPanel(Widget):
 
     def on_mount(self) -> None:
         self._repo_root = _find_repo_root()
+        self._last_agents: list[dict] | None = None
         self._refresh_display()
         self.set_interval(1, self._tick)
 
@@ -218,6 +219,11 @@ class StatusPanel(Widget):
 
     def _refresh_display(self) -> None:
         agents = _load_agents(self._repo_root)
+
+        if agents == self._last_agents:
+            return
+
+        self._last_agents = agents
         container = self.query_one("#status-agents", VerticalScroll)
         container.remove_children()
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Fix status panel flickering by caching previous agent data and skipping re-render when data is unchanged
- Added `_last_agents` cache to `StatusPanel` that stores the previously rendered agent data list
- `_refresh_display` now compares new data against cached data and early-returns if identical

## Test plan
- [ ] Launch Forge CLI and observe status panel — should not flicker during normal operation
- [ ] Change an agent's state (start/stop an agent) — panel should update within 1-2 seconds
- [ ] Verify all agent info (role, repo, interval, timers) still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
