### PR TITLE
Fix resize keys: use ctrl+arrow instead of bare arrows + rebase

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -9,6 +9,15 @@ from forge.event_feed import EventFeedPanel
 from forge.log_panel import LogPanel
 from forge.status_panel import StatusPanel, _AgentCard
 
+# Resize step as percentage points
+_RESIZE_STEP = 5
+# Boundaries for left column width (percentage of #main)
+_LEFT_COL_MIN = 20
+_LEFT_COL_MAX = 80
+# Boundaries for event feed height (rows)
+_EVENT_HEIGHT_MIN = 4
+_EVENT_HEIGHT_MAX = 30
+
 
 class ForgeApp(App):
     """Forge CLI command center."""
@@ -20,7 +29,16 @@ class ForgeApp(App):
         Binding("e", "toggle_events", "Toggle Events"),
         Binding("a", "add_agent", "Add Agent"),
         Binding("d", "remove_agent", "Remove Agent"),
+        Binding("ctrl+left", "resize_left", "Shrink Left", show=False),
+        Binding("ctrl+right", "resize_right", "Grow Left", show=False),
+        Binding("ctrl+up", "resize_event_shrink", "Shrink Events", show=False),
+        Binding("ctrl+down", "resize_event_grow", "Grow Events", show=False),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._left_pct = 75  # left column width as percentage
+        self._event_height = 12  # event feed height in rows
 
     def compose(self) -> ComposeResult:
         yield Static(" Forge — Agent Orchestration", id="header-bar")
@@ -30,6 +48,11 @@ class ForgeApp(App):
             with Vertical(id="right-col"):
                 yield StatusPanel()
         yield EventFeedPanel()
+
+    def on_mount(self) -> None:
+        self.query_one(LogPanel).display = False
+        self._apply_column_sizes()
+        self._apply_event_height()
 
     def action_toggle_logs(self) -> None:
         log_panel = self.query_one(LogPanel)
@@ -48,6 +71,32 @@ class ForgeApp(App):
             self.notify("Focus an agent card first (Tab to navigate)", severity="warning")
             return
         self.push_screen(ConfirmRemoveScreen(focused.agent_id))
+
+    def action_resize_left(self) -> None:
+        self._left_pct = max(_LEFT_COL_MIN, self._left_pct - _RESIZE_STEP)
+        self._apply_column_sizes()
+
+    def action_resize_right(self) -> None:
+        self._left_pct = min(_LEFT_COL_MAX, self._left_pct + _RESIZE_STEP)
+        self._apply_column_sizes()
+
+    def action_resize_event_shrink(self) -> None:
+        self._event_height = max(_EVENT_HEIGHT_MIN, self._event_height - 2)
+        self._apply_event_height()
+
+    def action_resize_event_grow(self) -> None:
+        self._event_height = min(_EVENT_HEIGHT_MAX, self._event_height + 2)
+        self._apply_event_height()
+
+    def _apply_column_sizes(self) -> None:
+        left = self.query_one("#left-col")
+        right = self.query_one("#right-col")
+        left.styles.width = f"{self._left_pct}%"
+        right.styles.width = f"{100 - self._left_pct}%"
+
+    def _apply_event_height(self) -> None:
+        event_panel = self.query_one(EventFeedPanel)
+        event_panel.styles.height = self._event_height
 
 
 def main() -> None:

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -19,14 +19,16 @@ Screen {
 }
 
 #left-col {
-    width: 3fr;
+    width: 75%;
     height: 1fr;
+    min-width: 20;
     border-right: solid #30363d;
 }
 
 #right-col {
-    width: 1fr;
+    width: 25%;
     height: 1fr;
+    min-width: 15;
 }
 
 StatusPanel {
@@ -124,8 +126,9 @@ _LogView VerticalScroll {
 /* Event Feed Panel */
 
 EventFeedPanel {
-    height: 16;
-    min-height: 8;
+    height: 12;
+    min-height: 4;
+    max-height: 30;
     border: round #30363d;
     background: #161b22;
     padding: 1;


### PR DESCRIPTION
**@worker-01**

## Summary
- Change resize keybindings from bare arrow keys to `ctrl+arrow` modifier keys to avoid conflicts with focus navigation, scrolling, and tab navigation
- Rebase resizable panels feature onto latest `main`, resolving merge conflicts with theme redesign, add/remove agent, event detail, and log formatter changes

## Test plan
- [ ] Verify `ctrl+left`/`ctrl+right` resize left/right columns (5% steps, 20-80% range)
- [ ] Verify `ctrl+up`/`ctrl+down` resize event feed height (2-row steps, 4-30 row range)
- [ ] Verify bare arrow keys still work for focus navigation between agent cards
- [ ] Verify scrolling works in log panel and event feed
- [ ] Verify tab navigation works in TabbedContent
- [ ] Verify add agent (a) and remove agent (d) keybindings still work

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
