### PR TITLE
Add resizable panels via ctrl+arrow keyboard shortcuts

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -9,6 +9,15 @@ from forge.event_feed import EventFeedPanel
 from forge.log_panel import LogPanel
 from forge.status_panel import StatusPanel, _AgentCard
 
+# Resize step as percentage points
+_RESIZE_STEP = 5
+# Boundaries for left column width (percentage of #main)
+_LEFT_COL_MIN = 20
+_LEFT_COL_MAX = 80
+# Boundaries for event feed height (rows)
+_EVENT_HEIGHT_MIN = 4
+_EVENT_HEIGHT_MAX = 30
+
 
 class ForgeApp(App):
     """Forge CLI command center."""
@@ -20,7 +29,16 @@ class ForgeApp(App):
         Binding("e", "toggle_events", "Toggle Events"),
         Binding("a", "add_agent", "Add Agent"),
         Binding("d", "remove_agent", "Remove Agent"),
+        Binding("ctrl+left", "resize_left", "Shrink Left", show=False),
+        Binding("ctrl+right", "resize_right", "Grow Left", show=False),
+        Binding("ctrl+up", "resize_event_shrink", "Shrink Events", show=False),
+        Binding("ctrl+down", "resize_event_grow", "Grow Events", show=False),
     ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._left_pct = 75  # left column width as percentage
+        self._event_height = 12  # event feed height in rows
 
     def compose(self) -> ComposeResult:
         yield Static(" Forge — Agent Orchestration", id="header-bar")
@@ -30,6 +48,10 @@ class ForgeApp(App):
             with Vertical(id="right-col"):
                 yield StatusPanel()
         yield EventFeedPanel()
+
+    def on_mount(self) -> None:
+        self._apply_column_sizes()
+        self._apply_event_height()
 
     def action_toggle_logs(self) -> None:
         log_panel = self.query_one(LogPanel)
@@ -48,6 +70,32 @@ class ForgeApp(App):
             self.notify("Focus an agent card first (Tab to navigate)", severity="warning")
             return
         self.push_screen(ConfirmRemoveScreen(focused.agent_id))
+
+    def action_resize_left(self) -> None:
+        self._left_pct = max(_LEFT_COL_MIN, self._left_pct - _RESIZE_STEP)
+        self._apply_column_sizes()
+
+    def action_resize_right(self) -> None:
+        self._left_pct = min(_LEFT_COL_MAX, self._left_pct + _RESIZE_STEP)
+        self._apply_column_sizes()
+
+    def action_resize_event_shrink(self) -> None:
+        self._event_height = max(_EVENT_HEIGHT_MIN, self._event_height - 2)
+        self._apply_event_height()
+
+    def action_resize_event_grow(self) -> None:
+        self._event_height = min(_EVENT_HEIGHT_MAX, self._event_height + 2)
+        self._apply_event_height()
+
+    def _apply_column_sizes(self) -> None:
+        left = self.query_one("#left-col")
+        right = self.query_one("#right-col")
+        left.styles.width = f"{self._left_pct}%"
+        right.styles.width = f"{100 - self._left_pct}%"
+
+    def _apply_event_height(self) -> None:
+        event_panel = self.query_one(EventFeedPanel)
+        event_panel.styles.height = self._event_height
 
 
 def main() -> None:

--- a/apps/cli/src/forge/layout.tcss
+++ b/apps/cli/src/forge/layout.tcss
@@ -19,14 +19,16 @@ Screen {
 }
 
 #left-col {
-    width: 3fr;
+    width: 75%;
     height: 1fr;
+    min-width: 20;
     border-right: solid #30363d;
 }
 
 #right-col {
-    width: 1fr;
+    width: 25%;
     height: 1fr;
+    min-width: 15;
 }
 
 StatusPanel {
@@ -124,11 +126,13 @@ _LogView VerticalScroll {
 /* Event Feed Panel */
 
 EventFeedPanel {
-    height: 16;
-    min-height: 8;
+    height: 12;
+    min-height: 4;
+    max-height: 30;
     border: round #30363d;
     background: #161b22;
     padding: 1;
+    overflow-y: auto;
 }
 
 #event-header {


### PR DESCRIPTION
**@worker-02**

## Summary
- Add keyboard-based resizable panels to Forge CLI using ctrl+arrow keys
- Ctrl+Left/Right adjusts left/right column width split (5% per step, 20-80% range)
- Ctrl+Up/Down adjusts EventFeedPanel height (2 rows per step, 4-30 row range)
- Layout uses percentage-based widths with min-width constraints to prevent collapse
- Cleanly rebased onto current main, preserving all existing features (add/remove agent, toggle panels)

## Test plan
- [ ] Launch Forge CLI and verify initial layout renders correctly
- [ ] Press Ctrl+Left/Right to resize left/right column split — verify smooth resizing within bounds
- [ ] Press Ctrl+Up/Down to resize event feed panel — verify height changes within bounds
- [ ] Verify panels cannot collapse below minimum sizes (20% width, 4 rows height)
- [ ] Verify all existing keybindings still work (l=logs, e=events, a=add, d=remove)
- [ ] Verify no overlapping or clipping after repeated resizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
