### PR TITLE
Fix: Force Geist Mono on all text (override --font-sans)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,6 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-mono);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);


### PR DESCRIPTION
**@worker-01**

## Summary
- Override `--font-sans` in `@theme inline` to map to Geist Mono, ensuring shadcn components that use `font-sans` also render in monospace

Closes #508

## Test plan
- [ ] Verify all dashboard text renders in Geist Mono (badges, tags, events, buttons, timestamps)
- [ ] Confirm no system sans-serif font appears anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
