### PR TITLE
Fix webhook trigger lock file path resolution

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,19 +35,36 @@ def _matches_rule(event: dict, rule: dict) -> bool:
 
 
 def _is_agent_running(repo_dir: str, workspace_id: str) -> bool:
-    lockfile = Path(repo_dir) / ".repos" / workspace_id / ".agent.lock"
+    repo_root = Path(repo_dir)
+
+    # Derive GitHub path from origin remote (same logic as run.sh)
+    try:
+        origin_url = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        # Fallback: check root .worktrees/ (legacy path)
+        lockfile = repo_root / ".worktrees" / workspace_id / ".agent.lock"
+        return _check_lockfile(lockfile)
+
+    # Normalize SSH/HTTPS URL to github.com/owner/repo
+    github_path = re.sub(r'^(git@|https://)', '', origin_url)
+    github_path = github_path.replace(':', '/', 1)
+    github_path = re.sub(r'\.git$', '', github_path)
+
+    lockfile = repo_root / ".repos" / github_path / ".worktrees" / workspace_id / ".agent.lock"
+    return _check_lockfile(lockfile)
+
+
+def _check_lockfile(lockfile: Path) -> bool:
     if not lockfile.exists():
         return False
-
     try:
         pid = int(lockfile.read_text().strip())
     except (ValueError, OSError):
         return False
-
     try:
-        import signal
-        import os
-
         os.kill(pid, 0)
         return True
     except ProcessLookupError:


### PR DESCRIPTION
**@worker-02**

## Summary
- Fix lock file path resolution in `_is_agent_running()` to use the unified workspace layout: `.repos/github.com/<owner>/<repo>/.worktrees/<id>/.agent.lock`
- Derive GitHub path from origin remote URL, handling both SSH and HTTPS formats
- Fall back to legacy `.worktrees/<id>/.agent.lock` if git remote lookup fails

## Test plan
- [ ] Verify lock file is found at correct path when agent is running in unified workspace
- [ ] Verify SSH origin URLs (git@github.com:owner/repo.git) are normalized correctly
- [ ] Verify HTTPS origin URLs (https://github.com/owner/repo.git) are normalized correctly
- [ ] Verify fallback to legacy path when git remote fails
- [ ] Verify PID check logic still works (running process, dead process, permission error)

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
