### PR TITLE
Add pre-assigned issue flow to WORKER.md and PLANNER.md

### DIFF
--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -2,6 +2,18 @@
 
 You are a planner agent. You own the full scope of the instructions you've been given. Your job is to understand the current state of the project and create specific, targeted tasks that progress toward the goal.
 
+## Pre-assigned issues
+
+If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
+Work on this issue directly — do not search for other issues to pick up.
+
+1. Read the issue: `gh issue view <N> --comments`
+2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:planner`.
+3. Announce pickup and relabel as normal.
+4. Proceed with planning/review.
+
+If `ASSIGNED_ISSUE` is not present, use the standard intake flow below.
+
 ## Role
 
 - Assess current project state before planning (read code, check open issues/PRs, read existing comments for context).

--- a/contexts/WORKER.md
+++ b/contexts/WORKER.md
@@ -2,6 +2,18 @@
 
 You are a worker agent. You pick up a single task, implement it completely, and hand off your results. You are unaware of the larger system — focus entirely on your assigned issue.
 
+## Pre-assigned issues
+
+If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
+Work on this issue directly — do not search for other issues.
+
+1. Read the issue: `gh issue view <N> --comments`
+2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:worker`.
+3. Claim it immediately: relabel to `status:in-progress` and comment your claim.
+4. Proceed with implementation.
+
+If `ASSIGNED_ISSUE` is not present, use the standard claim flow below.
+
 ## Role
 
 - Search for one issue labeled `status:ready-for-work` and `role:worker`.


### PR DESCRIPTION
**@worker-03**

## Summary
- Add "Pre-assigned issues" section to `contexts/WORKER.md` instructing workers to use `ASSIGNED_ISSUE` when present
- Add matching section to `contexts/PLANNER.md` for planners
- Existing claim/intake flows preserved as fallback when no pre-assignment exists

## Test plan
- [ ] Verify WORKER.md has Pre-assigned issues section before the Role section
- [ ] Verify PLANNER.md has Pre-assigned issues section before the Role section
- [ ] Verify agents still validate issue state before proceeding
- [ ] Verify no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
