### PR TITLE
Remove .worktrees from .gitignore and fix self-targeting lock path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ agent-kernel/logs/*
 *.egg-info/
 __pycache__/
 apps/webhook-monitor/config.toml
-.worktrees

--- a/apps/cli/src/forge/status_panel.py
+++ b/apps/cli/src/forge/status_panel.py
@@ -64,6 +64,29 @@ def _format_delta(delta: timedelta) -> str:
     return f"{secs}s"
 
 
+def _github_path_from_remote(repo_root: Path) -> str | None:
+    """Derive a github.com/<owner>/<repo> path from the git remote origin URL."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        url = result.stdout.strip()
+        # Handle SSH: git@github.com:owner/repo.git
+        m = re.match(r"git@github\.com:(.+?)(?:\.git)?$", url)
+        if m:
+            return f"github.com/{m.group(1)}"
+        # Handle HTTPS: https://github.com/owner/repo.git
+        m = re.match(r"https://github\.com/(.+?)(?:\.git)?$", url)
+        if m:
+            return f"github.com/{m.group(1)}"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return None
+
+
 def _is_agent_running(repo_root: Path, agent_id: str, repo: str) -> bool:
     """Check if an agent is currently running by inspecting its lock file.
 
@@ -72,7 +95,11 @@ def _is_agent_running(repo_root: Path, agent_id: str, repo: str) -> bool:
     if repo and repo.startswith("github.com/"):
         worktree_base = repo_root / ".repos" / repo
     else:
-        worktree_base = repo_root
+        github_path = _github_path_from_remote(repo_root)
+        if github_path:
+            worktree_base = repo_root / ".repos" / github_path
+        else:
+            worktree_base = repo_root
 
     lockfile = worktree_base / ".worktrees" / agent_id / ".agent.lock"
     if not lockfile.exists():


### PR DESCRIPTION
**@worker-02**

## Summary
- Remove legacy `.worktrees` line from `.gitignore` (`.repos/` already covers the unified layout)
- Update `status_panel.py` to resolve self-targeting agent lock files under `.repos/github.com/<owner>/<repo>/` by deriving the GitHub path from `git remote get-url origin`
- Falls back gracefully to `repo_root` if the git remote is unavailable

Closes #448

## Test plan
- [ ] Verify `.gitignore` no longer contains `.worktrees` line
- [ ] Verify `.repos/` is still present in `.gitignore`
- [ ] Verify `_is_agent_running` resolves self-targeting lock paths under `.repos/`
- [ ] Verify fallback behavior when git remote is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
