### PR TITLE
Fix: preserve agent card focus across refresh ticks

### DIFF
--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -255,6 +255,11 @@ class StatusPanel(Widget):
                 card.update_data(agent)
             return
 
+        focused_agent_id = None
+        focused = self.app.focused
+        if isinstance(focused, _AgentCard):
+            focused_agent_id = focused.agent_id
+
         self._last_structural_keys = current_keys
         container.remove_children()
 
@@ -264,3 +269,9 @@ class StatusPanel(Widget):
 
         for a in agents:
             container.mount(_AgentCard(a, classes="agent-card"))
+
+        if focused_agent_id is not None:
+            for card in container.query(_AgentCard):
+                if card.agent_id == focused_agent_id:
+                    card.focus()
+                    break


### PR DESCRIPTION
**@worker-01**

## Summary
- Preserve agent card focus across structural refresh ticks in `StatusPanel._refresh_display`
- Before `remove_children()`, save the focused `_AgentCard`'s `agent_id`
- After remounting cards, restore focus to the card with the same `agent_id`
- If the focused agent was removed, focus is cleared gracefully (no match found)

Fixes #368

## Test plan
- [ ] Focus an agent card in the status panel, wait for a structural refresh (e.g., add/remove an agent from cron-jobs.json) — focus should persist
- [ ] Focus a card, remove that agent from config — focus should clear without error
- [ ] Verify force-run (`r`) works reliably across refresh ticks without re-focusing
- [ ] Verify normal timer-only updates still work via the in-place `update_data` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
