### PR TITLE
Fix: Improve panel collapse UX and events scrolling

### DIFF
--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -221,10 +221,7 @@ export function AgentPanel() {
   };
 
   return (
-    <div className="h-full bg-surface p-3 overflow-y-auto flex flex-col">
-      <h2 className="text-text-bright font-semibold text-base uppercase tracking-wide mb-3">
-        Agents
-      </h2>
+    <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
 
       {error && (
         <p className="text-accent-red text-sm mb-2">{error}</p>

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -123,17 +123,13 @@ export function EventsPanel() {
   }, [fetchEvents]);
 
   return (
-    <div className="bg-surface p-3 overflow-y-auto flex flex-col">
-      <h2 className="text-text-bright font-semibold text-base uppercase tracking-wide mb-3">
-        Events
-      </h2>
-
-      {error && <p className="text-accent-red text-sm mb-2">{error}</p>}
+    <div className="bg-surface px-3 pb-3 flex flex-col h-full min-h-0">
+      {error && <p className="text-accent-red text-xs mb-2 shrink-0">{error}</p>}
 
       {events.length === 0 && !error ? (
         <p className="text-muted-foreground text-sm">No events yet.</p>
       ) : (
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0">
           {events.map((event, i) => (
             <EventCard key={`${event.timestamp}-${i}`} event={event} />
           ))}

--- a/apps/web/src/components/resizable-layout.tsx
+++ b/apps/web/src/components/resizable-layout.tsx
@@ -147,20 +147,30 @@ export function ResizableLayout({
       {/* Sidebar */}
       {collapsed.sidebar ? (
         <div
-          className="bg-surface flex items-center justify-center shrink-0 cursor-pointer hover:bg-surface-hover transition-colors"
-          style={{ width: 32 }}
+          className="bg-surface flex items-center justify-center shrink-0 cursor-pointer hover:bg-surface-hover transition-colors gap-1"
+          style={{ width: 36 }}
           onClick={() => setCollapsed((prev) => ({ ...prev, sidebar: false }))}
         >
           <span className="text-muted-foreground text-xs uppercase tracking-widest [writing-mode:vertical-lr]">
-            Agents
+            ▶ Agents
           </span>
         </div>
       ) : (
         <div
-          className="overflow-hidden shrink-0"
+          className="overflow-hidden shrink-0 flex flex-col"
           style={{ width: sidebarWidth }}
         >
-          {sidebar}
+          <div className="flex items-center justify-between px-3 pt-3 pb-1 shrink-0">
+            <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide">Agents</h2>
+            <button
+              className="text-muted-foreground hover:text-text-bright text-sm px-1"
+              onClick={() => setCollapsed((prev) => ({ ...prev, sidebar: true }))}
+              title="Collapse sidebar"
+            >
+              ◀
+            </button>
+          </div>
+          <div className="flex-1 overflow-hidden">{sidebar}</div>
         </div>
       )}
 
@@ -196,7 +206,7 @@ export function ResizableLayout({
             onClick={() => setCollapsed((prev) => ({ ...prev, bottom: false }))}
           >
             <span className="text-muted-foreground text-xs uppercase tracking-wide">
-              Events
+              ▲ Events
             </span>
           </div>
         ) : (
@@ -211,10 +221,20 @@ export function ResizableLayout({
         {/* Bottom right (Events) */}
         {!collapsed.bottom && (
           <div
-            className="overflow-hidden"
+            className="overflow-hidden flex flex-col min-h-0"
             style={{ flex: `0 0 calc(${(1 - sizes.topRightRatio) * 100}% - ${HANDLE_SIZE / 2}px)` }}
           >
-            {bottomRight}
+            <div className="flex items-center justify-between px-3 pt-2 pb-1 shrink-0 bg-surface">
+              <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide">Events</h2>
+              <button
+                className="text-muted-foreground hover:text-text-bright text-sm px-1"
+                onClick={() => setCollapsed((prev) => ({ ...prev, bottom: true }))}
+                title="Collapse events"
+              >
+                ▼
+              </button>
+            </div>
+            <div className="flex-1 overflow-hidden min-h-0">{bottomRight}</div>
           </div>
         )}
       </div>


### PR DESCRIPTION
**@worker-04**

## Summary
- Fix events panel scrolling by adding proper `flex-1 overflow-y-auto min-h-0` to the events list and `min-h-0` to the bottom-right layout container
- Add visible collapse chevron buttons (◀/▼) to agent and events panel headers inside `resizable-layout.tsx`
- Add chevron indicators (▶/▲) to collapsed state bars for better discoverability

## Test plan
- [ ] Verify events panel scrolls when content exceeds panel height
- [ ] Verify agent panel has a visible ◀ collapse button in its header
- [ ] Verify events panel has a visible ▼ collapse button in its header
- [ ] Verify clicking collapse buttons collapses the panels correctly
- [ ] Verify collapsed panels expand when clicking the collapsed bar (existing behavior)
- [ ] Verify panel resize + collapse still works with localStorage persistence
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
