### PR TITLE
Fix API route security and correctness issues

### DIFF
--- a/apps/web/src/app/api/agents/[id]/force-run/route.ts
+++ b/apps/web/src/app/api/agents/[id]/force-run/route.ts
@@ -4,13 +4,12 @@ import path from "path";
 import { spawn } from "child_process";
 import {
   cronJobsPath,
-  cronStatePath,
   runShPath,
   getForgeRoot,
   agentLogPath,
 } from "@/lib/paths";
 
-const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
 interface CronJob {
   id: string;
@@ -71,23 +70,6 @@ export async function POST(
   });
   child.unref();
   fs.closeSync(logFd);
-
-  // Update cron-state.json with current timestamp
-  try {
-    let state: { jobs: Record<string, Record<string, unknown>> } = { jobs: {} };
-    try {
-      const raw = fs.readFileSync(cronStatePath(), "utf-8");
-      state = JSON.parse(raw);
-    } catch {
-      // no existing state
-    }
-    if (!state.jobs) state.jobs = {};
-    if (!state.jobs[id]) state.jobs[id] = {};
-    state.jobs[id].last_run = new Date().toISOString();
-    fs.writeFileSync(cronStatePath(), JSON.stringify(state, null, 2) + "\n");
-  } catch {
-    // non-critical
-  }
 
   return NextResponse.json({ status: "started" });
 }

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "child_process";
 import fs from "fs";
 import { managePyPath, cronJobsPath, getForgeRoot } from "@/lib/paths";
 
-const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
 interface CronJob {
   id: string;

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -48,7 +48,10 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && err.code === "EPERM") {
+      return true;
+    }
     return false;
   }
 }

--- a/apps/web/src/app/api/logs/[agentId]/route.ts
+++ b/apps/web/src/app/api/logs/[agentId]/route.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { agentLogPath, logsDir } from "@/lib/paths";
 
-const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const SEED_READ_BYTES = 64 * 1024; // 64KB
 
 export async function GET(

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -1,12 +1,12 @@
 import path from "path";
 
 /**
- * Resolve the repo root (FORGE_ROOT) from which all data files are located.
+ * Resolve the repo root from which all data files are located.
  * Defaults to two levels up from apps/web/ (the repo root).
  */
 export function getForgeRoot(): string {
   return (
-    process.env.FORGE_ROOT || path.resolve(process.cwd(), "../..")
+    process.env.FORGE_REPO_ROOT || path.resolve(process.cwd(), "../..")
   );
 }
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Fix EPERM handling in `isProcessAlive` — returns `true` when process exists but owned by different user
- Remove `cron-state.json` write from force-run endpoint to eliminate race condition with `manage.py`
- Tighten agent ID validation regex to `/^[a-z][a-z0-9-]{0,63}$/` across all `[id]`/`[agentId]` routes
- Rename `FORGE_ROOT` env var to `FORGE_REPO_ROOT` in `lib/paths.ts`

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Test force-run endpoint no longer writes to cron-state.json
- [ ] Confirm agent IDs with uppercase or special chars are rejected
- [ ] Verify PID check works correctly for running/stopped processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
