### PR TITLE
Fix log panel to extend full vertical height

### DIFF
--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -84,7 +84,6 @@ StatusPanel {
 
 LogPanel {
     height: 1fr;
-    max-height: 50%;
     border-top: solid #3a3a5c;
     background: #16162a;
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- Remove `max-height: 50%` constraint from `LogPanel` in `layout.tcss` so the log panel extends to fill all remaining vertical space

## Test plan
- [ ] Open TUI with `l` to toggle logs — log panel should extend to the bottom of the terminal
- [ ] Verify status panel and event feed in the right column are unaffected
- [ ] Confirm log panel remains scrollable when content exceeds visible area
- [ ] Resize terminal and verify log panel still fills available space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
