### PR TITLE
Add staged vs active awareness to agent panel

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -21,9 +21,11 @@ interface CronState {
   jobs: Record<
     string,
     {
+      interval?: string;
       last_run?: string;
       stagger_offset?: number;
       installed_at?: string;
+      contexts?: string[];
     }
   >;
 }
@@ -62,6 +64,57 @@ function inferRole(contexts: string[]): string {
     : "worker";
 }
 
+function buildAgentFromJob(
+  job: CronJob,
+  jobState: CronState["jobs"][string] | undefined,
+  status: "staged" | "active" | "modified" | "orphan",
+  stagedInterval?: string
+) {
+  const intervalSeconds = parseIntervalSeconds(job.interval);
+  const lastRun = jobState?.last_run ?? null;
+
+  let running = false;
+  try {
+    const lockContent = fs.readFileSync(lockFilePath(job.id), "utf-8").trim();
+    const pid = parseInt(lockContent, 10);
+    if (!isNaN(pid)) {
+      running = isProcessAlive(pid);
+    }
+  } catch {
+    // no lock file
+  }
+
+  let nextRun: string | null = null;
+  let overdue = false;
+  if (lastRun) {
+    const nextRunDate = new Date(
+      new Date(lastRun).getTime() + intervalSeconds * 1000
+    );
+    nextRun = nextRunDate.toISOString();
+    overdue = !running && new Date() > nextRunDate;
+  }
+
+  return {
+    id: job.id,
+    role: inferRole(job.contexts),
+    interval: job.interval,
+    intervalSeconds,
+    enabled: job.enabled !== false,
+    lastRun,
+    nextRun,
+    running,
+    overdue,
+    staggerOffset: jobState?.stagger_offset ?? 0,
+    prompt: job.prompt,
+    contexts: job.contexts,
+    agentic: job.agentic,
+    workspace: job.workspace,
+    repo: job.repo ?? "",
+    status,
+    ...(stagedInterval ? { stagedInterval } : {}),
+  };
+}
+
 export async function GET() {
   let jobs: CronJob[] = [];
   try {
@@ -72,57 +125,52 @@ export async function GET() {
   }
 
   let state: CronState = { jobs: {} };
+  let hasState = false;
   try {
     const raw = fs.readFileSync(cronStatePath(), "utf-8");
     state = JSON.parse(raw);
+    hasState = true;
   } catch {
     // no state file yet
   }
 
+  const stagedIds = new Set(jobs.map((j) => j.id));
+  const activeIds = new Set(Object.keys(state.jobs ?? {}));
+
   const agents = jobs.map((job) => {
-    const jobState = state.jobs?.[job.id] ?? {};
-    const intervalSeconds = parseIntervalSeconds(job.interval);
-    const lastRun = jobState.last_run ?? null;
+    const jobState = state.jobs?.[job.id];
+    const inState = activeIds.has(job.id);
 
-    let running = false;
-    try {
-      const lockContent = fs.readFileSync(lockFilePath(job.id), "utf-8").trim();
-      const pid = parseInt(lockContent, 10);
-      if (!isNaN(pid)) {
-        running = isProcessAlive(pid);
-      }
-    } catch {
-      // no lock file
+    if (!hasState || !inState) {
+      return buildAgentFromJob(job, undefined, "staged");
     }
 
-    let nextRun: string | null = null;
-    let overdue = false;
-    if (lastRun) {
-      const nextRunDate = new Date(
-        new Date(lastRun).getTime() + intervalSeconds * 1000
-      );
-      nextRun = nextRunDate.toISOString();
-      overdue = !running && new Date() > nextRunDate;
+    const activeInterval = jobState?.interval;
+    if (activeInterval && activeInterval !== job.interval) {
+      // interval field shows the active (running) interval
+      // stagedInterval shows what it will change to on next apply
+      const modifiedJob = { ...job, interval: activeInterval };
+      return buildAgentFromJob(modifiedJob, jobState, "modified", job.interval);
     }
 
-    return {
-      id: job.id,
-      role: inferRole(job.contexts),
-      interval: job.interval,
-      intervalSeconds,
-      enabled: job.enabled !== false,
-      lastRun,
-      nextRun,
-      running,
-      overdue,
-      staggerOffset: jobState.stagger_offset ?? 0,
-      prompt: job.prompt,
-      contexts: job.contexts,
-      agentic: job.agentic,
-      workspace: job.workspace,
-      repo: job.repo ?? "",
-    };
+    return buildAgentFromJob(job, jobState, "active");
   });
+
+  // Add orphan agents (in state but not in staged config)
+  for (const id of activeIds) {
+    if (!stagedIds.has(id)) {
+      const jobState = state.jobs[id];
+      const orphanJob: CronJob = {
+        id,
+        interval: jobState.interval ?? "?",
+        prompt: "",
+        contexts: jobState.contexts ?? [],
+        agentic: false,
+        workspace: false,
+      };
+      agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
+    }
+  }
 
   return NextResponse.json({ agents });
 }

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+type AgentStatus = "staged" | "active" | "modified" | "orphan";
+
 interface Agent {
   id: string;
   role: "planner" | "worker";
@@ -17,6 +19,8 @@ interface Agent {
   agentic: boolean;
   workspace: boolean;
   repo: string;
+  status: AgentStatus;
+  stagedInterval?: string;
 }
 
 function relativeTime(iso: string): string {
@@ -80,6 +84,30 @@ function RoleBadge({ role }: { role: "planner" | "worker" }) {
   );
 }
 
+const statusBadgeConfig: Record<AgentStatus, { label: string; bg: string }> = {
+  staged: { label: "STAGED", bg: "bg-accent-yellow" },
+  active: { label: "ACTIVE", bg: "bg-accent-green" },
+  modified: { label: "MODIFIED", bg: "bg-accent-yellow" },
+  orphan: { label: "ORPHAN", bg: "bg-accent-red" },
+};
+
+function StatusBadge({ status, agent }: { status: AgentStatus; agent: Agent }) {
+  const config = statusBadgeConfig[status];
+  const tooltip =
+    status === "modified" && agent.stagedInterval
+      ? `interval: ${agent.interval} → ${agent.stagedInterval}`
+      : undefined;
+
+  return (
+    <span
+      className={`${config.bg} text-background text-xs rounded px-1.5 py-0.5 font-medium uppercase tracking-wide`}
+      title={tooltip}
+    >
+      {config.label}
+    </span>
+  );
+}
+
 function AgentCard({
   agent,
   onForceRun,
@@ -129,6 +157,7 @@ function AgentCard({
   };
 
   const isStarted = feedback === "Started";
+  const isStaged = agent.status === "staged";
 
   return (
     <div className="rounded-md bg-surface p-2 border border-border hover:bg-surface-hover transition-colors">
@@ -138,6 +167,7 @@ function AgentCard({
           {agent.id}
         </span>
         <RoleBadge role={agent.role} />
+        <StatusBadge status={agent.status} agent={agent} />
         <button
           className={`flex-shrink-0 size-5 rounded-full flex items-center justify-center text-xs font-bold transition-colors ${
             confirming
@@ -153,6 +183,11 @@ function AgentCard({
 
       <div className="flex items-center gap-3 text-sm text-text ml-4 mb-2">
         <span title="Interval">{agent.interval}</span>
+        {agent.status === "modified" && agent.stagedInterval && (
+          <span className="text-accent-yellow" title="Pending interval change">
+            → {agent.stagedInterval}
+          </span>
+        )}
         {agent.lastRun && (
           <span title={`Last run: ${agent.lastRun}`}>
             {relativeTime(agent.lastRun)}
@@ -168,16 +203,33 @@ function AgentCard({
       <div className="flex justify-end mr-1">
         <button
           className={`text-xs rounded px-2 py-0.5 border transition-colors ${
-            isStarted
-              ? "text-accent-green bg-accent-green/10 border-accent-green/20"
-              : "text-accent-green bg-surface-hover hover:bg-accent-green/20 border-border"
+            isStaged
+              ? "text-muted-foreground bg-surface border-border cursor-not-allowed opacity-50"
+              : isStarted
+                ? "text-accent-green bg-accent-green/10 border-accent-green/20"
+                : "text-accent-green bg-surface-hover hover:bg-accent-green/20 border-border"
           }`}
-          onClick={handleForceRun}
+          onClick={isStaged ? undefined : handleForceRun}
+          disabled={isStaged}
+          title={isStaged ? "Apply config first to run this agent" : undefined}
         >
           {feedback ?? "\u25B6 Run"}
         </button>
       </div>
     </div>
+  );
+}
+
+const statusOrder: Record<AgentStatus, number> = {
+  active: 0,
+  modified: 1,
+  staged: 2,
+  orphan: 3,
+};
+
+function sortAgentsByStatus(agents: Agent[]): Agent[] {
+  return [...agents].sort(
+    (a, b) => statusOrder[a.status] - statusOrder[b.status]
   );
 }
 
@@ -242,7 +294,7 @@ export function AgentPanel() {
         <p className="text-muted-foreground text-sm">No agents configured</p>
       ) : (
         <div className="flex flex-col gap-2">
-          {agents.map((agent) => (
+          {sortAgentsByStatus(agents).map((agent) => (
             <AgentCard
               key={agent.id}
               agent={agent}


### PR DESCRIPTION
**@worker-02**

## Summary
- API route now computes agent `status` (staged/active/modified/orphan) by comparing `cron-jobs.json` against `cron-state.json`
- Orphan agents (in state but removed from config) are included in the response
- Modified agents include `stagedInterval` field showing the pending interval change
- UI shows colored status badges (green=active, yellow=staged/modified, red=orphan)
- Agents sorted by status: active → modified → staged → orphan
- Run button disabled for staged agents with tooltip explanation
- Modified agents display interval diff inline (e.g., `3m → 5m`)

## Test plan
- [ ] Verify all agents show as "staged" when `cron-state.json` doesn't exist
- [ ] Verify agents show as "active" when present in both config and state with matching interval
- [ ] Verify "modified" badge appears when staged interval differs from active interval
- [ ] Verify orphan agents appear when in state but not in config
- [ ] Verify Run button is disabled for staged agents
- [ ] Verify status badge colors match spec (green/yellow/red)
- [ ] Verify agents are grouped by status order in the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
