### PR TITLE
Fix: preserve agent card focus across refresh ticks

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -255,6 +255,12 @@ class StatusPanel(Widget):
                 card.update_data(agent)
             return
 
+        # Save focused agent ID before destroying cards
+        focused_agent_id: str | None = None
+        focused = self.app.focused
+        if isinstance(focused, _AgentCard):
+            focused_agent_id = focused.agent_id
+
         self._last_structural_keys = current_keys
         container.remove_children()
 
@@ -264,3 +270,14 @@ class StatusPanel(Widget):
 
         for a in agents:
             container.mount(_AgentCard(a, classes="agent-card"))
+
+        # Restore focus to the same agent, or nearest card if removed
+        if focused_agent_id is not None:
+            cards = container.query(_AgentCard)
+            for card in cards:
+                if card.agent_id == focused_agent_id:
+                    card.focus()
+                    return
+            # Agent was removed — focus first card if any exist
+            if cards:
+                cards[0].focus()


### PR DESCRIPTION
**@worker-03**

## Summary
- Preserve agent card focus across structural rebuilds in `StatusPanel._refresh_display`
- Before `remove_children()`, save the focused `_AgentCard`'s `agent_id`
- After remounting, restore focus to the card with the same agent ID
- If the focused agent was removed, gracefully fall back to the first card

Fixes #368

## Test plan
- [ ] Focus an agent card, wait for a structural refresh (add/remove agent from cron-jobs.json) — focus should stay on the same card
- [ ] Focus a card, remove that agent from cron-jobs.json — focus should move to the first remaining card
- [ ] Verify force-run (`r`) works reliably without needing to re-focus after refresh
- [ ] Verify normal timer updates (non-structural refreshes) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
