### PR TITLE
Show detailed event info in event feed panel

### DIFF
--- a/apps/cli/src/forge/event_feed.py
+++ b/apps/cli/src/forge/event_feed.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 
 from textual.app import ComposeResult
+from textual.containers import VerticalScroll
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
@@ -39,7 +40,8 @@ def _color_for_action(raw_action: str) -> str:
     return EVENT_TYPE_COLORS.get(raw_action, "white")
 
 
-def _format_event_line(event: dict) -> str:
+def _format_event(event: dict) -> str:
+    """Format an event as a multi-line block with detailed info."""
     ts = event.get("timestamp", "")
     try:
         dt = datetime.fromisoformat(ts)
@@ -52,21 +54,33 @@ def _format_event_line(event: dict) -> str:
     actor = event.get("actor", "?")
     summary = event.get("summary", "")
     raw_action = event.get("raw_action", "")
+    labels = event.get("labels", [])
     color = _color_for_action(raw_action)
 
     num_str = f"#{number}" if number else "—"
 
-    # Truncate summary to keep lines readable
-    if len(summary) > 80:
-        summary = summary[:77] + "..."
-
-    return (
-        f"{time_str}  "
-        f"[{color}]{event_type:<16}[/{color}]  "
-        f"{num_str:<6}  "
-        f"{actor:<14}  "
-        f"{summary}"
+    # Line 1: timestamp, colored event type, issue/PR number
+    line1 = (
+        f"[dim]{time_str}[/dim]  "
+        f"[{color} bold]{event_type}[/{color} bold]  "
+        f"[cyan]{num_str}[/cyan]"
     )
+
+    # Line 2: actor and summary
+    if len(summary) > 100:
+        summary = summary[:97] + "..."
+    line2 = f"  [dim]@{actor}[/dim]  {summary}"
+
+    lines = [line1, line2]
+
+    # Line 3 (optional): labels
+    if labels:
+        label_str = ", ".join(labels[:5])
+        if len(labels) > 5:
+            label_str += f" +{len(labels) - 5}"
+        lines.append(f"  [yellow dim]labels: {label_str}[/yellow dim]")
+
+    return "\n".join(lines)
 
 
 def _load_events(path: Path) -> list[dict]:
@@ -94,7 +108,8 @@ class EventFeedPanel(Widget):
 
     def compose(self) -> ComposeResult:
         yield Static("Event Feed", id="event-header")
-        yield Static("No events yet", id="event-content")
+        with VerticalScroll(id="event-scroll"):
+            yield Static("No events yet", id="event-content")
 
     def on_mount(self) -> None:
         self._events_path = _get_events_path()
@@ -111,8 +126,10 @@ class EventFeedPanel(Widget):
     def _refresh_display(self) -> None:
         events = _load_events(self._events_path)
 
+        content = self.query_one("#event-content", Static)
+
         if not events:
-            self.query_one("#event-content", Static).update("No events yet")
+            content.update("No events yet")
             self._last_count = 0
             return
 
@@ -120,6 +137,7 @@ class EventFeedPanel(Widget):
         recent = events[-MAX_DISPLAY_EVENTS:]
         recent.reverse()
 
-        lines = [_format_event_line(e) for e in recent]
-        self.query_one("#event-content", Static).update("\n".join(lines))
+        # Join events with blank-line separator for readability
+        blocks = [_format_event(e) for e in recent]
+        content.update("\n\n".join(blocks))
         self._last_count = len(events)

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -121,12 +121,11 @@ _LogView VerticalScroll {
 /* Event Feed Panel */
 
 EventFeedPanel {
-    height: 12;
+    height: 16;
     min-height: 8;
     border: round #3a3a5c;
     background: #16162a;
     padding: 1;
-    overflow-y: auto;
 }
 
 #event-header {
@@ -134,6 +133,11 @@ EventFeedPanel {
     text-style: bold;
     color: #6c3fc5;
     margin-bottom: 1;
+}
+
+#event-scroll {
+    height: 1fr;
+    background: #16162a;
 }
 
 #event-content {


### PR DESCRIPTION
**@worker-02**

## Summary
- Reformats event feed entries from single-line to multi-line blocks showing event type (color-coded), timestamp, issue/PR number, actor, summary, and optional labels
- Wraps event content in a `VerticalScroll` container for proper scrolling when events exceed visible area
- Increases default panel height from 12 to 16 to accommodate multi-line events

## Test plan
- [ ] Toggle event feed with `e` keybinding — verify toggle still works
- [ ] Verify events display with all fields: timestamp, event type, #number, actor, summary
- [ ] Verify labels row appears when event has labels, and is omitted when empty
- [ ] Scroll through events when more than fit in the visible area
- [ ] Verify periodic refresh still updates the feed every 3 seconds

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
