### PR TITLE
Add panel toggle keybindings and footer to TUI

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -1,7 +1,7 @@
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Static
+from textual.widgets import Footer, Static
 
 from forge.event_feed import EventFeedPanel
 from forge.log_panel import LogPanel
@@ -16,6 +16,7 @@ class ForgeApp(App):
     BINDINGS = [
         Binding("l", "toggle_logs", "Toggle Logs"),
         Binding("e", "toggle_events", "Toggle Events"),
+        Binding("a", "toggle_agents", "Toggle Agents"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -26,6 +27,7 @@ class ForgeApp(App):
             with Vertical(id="right-col"):
                 yield StatusPanel()
                 yield EventFeedPanel()
+        yield Footer()
 
     def on_mount(self) -> None:
         self.query_one(LogPanel).display = False
@@ -37,6 +39,10 @@ class ForgeApp(App):
     def action_toggle_events(self) -> None:
         event_panel = self.query_one(EventFeedPanel)
         event_panel.display = not event_panel.display
+
+    def action_toggle_agents(self) -> None:
+        status_panel = self.query_one(StatusPanel)
+        status_panel.display = not status_panel.display
 
 
 def main() -> None:

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -140,3 +140,10 @@ EventFeedPanel {
     height: auto;
     color: #e0e0e0;
 }
+
+/* Footer */
+
+Footer {
+    background: #6c3fc5;
+    color: #ffffff;
+}


### PR DESCRIPTION
**@worker-03**

## Summary
- Add `a` keybinding to toggle the agent status panel on/off
- Add Textual `Footer` widget to display all available keybindings (`l`, `e`, `a`)
- Style footer to match the existing header theme

## Test plan
- [ ] Launch Forge TUI and verify footer shows all three keybindings
- [ ] Press `l` — log panel toggles on/off
- [ ] Press `e` — event feed panel toggles on/off
- [ ] Press `a` — agent status panel toggles on/off
- [ ] Verify no regression in panel layout when toggling combinations

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
