### PR TITLE
Add runtime and model fields to cron-jobs.json and manage.py

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -49,14 +49,18 @@ def parse_interval(interval):
     raise ValueError(f"Invalid interval '{interval}': must be Nm or Nh (e.g. 5m, 1h)")
 
 
-def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False, repo=None):
-    cmd = f"mkdir -p {LOGS_DIR} && cd {REPO_DIR} && ./agent-kernel/run.sh"
+def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False, repo=None, runtime=None, model=None):
+    runtime = runtime or "claude"
+    env_prefix = f"AGENT_RUNTIME={runtime} " if runtime != "claude" else ""
+    cmd = f"mkdir -p {LOGS_DIR} && cd {REPO_DIR} && {env_prefix}./agent-kernel/run.sh"
     if agentic:
         cmd += " --agentic"
     if workspace:
         cmd += f" --workspace {job_id}"
     if repo:
         cmd += f" --repo {repo}"
+    if model:
+        cmd += f" --model {model}"
     for ctx in (contexts or []):
         cmd += f" --context {ctx}"
     cmd += f' "{prompt}" >> {LOGS_DIR}/{job_id}.log 2>&1'
@@ -238,7 +242,9 @@ def cmd_apply(args):
                 d.get("agentic", False) != a.get("agentic", False) or
                 d.get("workspace", False) != a.get("workspace", False) or
                 d.get("contexts", []) != a.get("contexts", []) or
-                d.get("repo", "") != a.get("repo", "")):
+                d.get("repo", "") != a.get("repo", "") or
+                d.get("runtime", "claude") != a.get("runtime", "claude") or
+                d.get("model", "") != a.get("model", "")):
             to_update.add(job_id)
 
     no_change = (set(desired.keys()) & set(actual.keys())) - to_update
@@ -254,7 +260,9 @@ def cmd_apply(args):
         job = desired[job_id]
         contexts = job.get("contexts", [])
         repo = job.get("repo", "")
-        command = build_cron_command(job_id, job["prompt"], job.get("agentic", False), contexts, job.get("workspace", False), repo or None)
+        runtime = job.get("runtime", "claude")
+        model = job.get("model", "")
+        command = build_cron_command(job_id, job["prompt"], job.get("agentic", False), contexts, job.get("workspace", False), repo or None, runtime, model or None)
 
         offset = stagger_offsets.get(job_id, 0)
         if stagger and offset > 0:
@@ -274,6 +282,8 @@ def cmd_apply(args):
             "workspace": job.get("workspace", False),
             "contexts": contexts,
             "repo": repo,
+            "runtime": runtime,
+            "model": model,
             "stagger_offset": offset if stagger else 0,
             "installed_at": now_iso(),
         }
@@ -298,7 +308,9 @@ def cmd_add(args):
     cron_expr = parse_interval(args.interval)
     contexts = args.context or []
     repo = args.repo or ""
-    command = build_cron_command(args.id, args.prompt, args.agentic, contexts, args.workspace, repo or None)
+    runtime = args.runtime or "claude"
+    model = args.model or ""
+    command = build_cron_command(args.id, args.prompt, args.agentic, contexts, args.workspace, repo or None, runtime, model or None)
 
     crontab = read_crontab()
     crontab = add_job_to_crontab(crontab, args.id, cron_expr, command)
@@ -313,6 +325,8 @@ def cmd_add(args):
         "workspace": args.workspace,
         "contexts": contexts,
         "repo": repo,
+        "runtime": runtime,
+        "model": model,
         "installed_at": now_iso(),
     }
     save_state(state)
@@ -440,6 +454,10 @@ def cmd_run(args):
         print(f"No job with id '{args.id}' in {JOBS_FILE}", file=sys.stderr)
         sys.exit(1)
 
+    runtime = job.get("runtime", "claude")
+    if runtime != "claude":
+        os.environ["AGENT_RUNTIME"] = runtime
+
     cmd = [os.path.join(REPO_DIR, "agent-kernel", "run.sh")]
     if job.get("agentic"):
         cmd.append("--agentic")
@@ -447,6 +465,8 @@ def cmd_run(args):
         cmd += ["--workspace", job["id"]]
     if job.get("repo"):
         cmd += ["--repo", job["repo"]]
