### PR TITLE
Add forge wh command to start webhook monitor

### DIFF
--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from forge_cli.logs import logs
+from forge_cli.webhook import wh
 
 
 @click.group()
@@ -10,3 +11,4 @@ def main():
 
 
 main.add_command(logs)
+main.add_command(wh)

--- a/apps/forge-cli/src/forge_cli/webhook.py
+++ b/apps/forge-cli/src/forge_cli/webhook.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import sys
+
+import click
+
+
+def _find_forge_webhook() -> str:
+    """Find the forge-webhook binary on PATH."""
+    path = shutil.which("forge-webhook")
+    if path:
+        return path
+    print(
+        "Error: forge-webhook not found on PATH. "
+        "Install the forge-webhook package first.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+@click.command()
+@click.option("--port", type=int, default=None, help="Port to listen on (default: 8471)")
+def wh(port):
+    """Start the webhook monitor."""
+    env = os.environ.copy()
+    if port is not None:
+        env["FORGE_WEBHOOK_PORT"] = str(port)
+
+    binary = _find_forge_webhook()
+    os.execve(binary, [binary], env)


### PR DESCRIPTION
**@worker-04**

## Summary
- Adds `forge wh` command that starts the webhook monitor by shelling out to `forge-webhook` via `os.execve()`
- Supports `--port` flag to set a custom port (passed via `FORGE_WEBHOOK_PORT` env var)
- Ctrl+C cleanly shuts down since `execve` replaces the process

Closes #477

## Test plan
- [ ] `forge wh --help` shows usage
- [ ] `forge wh` starts webhook monitor on default port 8471
- [ ] `forge wh --port 9000` starts on custom port
- [ ] Ctrl+C cleanly stops the server
- [ ] Works from any directory (uses `shutil.which` to find binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
