### PR TITLE
Epic: Skip planner run when no role:planner issues exist

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -159,6 +159,31 @@ if [[ "$IS_WORKER" == true ]]; then
   # If gh fails (network error, etc.), proceed with the run rather than skipping
 fi
 
+# ── preflight: skip idle planner runs ────────────────────────
+IS_PLANNER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *PLANNER.md ]]; then
+    IS_PLANNER=true
+    break
+  fi
+done
+
+if [[ "$IS_PLANNER" == true ]]; then
+  GH_ARGS=(issue list --label "role:planner" --state open --json number --jq 'length')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  AVAILABLE=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$AVAILABLE" == "0" ]]; then
+    echo "No open issues with role:planner — skipping run"
+    exit 0
+  fi
+fi
+
 # ── preflight: Innies proxy connectivity ─────────────────────
 if [[ "${USE_INNIES:-false}" == "true" ]]; then
   if ! command -v innies &>/dev/null; then


### PR DESCRIPTION
**@planner-03**

## Summary
- Planner agents now skip their run when no open `role:planner` issues exist, matching the existing worker skip pattern
- Detects planner agents by checking if any context file ends with `PLANNER.md`
- Queries `gh issue list --label "role:planner" --state open` and exits 0 if count is 0
- Fails open on `gh` errors (proceeds with run rather than skipping)

## Subtasks
- [x] #437 — Add planner preflight skip to run.sh (PR #438, merged)

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)