+    if job.get("model"):
+        cmd += ["--model", job["model"]]
     for ctx in job.get("contexts", []):
         cmd += ["--context", ctx]
     cmd.append(job["prompt"])
@@ -489,6 +509,8 @@ def main():
     p_add.add_argument("--workspace", action="store_true", help="Run in isolated git worktree")
     p_add.add_argument("--context", action="append", help="Context file path relative to repo root (repeatable)")
     p_add.add_argument("--repo", help="Target repo (e.g. github.com/owner/repo or absolute path)")
+    p_add.add_argument("--runtime", default="claude", help="Agent runtime: claude or codex (default: claude)")
+    p_add.add_argument("--model", default="", help="Explicit model override (e.g. gpt-5.4)")
 
     p_rm = sub.add_parser("remove", help="Remove a cron job by ID")
     p_rm.add_argument("id", help="Job identifier")

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -22,9 +22,11 @@ PROMPT=""
 CONTEXTS=()
 WORKSPACE_ID=""
 TARGET_REPO=""
+MODEL=""
 NEXT_IS_CONTEXT=false
 NEXT_IS_WORKSPACE=false
 NEXT_IS_REPO=false
+NEXT_IS_MODEL=false
 
 for arg in "$@"; do
   if [[ "$NEXT_IS_CONTEXT" == true ]]; then
@@ -42,11 +44,17 @@ for arg in "$@"; do
     NEXT_IS_REPO=false
     continue
   fi
+  if [[ "$NEXT_IS_MODEL" == true ]]; then
+    MODEL="$arg"
+    NEXT_IS_MODEL=false
+    continue
+  fi
   case "$arg" in
     --agentic)    AGENTIC=true ;;
     --context)    NEXT_IS_CONTEXT=true ;;
     --workspace)  NEXT_IS_WORKSPACE=true ;;
     --repo)       NEXT_IS_REPO=true ;;
+    --model)      NEXT_IS_MODEL=true ;;
     *)            PROMPT="$arg" ;;
   esac
 done
@@ -57,7 +65,7 @@ if [[ -z "$PROMPT" ]] && [[ ! -t 0 ]]; then
 fi
 
 if [[ -z "$PROMPT" ]]; then
-  echo "Usage: $0 [--agentic] [--workspace <id>] [--repo <path-or-url>] [--context <path> ...] \"<prompt>\"" >&2
+  echo "Usage: $0 [--agentic] [--workspace <id>] [--repo <path-or-url>] [--model <model>] [--context <path> ...] \"<prompt>\"" >&2
   exit 1
 fi
 
@@ -260,6 +268,10 @@ else
   if [[ -n "$SYSTEM_PROMPT" ]]; then
     RUNTIME_ARGS+=(--append-system-prompt "$SYSTEM_PROMPT")
   fi
+fi
+
+if [[ -n "$MODEL" ]]; then
+  RUNTIME_ARGS+=(--model "$MODEL")
 fi
 
 if [[ -n "$WORKSPACE_ID" ]]; then


### PR DESCRIPTION
**@worker-01**

## Summary
- Add optional `runtime` field to cron job config (defaults to `"claude"`)
- Pass `AGENT_RUNTIME=<runtime>` env var in crontab commands when runtime != claude
- Add optional `model` field for explicit model override, passed as `--model` flag
- Track both fields in `cron-state.json` and detect changes on `apply`
- Update `run.sh` to parse `--model` flag and pass it to the Claude CLI
- `cmd_run` also sets `AGENT_RUNTIME` env var and passes `--model` for immediate runs

Closes #444

## Test plan
- [ ] Verify `python3 manage.py apply` works with existing jobs (no runtime/model fields)
- [ ] Add `"runtime": "codex"` to a job in cron-jobs.json, run apply, verify crontab has `AGENT_RUNTIME=codex`
- [ ] Add `"model": "gpt-5.4"` to a job, run apply, verify `--model gpt-5.4` in crontab command
- [ ] Verify `manage.py run <id>` passes runtime env and model flag
- [ ] Verify `manage.py add` accepts `--runtime` and `--model` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
