### PR TITLE
Add cron-state.json timer reset after force-run

### DIFF
--- a/apps/cli/src/forge/app.py
+++ b/apps/cli/src/forge/app.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from datetime import datetime, timezone
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -157,6 +158,20 @@ class ForgeApp(App):
                 cwd=str(repo_root),
                 start_new_session=True,
             )
+
+        state_path = repo_root / "agent-kernel" / "cron" / "cron-state.json"
+        now_iso = datetime.now(timezone.utc).isoformat()
+        state: dict = {}
+        if state_path.exists():
+            try:
+                with open(state_path) as f:
+                    state = json.load(f)
+            except (json.JSONDecodeError, KeyError):
+                pass
+        state.setdefault("jobs", {}).setdefault(agent_id, {})["last_run"] = now_iso
+        with open(state_path, "w") as f:
+            json.dump(state, f, indent=2)
+            f.write("\n")
 
         self.notify(f"Force-run started for {agent_id}")
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Adds `cron-state.json` timer reset after force-run in the TUI, so countdown timers reflect the latest run time
- Rebased version of PR #372 — stripped all duplicated force-run code that's already on `main` via #341

Closes #378
Parent: #367

## Test plan
- [ ] Force-run an agent from TUI and verify `cron-state.json` gets updated with current UTC timestamp
- [ ] Verify countdown timer resets after force-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
