### PR TITLE
Add resizable and collapsible panel layout

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,26 +1,14 @@
 import { AgentPanel } from "@/components/agent-panel";
 import { LogsPanel } from "@/components/logs-panel";
+import { EventsPanel } from "@/components/events-panel";
+import { ResizableLayout } from "@/components/resizable-layout";
 
 export default function Home() {
   return (
-    <div className="grid grid-cols-[300px_1fr] grid-rows-[1fr_300px] h-screen gap-px bg-border">
-      {/* Agent Panel — left sidebar */}
-      <AgentPanel />
-
-      {/* Logs Panel — top right */}
-      <div className="bg-background overflow-hidden">
-        <LogsPanel />
-      </div>
-
-      {/* Events Panel — bottom right */}
-      <div className="bg-surface p-4 overflow-y-auto">
-        <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide mb-4">
-          Events
-        </h2>
-        <p className="text-muted-foreground text-sm">
-          Event feed will appear here.
-        </p>
-      </div>
-    </div>
+    <ResizableLayout
+      sidebar={<AgentPanel />}
+      topRight={<LogsPanel />}
+      bottomRight={<EventsPanel />}
+    />
   );
 }

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -221,7 +221,7 @@ export function AgentPanel() {
   };
 
   return (
-    <div className="row-span-2 bg-surface p-3 overflow-y-auto flex flex-col">
+    <div className="h-full bg-surface p-3 overflow-y-auto flex flex-col">
       <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide mb-3">
         Agents
       </h2>

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface GitHubEvent {
+  action?: string;
+  issue?: { title: string; number: number; html_url: string };
+  pull_request?: { title: string; number: number; html_url: string };
+  comment?: { body: string; user: { login: string } };
+  sender?: { login: string; avatar_url: string };
+  repository?: { full_name: string };
+  [key: string]: unknown;
+}
+
+interface EventsResponse {
+  events: GitHubEvent[];
+  offset: number;
+  total: number;
+}
+
+function getEventType(event: GitHubEvent): "issue" | "pr" | "comment" | "other" {
+  if (event.comment) return "comment";
+  if (event.pull_request) return "pr";
+  if (event.issue) return "issue";
+  return "other";
+}
+
+function getAccentClass(type: "issue" | "pr" | "comment" | "other"): string {
+  switch (type) {
+    case "issue":
+      return "bg-accent-green";
+    case "pr":
+      return "bg-accent-blue";
+    case "comment":
+      return "bg-accent-yellow";
+    default:
+      return "bg-accent-cyan";
+  }
+}
+
+function getSummary(event: GitHubEvent): string {
+  const sender = event.sender?.login ?? "unknown";
+  const action = event.action ?? "triggered";
+
+  if (event.comment) {
+    const target = event.issue
+      ? `#${event.issue.number}`
+      : event.pull_request
+        ? `#${event.pull_request.number}`
+        : "unknown";
+    return `${sender} commented on ${target}`;
+  }
+  if (event.pull_request) {
+    return `${sender} ${action} PR #${event.pull_request.number}`;
+  }
+  if (event.issue) {
+    return `${sender} ${action} #${event.issue.number}`;
+  }
+  return `${sender} ${action} event`;
+}
+
+function getBodyPreview(event: GitHubEvent): string | null {
+  if (!event.comment?.body) return null;
+  const body = event.comment.body.replace(/\n/g, " ").trim();
+  return body.length > 80 ? body.slice(0, 77) + "..." : body;
+}
+
+function getTimestamp(event: GitHubEvent): string | null {
+  const raw =
+    (event.comment as Record<string, unknown>)?.created_at ??
+    (event.issue as Record<string, unknown>)?.updated_at ??
+    (event.pull_request as Record<string, unknown>)?.updated_at;
+  if (typeof raw !== "string") return null;
+  const date = new Date(raw);
+  if (isNaN(date.getTime())) return null;
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function EventCard({ event }: { event: GitHubEvent }) {
+  const type = getEventType(event);
+  const accent = getAccentClass(type);
+  const summary = getSummary(event);
+  const preview = getBodyPreview(event);
+  const timestamp = getTimestamp(event);
+
+  return (
+    <div className="bg-background rounded p-2 flex gap-2 items-start">
+      <div className={`w-1 shrink-0 self-stretch rounded-full ${accent}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <p className="text-text-bright text-sm truncate">{summary}</p>
+          {timestamp && (
+            <span className="text-muted-foreground text-xs font-mono shrink-0">
+              {timestamp}
+            </span>
+          )}
+        </div>
+        {preview && (
+          <p className="text-text text-xs mt-0.5 truncate">{preview}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function EventsPanel() {
+  const [events, setEvents] = useState<GitHubEvent[]>([]);
+  const [nextOffset, setNextOffset] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const fetchEvents = useCallback(async (offset: number, append: boolean) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/events?offset=${offset}`);
+      if (!res.ok) return;
+      const data: EventsResponse = await res.json();
+      setEvents((prev) => (append ? [...prev, ...data.events] : data.events));
+      setNextOffset(data.offset);
+      setTotal(data.total);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial fetch + polling
+  useEffect(() => {
+    fetchEvents(0, false);
+    const interval = setInterval(() => fetchEvents(0, false), 10_000);
+    return () => clearInterval(interval);
+  }, [fetchEvents]);
+
+  const hasMore = nextOffset < total;
+
+  return (
+    <div className="h-full bg-surface p-4 overflow-y-auto flex flex-col">
+      <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide mb-4">
+        Events
+      </h2>
+      {events.length === 0 && !loading ? (
+        <p className="text-muted-foreground text-sm">No events yet</p>
+      ) : (
+        <div className="flex flex-col gap-1 flex-1 min-h-0">
+          {events.map((event, i) => (
+            <EventCard key={`${i}-${nextOffset}`} event={event} />
+          ))}
+          {hasMore && (
+            <button
+              onClick={() => fetchEvents(nextOffset, true)}
+              disabled={loading}
+              className="text-sm text-accent-blue hover:text-text-bright mt-2 self-center disabled:opacity-50"
+            >
+              {loading ? "Loading..." : "Load more"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/resizable-layout.tsx
+++ b/apps/web/src/components/resizable-layout.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY = "dacl-panel-sizes";
+const SIDEBAR_MIN = 200;
+const SIDEBAR_MAX = 500;
+const PANEL_MIN = 100;
+const HANDLE_SIZE = 4;
+
+interface PanelSizes {
+  sidebarWidth: number;
+  topRightRatio: number; // 0-1, fraction of right area used by top panel
+}
+
+interface CollapsedState {
+  sidebar: boolean;
+  bottom: boolean;
+}
+
+function loadSizes(): PanelSizes {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return {
+        sidebarWidth: Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, parsed.sidebarWidth ?? 300)),
+        topRightRatio: Math.max(0.1, Math.min(0.9, parsed.topRightRatio ?? 0.7)),
+      };
+    }
+  } catch {
+    // ignore
+  }
+  return { sidebarWidth: 300, topRightRatio: 0.7 };
+}
+
+function saveSizes(sizes: PanelSizes) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sizes));
+  } catch {
+    // ignore
+  }
+}
+
+export function ResizableLayout({
+  sidebar,
+  topRight,
+  bottomRight,
+}: {
+  sidebar: ReactNode;
+  topRight: ReactNode;
+  bottomRight: ReactNode;
+}) {
+  const [sizes, setSizes] = useState<PanelSizes>({ sidebarWidth: 300, topRightRatio: 0.7 });
+  const [collapsed, setCollapsed] = useState<CollapsedState>({ sidebar: false, bottom: false });
+  const [hydrated, setHydrated] = useState(false);
+
+  const [dragging, setDragging] = useState<"vertical" | "horizontal" | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef<"vertical" | "horizontal" | null>(null);
+  const sizesBeforeCollapseRef = useRef<PanelSizes>(sizes);
+
+  // Load sizes from localStorage after mount
+  useEffect(() => {
+    const loaded = loadSizes();
+    setSizes(loaded);
+    sizesBeforeCollapseRef.current = loaded;
+    setHydrated(true);
+  }, []);
+
+  // Persist sizes on change
+  useEffect(() => {
+    if (hydrated && !collapsed.sidebar && !collapsed.bottom) {
+      saveSizes(sizes);
+      sizesBeforeCollapseRef.current = sizes;
+    }
+  }, [sizes, hydrated, collapsed]);
+
+  const handlePointerDown = useCallback(
+    (axis: "vertical" | "horizontal") => (e: React.PointerEvent) => {
+      e.preventDefault();
+      draggingRef.current = axis;
+      setDragging(axis);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    []
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingRef.current || !containerRef.current) return;
+
+      const rect = containerRef.current.getBoundingClientRect();
+
+      if (draggingRef.current === "vertical") {
+        const newWidth = Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, e.clientX - rect.left));
+        setSizes((prev) => ({ ...prev, sidebarWidth: newWidth }));
+      } else if (draggingRef.current === "horizontal") {
+        const rightHeight = rect.height;
+        const relativeY = e.clientY - rect.top;
+        const ratio = Math.max(0.1, Math.min(0.9, relativeY / rightHeight));
+        // Enforce minimum pixel sizes
+        const topPx = ratio * rightHeight;
+        const bottomPx = rightHeight - topPx - HANDLE_SIZE;
+        if (topPx >= PANEL_MIN && bottomPx >= PANEL_MIN) {
+          setSizes((prev) => ({ ...prev, topRightRatio: ratio }));
+        }
+      }
+    },
+    [collapsed.sidebar, sizes.sidebarWidth]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    draggingRef.current = null;
+    setDragging(null);
+  }, []);
+
+  const handleDoubleClickVertical = useCallback(() => {
+    setCollapsed((prev) => {
+      if (!prev.sidebar) {
+        return { ...prev, sidebar: true };
+      }
+      return { ...prev, sidebar: false };
+    });
+  }, []);
+
+  const handleDoubleClickHorizontal = useCallback(() => {
+    setCollapsed((prev) => {
+      if (!prev.bottom) {
+        return { ...prev, bottom: true };
+      }
+      return { ...prev, bottom: false };
+    });
+  }, []);
+
+  const sidebarWidth = collapsed.sidebar ? 0 : sizes.sidebarWidth;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`h-screen w-screen overflow-hidden flex bg-border${dragging ? " select-none" : ""}`}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      style={{ cursor: dragging === "vertical" ? "col-resize" : dragging === "horizontal" ? "row-resize" : undefined }}
+    >
+      {/* Sidebar */}
+      {collapsed.sidebar ? (
+        <div
+          className="bg-surface flex items-center justify-center shrink-0 cursor-pointer hover:bg-surface-hover transition-colors"
+          style={{ width: 32 }}
+          onClick={() => setCollapsed((prev) => ({ ...prev, sidebar: false }))}
+        >
+          <span className="text-muted-foreground text-xs uppercase tracking-widest [writing-mode:vertical-lr]">
+            Agents
+          </span>
+        </div>
+      ) : (
+        <div
+          className="overflow-hidden shrink-0"
+          style={{ width: sidebarWidth }}
+        >
+          {sidebar}
+        </div>
+      )}
+
+      {/* Vertical resize handle */}
+      <div
+        className="shrink-0 bg-border hover:bg-accent-blue transition-colors"
+        style={{ width: HANDLE_SIZE, cursor: "col-resize" }}
+        onPointerDown={handlePointerDown("vertical")}
+        onDoubleClick={handleDoubleClickVertical}
+      />
+
+      {/* Right area: top + handle + bottom */}
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        {/* Top right (Logs) */}
+        {collapsed.bottom ? (
+          <div className="flex-1 overflow-hidden bg-background">
+            {topRight}
+          </div>
+        ) : (
+          <div
+            className="overflow-hidden bg-background"
+            style={{ flex: `0 0 calc(${sizes.topRightRatio * 100}% - ${HANDLE_SIZE / 2}px)` }}
+          >
+            {topRight}
+          </div>
+        )}
+
+        {/* Horizontal resize handle */}
+        {collapsed.bottom ? (
+          <div
+            className="shrink-0 bg-surface flex items-center justify-center cursor-pointer hover:bg-surface-hover transition-colors"
+            style={{ height: 24 }}
+            onClick={() => setCollapsed((prev) => ({ ...prev, bottom: false }))}
+          >
+            <span className="text-muted-foreground text-xs uppercase tracking-wide">
+              Events
+            </span>
+          </div>
+        ) : (
+          <div
+            className="shrink-0 bg-border hover:bg-accent-blue transition-colors"
+            style={{ height: HANDLE_SIZE, cursor: "row-resize" }}
+            onPointerDown={handlePointerDown("horizontal")}
+            onDoubleClick={handleDoubleClickHorizontal}
+          />
+        )}
+
+        {/* Bottom right (Events) */}
+        {!collapsed.bottom && (
+          <div
+            className="overflow-hidden"
+            style={{ flex: `0 0 calc(${(1 - sizes.topRightRatio) * 100}% - ${HANDLE_SIZE / 2}px)` }}
+          >
+            {bottomRight}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `ResizableLayout` component with mouse-driven drag handles between all three panels
- Vertical resize handle between sidebar (200-500px) and right panels
- Horizontal resize handle between logs and events panels (100px min each)
- Double-click any handle to collapse/expand the adjacent panel
- Collapsed panels show a thin labeled bar that can be clicked to restore
- Panel sizes persisted in localStorage across page reloads
- No external resize libraries — implemented with pointer events

## Test plan
- [ ] Drag vertical handle to resize sidebar width — verify min/max enforcement
- [ ] Drag horizontal handle to resize logs/events split — verify min enforcement
- [ ] Double-click vertical handle to collapse sidebar — verify thin "Agents" bar appears
- [ ] Click collapsed sidebar bar to restore it
- [ ] Double-click horizontal handle to collapse events — verify thin "Events" bar appears
- [ ] Click collapsed events bar to restore it
- [ ] Resize panels, reload page — verify sizes are restored from localStorage
- [ ] `npm run build` passes

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
