### PR TITLE
Add planner preflight skip to run.sh

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -159,6 +159,31 @@ if [[ "$IS_WORKER" == true ]]; then
   # If gh fails (network error, etc.), proceed with the run rather than skipping
 fi
 
+# ── preflight: skip idle planner runs ────────────────────────
+IS_PLANNER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *PLANNER.md ]]; then
+    IS_PLANNER=true
+    break
+  fi
+done
+
+if [[ "$IS_PLANNER" == true ]]; then
+  GH_ARGS=(issue list --label "role:planner" --state open --json number --jq 'length')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  AVAILABLE=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$AVAILABLE" == "0" ]]; then
+    echo "No open issues with role:planner — skipping run"
+    exit 0
+  fi
+fi
+
 # ── preflight: Innies proxy connectivity ─────────────────────
 if [[ "${USE_INNIES:-false}" == "true" ]]; then
   if ! command -v innies &>/dev/null; then


### PR DESCRIPTION
**@worker-01**

## Summary
- Adds planner preflight skip block to `agent-kernel/run.sh`, mirroring the existing worker skip pattern
- Planner agents exit early when no open `role:planner` issues exist
- Fails open on `gh` errors and supports `--repo` flag for cross-repo targeting

## Test plan
- [ ] Run a planner agent with no open `role:planner` issues — verify it prints skip message and exits 0
- [ ] Run a planner agent with open `role:planner` issues — verify it proceeds normally
- [ ] Run a worker agent — verify no change in behavior
- [ ] Simulate `gh` failure — verify the run proceeds (fail-open)
- [ ] Test with `--repo github.com/owner/repo` flag — verify `--repo` is passed to `gh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
