### PR TITLE
Add status panel toggle keybinding (s)

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -18,6 +18,7 @@ class ForgeApp(App):
     BINDINGS = [
         Binding("l", "toggle_logs", "Toggle Logs"),
         Binding("e", "toggle_events", "Toggle Events"),
+        Binding("s", "toggle_status", "Toggle Status"),
         Binding("a", "add_agent", "Add Agent"),
         Binding("d", "remove_agent", "Remove Agent"),
     ]
@@ -38,6 +39,10 @@ class ForgeApp(App):
     def action_toggle_events(self) -> None:
         event_panel = self.query_one(EventFeedPanel)
         event_panel.display = not event_panel.display
+
+    def action_toggle_status(self) -> None:
+        status_panel = self.query_one(StatusPanel)
+        status_panel.display = not status_panel.display
 
     def action_add_agent(self) -> None:
         self.push_screen(AddAgentScreen())


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `s` keyboard shortcut to toggle the StatusPanel visibility
- Follows the same pattern as existing `l` (logs) and `e` (events) toggles
- All three toggle shortcuts appear in the footer

## Test plan
- [ ] Press `s` to hide the status panel, press again to show it
- [ ] Verify `l` and `e` toggles still work as before
- [ ] Verify all three shortcuts appear in the footer bar
- [ ] Verify no layout regressions when toggling panels on/off

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
