### PR TITLE
Improve CLI output formatting for add/remove/cron commands

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -10,6 +10,20 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 
+# ── ANSI color helpers ────────────────────────────────────────
+
+def _color(text, code):
+    """Wrap text in ANSI color escape codes."""
+    if not sys.stdout.isatty():
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+def _green(text):  return _color(text, "32")
+def _red(text):    return _color(text, "31")
+def _yellow(text): return _color(text, "33")
+def _dim(text):    return _color(text, "2")
+
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 KERNEL_DIR = os.path.dirname(SCRIPT_DIR)
 REPO_DIR = os.path.dirname(KERNEL_DIR)
@@ -268,12 +282,15 @@ def cmd_apply(args):
 
     crontab = read_crontab()
 
-    for job_id in to_remove:
+    print("Applied cron changes:")
+
+    for job_id in sorted(to_remove):
+        old_interval = actual[job_id].get("interval", "?")
         crontab = remove_job_from_crontab(crontab, job_id)
         del state["jobs"][job_id]
-        print(f"  - Removed: {job_id}")
+        print(_red(f"  - {job_id:<20} {old_interval:<6} (removed)"))
 
-    for job_id in to_add | to_update:
+    for job_id in sorted(to_add | to_update):
         job = desired[job_id]
         contexts = job.get("contexts", [])
         repo = job.get("repo", "")
@@ -306,17 +323,26 @@ def cmd_apply(args):
             "stagger_offset": offset if stagger else 0,
             "installed_at": now_iso(),
         }
-        action = "Added" if job_id in to_add else "Updated"
-        sym = "+" if job_id in to_add else "~"
-        offset_info = f" (stagger: +{offset}s)" if stagger and offset > 0 else ""
-        print(f"  {sym} {action}: {job_id}{offset_info}")
+        if job_id in to_add:
+            print(_green(f"  + {job_id:<20} {job['interval']:<6} (new)"))
+        else:
+            old_interval = actual[job_id].get("interval", "?")
+            if old_interval != job["interval"]:
+                print(_yellow(f"  ~ {job_id:<20} {old_interval} \u2192 {job['interval']:<6} (updated)"))
+            else:
+                print(_yellow(f"  ~ {job_id:<20} {job['interval']:<6} (updated)"))
+
+    for job_id in sorted(no_change):
+        interval = desired[job_id]["interval"]
+        print(_dim(f"  = {job_id:<20} {interval:<6} (unchanged)"))
 
     write_crontab(crontab)
     state["stagger"] = stagger
     save_state(state)
 
-    print(f"Applied: +{len(to_add)} added, ~{len(to_update)} updated, "
-          f"-{len(to_remove)} removed, {len(no_change)} unchanged")
+    total_active = len(desired)
+    print()
+    print(f"{total_active} agent{'s' if total_active != 1 else ''} active.")
 
 
 def cmd_add(args):

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -125,7 +125,19 @@ def add(agent_type, agent_id, interval, list_templates):
     cron_data.setdefault("jobs", []).append(job)
     _save_cron_jobs(cron_path, cron_data)
 
-    click.echo(f"Added {agent_id} (template: {agent_type}, interval: {job['interval']})")
+    click.echo(click.style(
+        f"Staged {agent_id} (template: {agent_type}, interval: {job['interval']})",
+        fg="green",
+    ))
+    prompt_display = job["prompt"]
+    if len(prompt_display) > 60:
+        prompt_display = prompt_display[:57] + "..."
+    click.echo(f"  prompt:    \"{prompt_display}\"")
+    if job["contexts"]:
+        click.echo(f"  contexts:  {', '.join(job['contexts'])}")
+    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
+    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+    click.echo()
     click.echo("Run `forge cron apply` to activate.")
 
 
@@ -137,6 +149,7 @@ def remove(agent_id):
     cron_data = _load_cron_jobs(cron_path)
 
     jobs = cron_data.get("jobs", [])
+    removed = [j for j in jobs if j["id"] == agent_id]
     new_jobs = [j for j in jobs if j["id"] != agent_id]
 
     if len(new_jobs) == len(jobs):
@@ -146,5 +159,10 @@ def remove(agent_id):
     cron_data["jobs"] = new_jobs
     _save_cron_jobs(cron_path, cron_data)
 
-    click.echo(f"Removed {agent_id}")
-    click.echo("Run `forge cron apply` to activate.")
+    interval = removed[0].get("interval", "?") if removed else "?"
+    click.echo(click.style(
+        f"Unstaged {agent_id} (was: interval {interval})",
+        fg="red",
+    ))
+    click.echo()
+    click.echo("Run `forge cron apply` to deactivate.")


### PR DESCRIPTION
**@worker-03**

## Summary
- Enhanced `forge add` to show full staged agent config (prompt, contexts, agentic, workspace) with green color
- Enhanced `forge remove` to show unstaged agent with interval info and red color
- Enhanced `forge cron apply` with color-coded diff output: green (+) new, red (-) removed, yellow (~) updated, dim (=) unchanged
- Added ANSI color helpers to `manage.py` with TTY detection (no colors when piped)

## Test plan
- [ ] Run `forge add worker` and verify full config is displayed with green styling
- [ ] Run `forge remove <agent-id>` and verify unstaged message with interval info
- [ ] Run `forge cron apply` with a mix of new/removed/updated/unchanged agents and verify color-coded diff
- [ ] Pipe `forge cron apply` output to a file and verify no ANSI escape codes in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
