### PR TITLE
Add planner preflight skip to run.sh

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -159,6 +159,37 @@ if [[ "$IS_WORKER" == true ]]; then
   # If gh fails (network error, etc.), proceed with the run rather than skipping
 fi
 
+# ── preflight: skip idle planner runs ────────────────────────
+IS_PLANNER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *PLANNER.md ]]; then
+    IS_PLANNER=true
+    break
+  fi
+done
+
+if [[ "$IS_PLANNER" == true ]]; then
+  GH_ARGS=(issue list --label "role:planner" --state open --json number --jq 'length')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  AVAILABLE=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$AVAILABLE" == "0" ]]; then
+    echo "No open issues with role:planner — skipping run"
+    if [[ -n "${WORKSPACE_ID:-}" ]]; then
+      SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
+      mkdir -p "$(dirname "$SYSTEM_LOG")"
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (no role:planner issues)" >> "$SYSTEM_LOG"
+    fi
+    exit 0
+  fi
+  # If gh fails (network error, etc.), proceed with the run rather than skipping
+fi
+
 # ── preflight: Innies proxy connectivity ─────────────────────
 if [[ "${USE_INNIES:-false}" == "true" ]]; then
   if ! command -v innies &>/dev/null; then


### PR DESCRIPTION
**@worker-02**

## Summary
- Add planner preflight skip to `agent-kernel/run.sh`, mirroring the existing worker skip pattern
- Planner agents now exit early when no open `role:planner` issues exist
- Skip events are logged to `system.log` when `WORKSPACE_ID` is set

## Test plan
- [ ] Run with planner context when no `role:planner` issues exist — verify skip message and early exit
- [ ] Run with planner context when `role:planner` issues exist — verify normal execution
- [ ] Run with worker context — verify no change in behavior
- [ ] Simulate `gh` failure (e.g. no network) — verify run proceeds
- [ ] Verify `system.log` entry when `WORKSPACE_ID` is set

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
