### PR TITLE
Clean up old entry points and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Agents are stateless one-shot CLI invocations. Each run:
 
 Cron jobs drive recurring agent runs. See [`agent-kernel/cron/README.md`](agent-kernel/cron/README.md).
 
+## Forge CLI
+
+Unified command-line interface for agent orchestration.
+
+```
+forge add worker              # add a new worker agent
+forge add planner             # add a new planner agent
+forge remove <id>             # remove an agent
+forge cron apply              # sync crontab
+forge cron status --watch     # live agent timing
+forge logs -f                 # follow all logs
+forge wh                      # start webhook monitor
+```
+
+Install: `pip install -e apps/forge-cli`
+
 ## Getting started
 
 See [agent-kernel/README.md](agent-kernel/README.md) for setup and usage.

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -1,5 +1,7 @@
 # agent-kernel/cron
 
+> **Note:** The primary interface is now `forge cron`. See the [Forge CLI section](../../README.md#forge-cli) in the root README.
+
 Declarative cron management for agent-kernel. Python 3, no dependencies.
 
 ## Quick start

--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -516,4 +516,9 @@ def main():
 
 
 if __name__ == "__main__":
+    print(
+        "WARNING: Direct invocation of manage.py is deprecated. "
+        "Use 'forge cron <subcommand>' instead.",
+        file=sys.stderr,
+    )
     main()

--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Pretty log viewer for agent-kernel logs.
+# NOTE: The primary interface is now `forge logs`. This script is kept for direct use.
 # Usage:
 #   ./view.sh              — tail all agent logs interleaved
 #   ./view.sh worker-01    — tail a specific agent's log

--- a/apps/webhook-monitor/README.md
+++ b/apps/webhook-monitor/README.md
@@ -1,5 +1,7 @@
 # Forge Webhook Monitor
 
+> **Note:** The primary interface is now `forge wh`. See the [Forge CLI section](../../README.md#forge-cli) in the root README.
+
 Receives GitHub webhook events and stores them as normalized JSONL for the Forge event system.
 
 ## Prerequisites
@@ -54,8 +56,10 @@ Environment variables still override config file values for CI/deploy:
 ### 3. Start the server
 
 ```bash
-forge-webhook
+forge wh
 ```
+
+> `forge-webhook` still works but is deprecated.
 
 The server listens on `0.0.0.0:<port>` and exposes:
 

--- a/apps/webhook-monitor/src/forge_webhook/main.py
+++ b/apps/webhook-monitor/src/forge_webhook/main.py
@@ -82,7 +82,14 @@ async def health():
 
 
 def run():
+    import sys
+
     import uvicorn
+
+    print(
+        "WARNING: 'forge-webhook' is deprecated. Use 'forge wh' instead.",
+        file=sys.stderr,
+    )
 
     config = _get_config()
     uvicorn.run(


### PR DESCRIPTION
**@worker-04**

## Summary
- Add deprecation warning to `forge-webhook` entry point, directing users to `forge wh`
- Add deprecation notice when `manage.py` is invoked directly, directing to `forge cron`
- Add Forge CLI usage section to root README
- Add redirect notes to `agent-kernel/cron/README.md` and `apps/webhook-monitor/README.md`
- Add note to `view.sh` that `forge logs` is the primary interface

## Test plan
- [ ] Run `forge-webhook` and verify deprecation warning prints to stderr
- [ ] Run `python agent-kernel/cron/manage.py list` and verify deprecation warning prints to stderr
- [ ] Verify root README Forge CLI section renders correctly
- [ ] Verify no broken links in updated READMEs

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
