### PR TITLE
Rewrite log panel formatter to match view.sh output style

### DIFF
--- a/apps/cli/src/forge/log_panel.py
+++ b/apps/cli/src/forge/log_panel.py
@@ -20,9 +20,7 @@ MAX_LINES = 500
 _RUN_START_RE = re.compile(r"^=== RUN (\d{4}-\d{2}-\d{2}T(\d{2}:\d{2}:\d{2})Z?) ===$")
 _RUN_END_RE = re.compile(r"^=== END RUN ===$")
 
-CARD_WIDTH = 60
-CARD_BORDER_COLOR = "#6272a4"
-CARD_HEADER_COLOR = "bold cyan"
+_SEPARATOR = "─────────────────────────"
 
 # How many bytes to read from the end of a file when opening it for the first
 # time. 64 KiB is enough to capture ~500 lines of typical log output without
@@ -86,36 +84,30 @@ def _load_agent_ids(repo_root: Path) -> list[str]:
 
 
 def _format_lines(lines: list[str]) -> list[str]:
-    """Format run blocks as card-style Rich markup."""
+    """Format run blocks to match view.sh output style."""
     formatted: list[str] = []
     i = 0
-    bc = CARD_BORDER_COLOR
-    hc = CARD_HEADER_COLOR
     while i < len(lines):
         stripped = lines[i].strip()
         m = _RUN_START_RE.match(stripped)
         if m:
             time_str = m.group(2)
-            # Collect body lines until END RUN or EOF
-            body_lines: list[str] = []
+            formatted.append(
+                f"[bold cyan]{time_str} {_SEPARATOR}[/bold cyan]"
+            )
             i += 1
             while i < len(lines):
                 end_stripped = lines[i].strip()
                 if _RUN_END_RE.match(end_stripped):
                     i += 1
                     break
-                body_lines.append(lines[i])
+                if not lines[i].strip():
+                    i += 1
+                    continue
+                formatted.append(f"  {lines[i]}")
                 i += 1
-            # Build card
-            header = f" {time_str} "
-            top = f"[{bc}]╭{'─' * 2}{f'[/{bc}][{hc}]{header}[/{hc}][{bc}]'}{'─' * max(1, CARD_WIDTH - 4 - len(header))}╮[/{bc}]"
-            formatted.append(top)
-            for body_line in body_lines:
-                formatted.append(f"[{bc}]│[/{bc}]  {body_line}")
-            bottom = f"[{bc}]╰{'─' * (CARD_WIDTH - 2)}╯[/{bc}]"
-            formatted.append(bottom)
         else:
-            formatted.append(lines[i])
+            formatted.append(f"  {lines[i]}")
             i += 1
     return formatted
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Rewrites `_format_lines()` in `log_panel.py` to match `view.sh`'s `format_lines()` output style
- Replaces card-style box-drawing formatting (╭╮│╰╯) with clean timestamp header + separator
- Skips blank lines within run blocks and hides raw run markers

## Test plan
- [ ] Run the CLI TUI and verify per-agent log tabs show formatted output
- [ ] Verify run blocks display `HH:MM:SS ─────────────────────────` headers in bold cyan
- [ ] Verify content lines within run blocks are 2-space indented
- [ ] Verify blank lines within run blocks are omitted
- [ ] Verify `=== RUN ... ===` and `=== END RUN ===` markers are not shown raw
- [ ] Verify lines outside run blocks display with 2-space indent
- [ ] Verify MAX_LINES trimming still works (large log files)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
