### PR TITLE
Add backend API routes for agents, logs, and events

### DIFF
--- a/apps/web/src/app/api/agents/[id]/force-run/route.ts
+++ b/apps/web/src/app/api/agents/[id]/force-run/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { spawn } from "child_process";
+import {
+  cronJobsPath,
+  cronStatePath,
+  runShPath,
+  getForgeRoot,
+  agentLogPath,
+} from "@/lib/paths";
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+  repo?: string;
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!SAFE_ID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid agent ID" }, { status: 400 });
+  }
+
+  let jobs: CronJob[] = [];
+  try {
+    const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+    jobs = JSON.parse(raw).jobs ?? [];
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to read agent config" },
+      { status: 500 }
+    );
+  }
+
+  const agent = jobs.find((j) => j.id === id);
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  const args: string[] = [];
+  if (agent.agentic) args.push("--agentic");
+  if (agent.workspace) args.push("--workspace", agent.id);
+  for (const ctx of agent.contexts) {
+    args.push("--context", ctx);
+  }
+  if (agent.repo) args.push("--repo", agent.repo);
+  args.push(agent.prompt);
+
+  const logPath = agentLogPath(agent.id);
+  const logDir = path.dirname(logPath);
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+  const logFd = fs.openSync(logPath, "a");
+
+  const child = spawn("bash", [runShPath(), ...args], {
+    cwd: getForgeRoot(),
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+  child.unref();
+  fs.closeSync(logFd);
+
+  // Update cron-state.json with current timestamp
+  try {
+    let state: { jobs: Record<string, Record<string, unknown>> } = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch {
+      // no existing state
+    }
+    if (!state.jobs) state.jobs = {};
+    if (!state.jobs[id]) state.jobs[id] = {};
+    state.jobs[id].last_run = new Date().toISOString();
+    fs.writeFileSync(cronStatePath(), JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    // non-critical
+  }
+
+  return NextResponse.json({ status: "started" });
+}

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import { managePyPath, cronJobsPath, getForgeRoot } from "@/lib/paths";
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+interface CronJob {
+  id: string;
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!SAFE_ID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid agent ID" }, { status: 400 });
+  }
+
+  // Verify agent exists
+  try {
+    const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+    const jobs: CronJob[] = JSON.parse(raw).jobs ?? [];
+    if (!jobs.some((j) => j.id === id)) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to read agent config" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const result = spawnSync("python3", [managePyPath(), "remove", id], {
+      cwd: getForgeRoot(),
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    if (result.status !== 0) {
+      return NextResponse.json(
+        { ok: false, error: result.stderr || "Command failed" },
+        { status: 500 }
+      );
+    }
+    return NextResponse.json({ ok: true, output: result.stdout });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import {
+  cronJobsPath,
+  cronStatePath,
+  lockFilePath,
+} from "@/lib/paths";
+
+interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+  enabled?: boolean;
+  repo?: string;
+}
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      last_run?: string;
+      stagger_offset?: number;
+      installed_at?: string;
+    }
+  >;
+}
+
+function parseIntervalSeconds(interval: string): number {
+  const match = interval.match(/^(\d+)(s|m|h)$/);
+  if (!match) return 0;
+  const value = parseInt(match[1], 10);
+  switch (match[2]) {
+    case "s":
+      return value;
+    case "m":
+      return value * 60;
+    case "h":
+      return value * 3600;
+    default:
+      return 0;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function inferRole(contexts: string[]): string {
+  return contexts.some((c) => c.includes("PLANNER.md"))
+    ? "planner"
+    : "worker";
+}
+
+export async function GET() {
+  let jobs: CronJob[] = [];
+  try {
+    const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+    jobs = JSON.parse(raw).jobs ?? [];
+  } catch {
+    return NextResponse.json({ agents: [] });
+  }
+
+  let state: CronState = { jobs: {} };
+  try {
+    const raw = fs.readFileSync(cronStatePath(), "utf-8");
+    state = JSON.parse(raw);
+  } catch {
+    // no state file yet
+  }
+
+  const agents = jobs.map((job) => {
+    const jobState = state.jobs?.[job.id] ?? {};
+    const intervalSeconds = parseIntervalSeconds(job.interval);
+    const lastRun = jobState.last_run ?? null;
+
+    let running = false;
+    try {
+      const lockContent = fs.readFileSync(lockFilePath(job.id), "utf-8").trim();
+      const pid = parseInt(lockContent, 10);
+      if (!isNaN(pid)) {
+        running = isProcessAlive(pid);
+      }
+    } catch {
+      // no lock file
+    }
+
+    let nextRun: string | null = null;
+    let overdue = false;
+    if (lastRun) {
+      const nextRunDate = new Date(
+        new Date(lastRun).getTime() + intervalSeconds * 1000
+      );
+      nextRun = nextRunDate.toISOString();
+      overdue = !running && new Date() > nextRunDate;
+    }
+
+    return {
+      id: job.id,
+      role: inferRole(job.contexts),
+      interval: job.interval,
+      intervalSeconds,
+      enabled: job.enabled !== false,
+      lastRun,
+      nextRun,
+      running,
+      overdue,
+      staggerOffset: jobState.stagger_offset ?? 0,
+      prompt: job.prompt,
+      contexts: job.contexts,
+      agentic: job.agentic,
+      workspace: job.workspace,
+      repo: job.repo ?? "",
+    };
+  });
+
+  return NextResponse.json({ agents });
+}

--- a/apps/web/src/app/api/events/route.ts
+++ b/apps/web/src/app/api/events/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import { eventsPath } from "@/lib/paths";
+
+const MAX_EVENTS_PER_RESPONSE = 50;
+
+export async function GET(request: NextRequest) {
+  const offsetParam = request.nextUrl.searchParams.get("offset") ?? "0";
+  const offset = parseInt(offsetParam, 10);
+
+  if (isNaN(offset) || offset < 0) {
+    return NextResponse.json(
+      { error: "Invalid offset parameter" },
+      { status: 400 }
+    );
+  }
+
+  const filePath = eventsPath();
+
+  let lines: string[];
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    lines = content.split("\n").filter((l) => l.trim() !== "");
+  } catch {
+    return NextResponse.json({ events: [], offset: 0, total: 0 });
+  }
+
+  const total = lines.length;
+
+  // Reverse lines so index 0 = most recent, then paginate
+  const reversed = [...lines].reverse();
+  const slice = reversed.slice(offset, offset + MAX_EVENTS_PER_RESPONSE);
+
+  const events: unknown[] = [];
+  for (const line of slice) {
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return NextResponse.json({
+    events,
+    offset: Math.min(offset + slice.length, total),
+    total,
+  });
+}

--- a/apps/web/src/app/api/logs/[agentId]/route.ts
+++ b/apps/web/src/app/api/logs/[agentId]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { agentLogPath, logsDir } from "@/lib/paths";
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SEED_READ_BYTES = 64 * 1024; // 64KB
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const { agentId } = await params;
+
+  if (!SAFE_ID_RE.test(agentId)) {
+    return NextResponse.json({ error: "Invalid agent ID" }, { status: 400 });
+  }
+
+  const logPath = agentLogPath(agentId);
+
+  // Path traversal guard
+  const resolvedLogsDir = path.resolve(logsDir());
+  const resolvedLogPath = path.resolve(logPath);
+  if (!resolvedLogPath.startsWith(resolvedLogsDir + path.sep)) {
+    return NextResponse.json({ error: "Invalid agent ID" }, { status: 400 });
+  }
+
+  const offsetParam = request.nextUrl.searchParams.get("offset") ?? "0";
+  const offset = parseInt(offsetParam, 10);
+
+  if (isNaN(offset) || offset < 0) {
+    return NextResponse.json(
+      { error: "Invalid offset parameter" },
+      { status: 400 }
+    );
+  }
+
+  let fileSize: number;
+  try {
+    const stat = fs.statSync(logPath);
+    fileSize = stat.size;
+  } catch {
+    return NextResponse.json({ data: "", offset: 0, fileSize: 0 });
+  }
+
+  // Handle file truncation (log rotation, etc.)
+  const effectiveOffset = offset > fileSize ? 0 : offset;
+
+  let data: string;
+  if (effectiveOffset === 0 && fileSize > SEED_READ_BYTES) {
+    // Seed read: return last 64KB
+    const fd = fs.openSync(logPath, "r");
+    const buffer = Buffer.alloc(SEED_READ_BYTES);
+    const startPos = fileSize - SEED_READ_BYTES;
+    fs.readSync(fd, buffer, 0, SEED_READ_BYTES, startPos);
+    fs.closeSync(fd);
+    data = buffer.toString("utf-8");
+    return NextResponse.json({
+      data,
+      offset: fileSize,
+      fileSize,
+    });
+  }
+
+  // Incremental read from offset
+  const fd = fs.openSync(logPath, "r");
+  const bytesToRead = fileSize - effectiveOffset;
+  if (bytesToRead <= 0) {
+    fs.closeSync(fd);
+    return NextResponse.json({ data: "", offset: fileSize, fileSize });
+  }
+  const buffer = Buffer.alloc(bytesToRead);
+  fs.readSync(fd, buffer, 0, bytesToRead, effectiveOffset);
+  fs.closeSync(fd);
+  data = buffer.toString("utf-8");
+
+  return NextResponse.json({
+    data,
+    offset: fileSize,
+    fileSize,
+  });
+}

--- a/apps/web/src/app/api/logs/route.ts
+++ b/apps/web/src/app/api/logs/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { logsDir } from "@/lib/paths";
+
+const SEED_READ_BYTES = 64 * 1024;
+
+interface LogResult {
+  data: string;
+  offset: number;
+  fileSize: number;
+}
+
+function readLog(logPath: string, offset: number): LogResult {
+  let fileSize: number;
+  try {
+    fileSize = fs.statSync(logPath).size;
+  } catch {
+    return { data: "", offset: 0, fileSize: 0 };
+  }
+
+  const effectiveOffset = offset > fileSize ? 0 : offset;
+
+  if (effectiveOffset === 0 && fileSize > SEED_READ_BYTES) {
+    const fd = fs.openSync(logPath, "r");
+    const buffer = Buffer.alloc(SEED_READ_BYTES);
+    fs.readSync(fd, buffer, 0, SEED_READ_BYTES, fileSize - SEED_READ_BYTES);
+    fs.closeSync(fd);
+    return { data: buffer.toString("utf-8"), offset: fileSize, fileSize };
+  }
+
+  const bytesToRead = fileSize - effectiveOffset;
+  if (bytesToRead <= 0) {
+    return { data: "", offset: fileSize, fileSize };
+  }
+
+  const fd = fs.openSync(logPath, "r");
+  const buffer = Buffer.alloc(bytesToRead);
+  fs.readSync(fd, buffer, 0, bytesToRead, effectiveOffset);
+  fs.closeSync(fd);
+  return { data: buffer.toString("utf-8"), offset: fileSize, fileSize };
+}
+
+export async function GET(request: NextRequest) {
+  const offsetParam = request.nextUrl.searchParams.get("offset") ?? "0";
+  const defaultOffset = parseInt(offsetParam, 10);
+
+  if (isNaN(defaultOffset) || defaultOffset < 0) {
+    return NextResponse.json(
+      { error: "Invalid offset parameter" },
+      { status: 400 }
+    );
+  }
+
+  const dir = logsDir();
+  let files: string[] = [];
+  try {
+    files = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".log"));
+  } catch {
+    return NextResponse.json({ agents: {} });
+  }
+
+  const agents: Record<string, LogResult> = {};
+  for (const file of files) {
+    const agentId = path.basename(file, ".log");
+    agents[agentId] = readLog(path.join(dir, file), defaultOffset);
+  }
+
+  return NextResponse.json({ agents });
+}

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -1,0 +1,43 @@
+import path from "path";
+
+/**
+ * Resolve the repo root (FORGE_ROOT) from which all data files are located.
+ * Defaults to two levels up from apps/web/ (the repo root).
+ */
+export function getForgeRoot(): string {
+  return (
+    process.env.FORGE_ROOT || path.resolve(process.cwd(), "../..")
+  );
+}
+
+export function cronJobsPath(): string {
+  return path.join(getForgeRoot(), "agent-kernel/cron/cron-jobs.json");
+}
+
+export function cronStatePath(): string {
+  return path.join(getForgeRoot(), "agent-kernel/cron/cron-state.json");
+}
+
+export function lockFilePath(agentId: string): string {
+  return path.join(getForgeRoot(), `.worktrees/${agentId}/.agent.lock`);
+}
+
+export function agentLogPath(agentId: string): string {
+  return path.join(getForgeRoot(), `agent-kernel/logs/${agentId}.log`);
+}
+
+export function logsDir(): string {
+  return path.join(getForgeRoot(), "agent-kernel/logs");
+}
+
+export function eventsPath(): string {
+  return path.join(getForgeRoot(), "events.jsonl");
+}
+
+export function managePyPath(): string {
+  return path.join(getForgeRoot(), "agent-kernel/cron/manage.py");
+}
+
+export function runShPath(): string {
+  return path.join(getForgeRoot(), "agent-kernel/run.sh");
+}


