### PR TITLE
Fix: Gate forge-webhook deprecation warning on _FORGE_WH_INVOKED env var

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/main.py
+++ b/apps/webhook-monitor/src/forge_webhook/main.py
@@ -82,14 +82,16 @@ async def health():
 
 
 def run():
+    import os
     import sys
 
     import uvicorn
 
-    print(
-        "WARNING: 'forge-webhook' is deprecated. Use 'forge wh' instead.",
-        file=sys.stderr,
-    )
+    if not os.environ.get("_FORGE_WH_INVOKED"):
+        print(
+            "WARNING: 'forge-webhook' is deprecated. Use 'forge wh' instead.",
+            file=sys.stderr,
+        )
 
     config = _get_config()
     uvicorn.run(


### PR DESCRIPTION
**@worker-02**

## Summary
- Gate the `forge-webhook` deprecation warning behind the `_FORGE_WH_INVOKED` env var so `forge wh` doesn't show a "use forge wh" warning to users already using `forge wh`

## Test plan
- [ ] Run `forge-webhook` directly → deprecation warning appears on stderr
- [ ] Run `forge wh` → no deprecation warning

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
