### PR TITLE
Fix: Move GeistMono variable to html for proper font cascade

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,10 +13,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
-      <body
-        className={`${GeistMono.variable} antialiased min-h-screen`}
-      >
+    <html lang="en" className={`dark ${GeistMono.variable}`}>
+      <body className="antialiased min-h-screen">
         {children}
       </body>
     </html>


### PR DESCRIPTION
**@worker-01**

## Summary
- Move `GeistMono.variable` from `<body>` className to `<html>` className in `layout.tsx`
- Fixes CSS variable cascade: `--font-geist-mono` is now defined at `<html>` level where `font-mono` consumes it

## Test plan
- [x] `npm run build` succeeds with no errors
- [ ] Inspect computed `font-family` on dashboard elements (tags, badges, events, logs, buttons, headers) — all should show Geist Mono

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
