### PR TITLE
Add `forge clear` command — reset staged config

### DIFF
--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -3,44 +3,15 @@
 import json
 import os
 import re
-import subprocess
 import sys
 
 import click
 
-
-def _repo_root():
-    """Return the repository root directory."""
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            stderr=subprocess.DEVNULL,
-            text=True,
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        click.echo("Error: not inside a git repository.", err=True)
-        sys.exit(1)
+from forge_cli.paths import cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
 
 
 def _templates_dir():
-    return os.path.join(_repo_root(), "templates")
-
-
-def _cron_jobs_path():
-    return os.path.join(_repo_root(), "agent-kernel", "cron", "cron-jobs.json")
-
-
-def _load_cron_jobs(path):
-    if not os.path.exists(path):
-        return {"stagger": True, "jobs": []}
-    with open(path) as f:
-        return json.load(f)
-
-
-def _save_cron_jobs(path, data):
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
+    return os.path.join(repo_root(), "templates")
 
 
 def _available_templates():
@@ -104,8 +75,8 @@ def add(agent_type, agent_id, interval, list_templates):
     with open(templates[agent_type]) as f:
         template = json.load(f)
 
-    cron_path = _cron_jobs_path()
-    cron_data = _load_cron_jobs(cron_path)
+    cron_path = cron_jobs_path()
+    cron_data = load_cron_jobs(cron_path)
     existing_ids = [j["id"] for j in cron_data.get("jobs", [])]
 
     if agent_id is None:
@@ -123,7 +94,7 @@ def add(agent_type, agent_id, interval, list_templates):
     job["workspace"] = template.get("workspace", False)
 
     cron_data.setdefault("jobs", []).append(job)
-    _save_cron_jobs(cron_path, cron_data)
+    save_cron_jobs(cron_path, cron_data)
 
     click.echo(f"Added {agent_id} (template: {agent_type}, interval: {job['interval']})")
     click.echo("Run `forge cron apply` to activate.")
@@ -133,8 +104,8 @@ def add(agent_type, agent_id, interval, list_templates):
 @click.argument("agent_id")
 def remove(agent_id):
     """Remove an agent by ID."""
-    cron_path = _cron_jobs_path()
-    cron_data = _load_cron_jobs(cron_path)
+    cron_path = cron_jobs_path()
+    cron_data = load_cron_jobs(cron_path)
 
     jobs = cron_data.get("jobs", [])
     new_jobs = [j for j in jobs if j["id"] != agent_id]
@@ -144,7 +115,7 @@ def remove(agent_id):
         sys.exit(1)
 
     cron_data["jobs"] = new_jobs
-    _save_cron_jobs(cron_path, cron_data)
+    save_cron_jobs(cron_path, cron_data)
 
     click.echo(f"Removed {agent_id}")
     click.echo("Run `forge cron apply` to activate.")

--- a/apps/forge-cli/src/forge_cli/clear_cmd.py
+++ b/apps/forge-cli/src/forge_cli/clear_cmd.py
@@ -1,0 +1,32 @@
+"""forge clear — reset staged config to empty state."""
+
+import click
+
+from forge_cli.paths import cron_jobs_path, load_cron_jobs, save_cron_jobs
+
+
+@click.command("clear")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+def clear_cmd(yes):
+    """Reset staged config — remove all agents from cron-jobs.json."""
+    path = cron_jobs_path()
+    data = load_cron_jobs(path)
+    jobs = data.get("jobs", [])
+
+    if not jobs:
+        click.echo("Nothing to clear — no staged agents.")
+        return
+
+    click.echo(f"Staged agents ({len(jobs)}):")
+    for job in jobs:
+        click.echo(f"  {job['id']}  ({job.get('interval', '?')})")
+
+    if not yes:
+        click.confirm("Clear all staged agents?", abort=True)
+
+    count = len(jobs)
+    data["jobs"] = []
+    save_cron_jobs(path, data)
+
+    click.echo(f"Cleared {count} staged agent{'s' if count != 1 else ''} from config.")
+    click.echo("Run `forge cron apply` to deactivate them.")

--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from forge_cli.agents import add, remove
+from forge_cli.clear_cmd import clear_cmd
 from forge_cli.cron import cron
 from forge_cli.logs import logs
 from forge_cli.webhook import wh
@@ -13,6 +14,7 @@ def main():
 
 main.add_command(add)
 main.add_command(remove)
+main.add_command(clear_cmd, name="clear")
 main.add_command(cron)
 main.add_command(logs)
 main.add_command(wh)

--- a/apps/forge-cli/src/forge_cli/paths.py
+++ b/apps/forge-cli/src/forge_cli/paths.py
@@ -1,0 +1,38 @@
+"""Shared path and config helpers for forge-cli."""
+
+import json
+import os
+import subprocess
+import sys
+
+import click
+
+
+def repo_root():
+    """Return the repository root directory."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        click.echo("Error: not inside a git repository.", err=True)
+        sys.exit(1)
+
+
+def cron_jobs_path():
+    return os.path.join(repo_root(), "agent-kernel", "cron", "cron-jobs.json")
+
+
+def load_cron_jobs(path):
+    if not os.path.exists(path):
+        return {"stagger": True, "jobs": []}
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_cron_jobs(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")


### PR DESCRIPTION
**@worker-01**

## Summary
- Adds `forge clear` command that resets `cron-jobs.json` to empty state (`{"stagger": true, "jobs": []}`)
- Extracts shared path/config helpers (`repo_root`, `cron_jobs_path`, `load_cron_jobs`, `save_cron_jobs`) into `paths.py` module
- Updates `agents.py` to import from shared `paths.py` instead of private helpers

## Test plan
- [ ] Run `forge clear` with staged agents — verify it lists them, prompts, then clears
- [ ] Run `forge clear -y` — verify it skips confirmation
- [ ] Run `forge clear` with empty config — verify "Nothing to clear" message
- [ ] Run `forge add worker` / `forge remove <id>` — verify agents.py still works after refactor

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)
