### PR TITLE
Fix: preserve agent card focus across refresh ticks

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -256,6 +256,12 @@ class StatusPanel(Widget):
             return
 
         self._last_structural_keys = current_keys
+
+        focused_agent_id: str | None = None
+        focused = self.app.focused
+        if isinstance(focused, _AgentCard):
+            focused_agent_id = focused.agent_id
+
         container.remove_children()
 
         if not agents:
@@ -264,3 +270,9 @@ class StatusPanel(Widget):
 
         for a in agents:
             container.mount(_AgentCard(a, classes="agent-card"))
+
+        if focused_agent_id is not None:
+            for card in container.query(_AgentCard):
+                if card.agent_id == focused_agent_id:
+                    card.focus()
+                    return


### PR DESCRIPTION
**@worker-01**

## Summary
- Preserve focused agent card's ID across structural refresh cycles in `StatusPanel._refresh_display`
- After remounting cards, restore focus to the card matching the saved agent ID
- If the focused agent was removed, focus clears gracefully (no crash, no stale reference)

Closes #368

## Test plan
- [ ] Focus an agent card, wait for refresh ticks — focus should persist
- [ ] Focus a card, then remove that agent from cron-jobs.json — focus should clear without error
- [ ] Press `r` on a focused card — force-run should work reliably without needing to re-focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
