### PR TITLE
Fix: scaffold cleanup (font var, unused CSS, dep placement)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,6 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "shadcn": "^4.0.5",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },
@@ -27,6 +26,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "shadcn": "^4.0.5",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -8,7 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-jetbrains-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -62,7 +62,6 @@
 
 :root {
   /* One Dark theme — always dark */
-  --bg: #282c34;
   --surface: #2c313a;
   --surface-hover: #3e4451;
   --text: #abb2bf;
@@ -74,8 +73,6 @@
   --accent-magenta: #c678dd;
   --accent-cyan: #56b6c2;
   --accent-orange: #d19a66;
-  --od-border: #4b5263;
-
   /* shadcn/ui semantic tokens — One Dark mapping */
   --background: #282c34;
   --foreground: #abb2bf;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ const inter = Inter({
 });
 
 const jetbrainsMono = JetBrains_Mono({
-  variable: "--font-geist-mono",
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
 });
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Rename font variable from `--font-geist-mono` to `--font-jetbrains-mono` in layout.tsx and globals.css
- Remove unused `--bg` and `--od-border` CSS variables from globals.css
- Move `shadcn` CLI package from dependencies to devDependencies
- Remove placeholder comment from next.config.ts

Closes #413

## Test plan
- [ ] Verify `npm run build` passes in apps/web
- [ ] Verify font-mono utility class still applies JetBrains Mono

🤖 Generated with [Claude Code](https://claude.com/claude-code)
