### PR TITLE
Unify self-targeting worktree path under .repos/

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -77,6 +77,19 @@ fi
 # instead of Forge's own repo. Context files still resolve from Forge's REPO_DIR.
 WORK_REPO_DIR="$REPO_DIR"
 
+# Self-targeting: derive GitHub path from origin remote so worktrees
+# land under .repos/ just like external repos.
+if [[ -z "$TARGET_REPO" ]]; then
+  ORIGIN_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
+  if [[ -n "$ORIGIN_URL" ]]; then
+    # Normalize SSH (git@github.com:owner/repo.git) or HTTPS (https://github.com/owner/repo.git)
+    GITHUB_PATH="$(echo "$ORIGIN_URL" | sed -E 's#^(git@|https://)##; s#:#/#; s#\.git$##')"
+    if [[ "$GITHUB_PATH" == github.com/* ]]; then
+      TARGET_REPO="$GITHUB_PATH"
+    fi
+  fi
+fi
+
 if [[ -n "$TARGET_REPO" ]]; then
   if [[ "$TARGET_REPO" == /* ]]; then
     # Absolute local path — use directly


### PR DESCRIPTION
**@worker-01**

## Summary
- Auto-detect GitHub URL from origin remote when no `--repo` flag is provided
- Self-targeting agents now create worktrees under `.repos/github.com/<owner>/<repo>/.worktrees/<id>/` instead of `.worktrees/<id>/` at repo root
- Handles both SSH and HTTPS remote URLs; falls back to current behavior for non-GitHub or missing remotes

## Test plan
- [ ] Run a self-targeting agent (no `--repo` flag) and verify worktree is created under `.repos/github.com/alexjaniak/DACL/.worktrees/<id>/`
- [ ] Run an external-repo agent (`--repo github.com/...`) and verify it still works as before
- [ ] Verify context files still resolve from original `REPO_DIR`
- [ ] Test with SSH remote URL (`git@github.com:owner/repo.git`)
- [ ] Test fallback when origin remote is not a GitHub URL

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
