### PR TITLE
Integrate event feed panel into CLI TUI

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -3,6 +3,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Static
 
+from forge.event_feed import EventFeedPanel
 from forge.log_panel import LogPanel
 from forge.status_panel import StatusPanel
 
@@ -14,6 +15,7 @@ class ForgeApp(App):
     TITLE = "Forge"
     BINDINGS = [
         Binding("l", "toggle_logs", "Toggle Logs"),
+        Binding("e", "toggle_events", "Toggle Events"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -21,7 +23,9 @@ class ForgeApp(App):
         with Horizontal(id="main"):
             with Vertical(id="left-col"):
                 yield LogPanel()
-            yield StatusPanel()
+            with Vertical(id="right-col"):
+                yield StatusPanel()
+                yield EventFeedPanel()
 
     def on_mount(self) -> None:
         self.query_one(LogPanel).display = False
@@ -29,6 +33,10 @@ class ForgeApp(App):
     def action_toggle_logs(self) -> None:
         log_panel = self.query_one(LogPanel)
         log_panel.display = not log_panel.display
+
+    def action_toggle_events(self) -> None:
+        event_panel = self.query_one(EventFeedPanel)
+        event_panel.display = not event_panel.display
 
 
 def main() -> None:

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -24,8 +24,12 @@ Screen {
     border-right: solid #3a3a5c;
 }
 
-StatusPanel {
+#right-col {
     width: 1fr;
+    height: 1fr;
+}
+
+StatusPanel {
     height: 1fr;
     padding: 1;
     overflow-y: auto;
@@ -112,4 +116,27 @@ _LogView VerticalScroll {
     height: auto;
     padding: 1;
     color: #808090;
+}
+
+/* Event Feed Panel */
+
+EventFeedPanel {
+    height: auto;
+    max-height: 40%;
+    border: round #3a3a5c;
+    background: #16162a;
+    padding: 1;
+    overflow-y: auto;
+}
+
+#event-header {
+    height: auto;
+    text-style: bold;
+    color: #6c3fc5;
+    margin-bottom: 1;
+}
+
+#event-content {
+    height: auto;
+    color: #e0e0e0;
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- Integrate `EventFeedPanel` into the TUI layout below the `StatusPanel` in a new right-column vertical container
- Add `e` keybinding to toggle event feed visibility
- Style the event feed panel to match the existing dark theme

## Test plan
- [ ] Run `forge` CLI and verify EventFeedPanel is visible below StatusPanel
- [ ] Verify events from `events.jsonl` display when webhook monitor is running
- [ ] Verify `e` key toggles event feed visibility
- [ ] Verify StatusPanel and EventFeedPanel are both readable (not crowded)
- [ ] Test on 80x24 terminal minimum

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
