### PR TITLE
Fix: Package webhook monitor under forge CLI (forge wh)

### DIFF
--- a/apps/forge-cli/pyproject.toml
+++ b/apps/forge-cli/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "forge-cli"
 version = "0.1.0"
 description = "Forge — agent orchestration CLI"
-requires-python = ">=3.10"
-dependencies = ["click>=8.0"]
+requires-python = ">=3.11"
+dependencies = ["click>=8.0", "forge-webhook>=0.1.0"]
 
 [project.scripts]
 forge = "forge_cli.cli:main"

--- a/apps/forge-cli/src/forge_cli/webhook.py
+++ b/apps/forge-cli/src/forge_cli/webhook.py
@@ -1,31 +1,19 @@
 import os
-import shutil
 
 import click
-
-
-def _find_forge_webhook() -> str:
-    """Find the forge-webhook binary on PATH."""
-    path = shutil.which("forge-webhook")
-    if path:
-        return path
-    raise click.ClickException(
-        "forge-webhook not found on PATH. Install the forge-webhook package first."
-    )
 
 
 @click.command()
 @click.option("--port", type=int, default=None, help="Port for the webhook server")
 def wh(port):
     """Start the webhook monitor."""
-    env = os.environ.copy()
     if port is not None:
-        env["FORGE_WEBHOOK_PORT"] = str(port)
+        os.environ["FORGE_WEBHOOK_PORT"] = str(port)
 
-    binary = _find_forge_webhook()
-    # Signal to forge-webhook that it was invoked via `forge wh`,
-    # so it can suppress its deprecation warning.
-    env["_FORGE_WH_INVOKED"] = "1"
-    # argv is [binary] with no additional args — forge-webhook reads
-    # its configuration (e.g. port) from environment variables.
-    os.execve(binary, [binary], env)
+    # Signal that we were invoked via `forge wh` to suppress the
+    # deprecation warning inside the webhook monitor.
+    os.environ["_FORGE_WH_INVOKED"] = "1"
+
+    from forge_webhook.main import run
+
+    run()


### PR DESCRIPTION
**@worker-02**

## Summary
- Replace `os.execve()` subprocess call to `forge-webhook` binary with a direct Python import of `forge_webhook.main.run()`
- Add `forge-webhook` as a dependency in `forge-cli`'s `pyproject.toml`
- `forge wh` is now self-contained — no need for `forge-webhook` separately on PATH

Closes #506

## Test plan
- [ ] Run `forge wh` and verify the webhook monitor starts without needing `forge-webhook` on PATH
- [ ] Verify `--port` flag still works
- [ ] Verify deprecation warning is suppressed when invoked via `forge wh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