### PR DESCRIPTION
**@worker-03**

## Summary
- Initialize NextJS app at `apps/web/` with App Router, TypeScript, Tailwind
- Implement all 6 backend API routes reading from agent-kernel data files
- Create shared `lib/paths.ts` utility resolving paths via `FORGE_ROOT` env var

## Endpoints
- `GET /api/agents` — merges cron-jobs.json + cron-state.json + lock file PID checks
- `POST /api/agents/[id]/force-run` — spawns `run.sh` detached, updates cron-state
- `DELETE /api/agents/[id]` — runs `manage.py remove`
- `GET /api/logs/[agentId]?offset=0` — byte-offset incremental reads with 64KB seed
- `GET /api/logs?offset=0` — aggregated logs for all agents
- `GET /api/events?offset=0` — line-offset JSONL pagination, max 50 per response

## Test plan
- [ ] `cd apps/web && npm install && npm run dev` starts successfully
- [ ] `curl localhost:3000/api/agents` returns agent data from cron-jobs.json
- [ ] `curl localhost:3000/api/events` returns parsed events from events.jsonl
- [ ] `curl localhost:3000/api/logs/planner-01` returns log content
- [ ] Force-run endpoint spawns detached process and returns immediately
- [ ] Delete endpoint calls manage.py and returns result
- [ ] Missing files return empty results, not 500 errors

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
