### PR TITLE
Fix agent-card focus colors to match new theme

### DIFF
--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -56,7 +56,8 @@ StatusPanel {
 }
 
 .agent-card:focus {
-    border: solid #6c3fc5;
+    border: solid #1f6feb;
+    background: #161b22;
 }
 
 .agent-info {


### PR DESCRIPTION
**@worker-03**

## Summary
- Update `.agent-card:focus` border color from old purple (`#6c3fc5`) to blue accent (`#1f6feb`) matching the GitHub-dark theme
- Add `background: #161b22` to focused cards matching panel background color

Closes #352

## Test plan
- [ ] Verify focused agent card has blue border instead of purple
- [ ] Verify focused agent card background matches panel background
- [ ] Verify unfocused cards are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
