### PR TITLE
Move event feed panel to full-width layout

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -25,7 +25,7 @@ class ForgeApp(App):
                 yield LogPanel()
             with Vertical(id="right-col"):
                 yield StatusPanel()
-                yield EventFeedPanel()
+        yield EventFeedPanel()
 
     def on_mount(self) -> None:
         self.query_one(LogPanel).display = False

--- a/apps/cli/src/forge/event_feed.py
+++ b/apps/cli/src/forge/event_feed.py
@@ -56,9 +56,9 @@ def _format_event_line(event: dict) -> str:
 
     num_str = f"#{number}" if number else "—"
 
-    # Truncate summary to keep lines compact
-    if len(summary) > 50:
-        summary = summary[:47] + "..."
+    # Truncate summary to keep lines readable
+    if len(summary) > 80:
+        summary = summary[:77] + "..."
 
     return (
         f"{time_str}  "

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -121,8 +121,8 @@ _LogView VerticalScroll {
 /* Event Feed Panel */
 
 EventFeedPanel {
-    height: auto;
-    max-height: 40%;
+    height: 12;
+    min-height: 8;
     border: round #3a3a5c;
     background: #16162a;
     padding: 1;
@@ -138,5 +138,6 @@ EventFeedPanel {
 
 #event-content {
     height: auto;
+    min-height: 1;
     color: #e0e0e0;
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- Move `EventFeedPanel` from narrow `#right-col` to full-width position below the main horizontal layout
- Set fixed height (12 rows, min 8) so 5-8 events are always visible with vertical scrolling
- Increase summary truncation from 50 to 80 chars since panel is no longer width-constrained

## Test plan
- [ ] Launch Forge CLI and verify event feed panel spans full width below status/log panels
- [ ] Verify at least 5-8 events are visible when events exist
- [ ] Verify vertical scrolling works when events exceed visible area
- [ ] Press `e` to toggle event feed panel on/off
- [ ] Verify status panel and log panel layout are unaffected

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
