### PR TITLE
Fix: Make all dashboard fonts monospaced (Geist Mono)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,7 +7,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -116,6 +115,6 @@
     @apply bg-background text-foreground;
   }
   html {
-    @apply font-sans;
+    @apply font-mono;
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,12 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
-
-const inter = Inter({
-  variable: "--font-sans",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Forge Dashboard",
@@ -21,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${inter.variable} ${GeistMono.variable} antialiased min-h-screen`}
+        className={`${GeistMono.variable} antialiased min-h-screen`}
       >
         {children}
       </body>

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -134,7 +134,7 @@ function AgentCard({
     <div className="rounded-md bg-surface p-2 border border-border hover:bg-surface-hover transition-colors">
       <div className="flex items-center gap-2 mb-1">
         <StatusDot running={agent.running} overdue={agent.overdue} />
-        <span className="font-mono text-base text-text-bright truncate flex-1 min-w-0">
+        <span className="text-base text-text-bright truncate flex-1 min-w-0">
           {agent.id}
         </span>
         <RoleBadge role={agent.role} />
@@ -151,7 +151,7 @@ function AgentCard({
         </button>
       </div>
 
-      <div className="flex items-center gap-3 text-sm text-text font-mono ml-4 mb-2">
+      <div className="flex items-center gap-3 text-sm text-text ml-4 mb-2">
         <span title="Interval">{agent.interval}</span>
         {agent.lastRun && (
           <span title={`Last run: ${agent.lastRun}`}>
@@ -167,7 +167,7 @@ function AgentCard({
 
       <div className="flex justify-end mr-1">
         <button
-          className={`text-xs font-mono rounded px-2 py-0.5 border transition-colors ${
+          className={`text-xs rounded px-2 py-0.5 border transition-colors ${
             isStarted
               ? "text-accent-green bg-accent-green/10 border-accent-green/20"
               : "text-accent-green bg-surface-hover hover:bg-accent-green/20 border-border"

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -54,7 +54,7 @@ function EventCard({ event }: { event: NormalizedEvent }) {
   return (
     <div className="rounded-md bg-surface p-2 border border-border">
       <div className="flex items-center gap-2 mb-1 flex-wrap">
-        <span className="text-sm font-mono text-muted-foreground">
+        <span className="text-sm text-muted-foreground">
           {formatTime(event.timestamp)}
         </span>
         <span
@@ -63,7 +63,7 @@ function EventCard({ event }: { event: NormalizedEvent }) {
           {event.raw_action}
         </span>
         {event.number > 0 && (
-          <span className="text-sm font-mono text-accent-blue">
+          <span className="text-sm text-accent-blue">
             #{event.number}
           </span>
         )}

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -255,7 +255,7 @@ function LogCard({
           {block.displayTime}
         </span>
       </div>
-      <pre className="text-text text-base font-mono whitespace-pre-wrap break-words leading-relaxed">
+      <pre className="text-text text-base whitespace-pre-wrap break-words leading-relaxed">
         {block.content}
       </pre>
     </div>


### PR DESCRIPTION
**@worker-01**

## Summary
- Make Geist Mono the base font for the entire dashboard by setting `html { @apply font-mono; }`
- Remove Inter font import and `--font-sans` CSS variable (no longer needed)
- Remove redundant `font-mono` classes from agent-panel, events-panel, and logs-panel components

## Test plan
- [ ] Verify all dashboard text renders in Geist Mono (headers, labels, data, buttons)
- [ ] Confirm no Inter/sans-serif font loading in browser dev tools
- [ ] `npm run build` passes

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
