### PR TITLE
Reverse log and event display order (newest at bottom)

### DIFF
--- a/apps/web/src/app/api/events/route.ts
+++ b/apps/web/src/app/api/events/route.ts
@@ -27,9 +27,8 @@ export async function GET(request: NextRequest) {
 
   const total = lines.length;
 
-  // Reverse lines so index 0 = most recent, then paginate
-  const reversed = [...lines].reverse();
-  const slice = reversed.slice(offset, offset + MAX_EVENTS_PER_RESPONSE);
+  // Lines are already in chronological order (oldest first), paginate from start
+  const slice = lines.slice(offset, offset + MAX_EVENTS_PER_RESPONSE);
 
   const events: unknown[] = [];
   for (const line of slice) {

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -91,8 +91,11 @@ function EventCard({ event }: { event: NormalizedEvent }) {
 export function EventsPanel() {
   const [events, setEvents] = useState<NormalizedEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
   const totalRef = useRef(0);
   const mountedRef = useRef(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevScrollTop = useRef(0);
 
   const fetchEvents = useCallback(async () => {
     try {
@@ -101,7 +104,7 @@ export function EventsPanel() {
       const data = await res.json();
       if (mountedRef.current) {
         const fetched: NormalizedEvent[] = data.events ?? [];
-        setEvents(fetched.slice(0, MAX_DISPLAY));
+        setEvents(fetched.slice(-MAX_DISPLAY));
         totalRef.current = data.total ?? 0;
         setError(null);
       }
@@ -122,6 +125,25 @@ export function EventsPanel() {
     };
   }, [fetchEvents]);
 
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 20;
+    if (!atBottom && el.scrollTop < prevScrollTop.current) {
+      setAutoScroll(false);
+    }
+    if (atBottom) {
+      setAutoScroll(true);
+    }
+    prevScrollTop.current = el.scrollTop;
+  }, []);
+
+  useEffect(() => {
+    if (autoScroll && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [events, autoScroll]);
+
   return (
     <div className="bg-surface px-3 pb-3 flex flex-col h-full min-h-0">
       {error && <p className="text-accent-red text-xs mb-2 shrink-0">{error}</p>}
@@ -129,7 +151,11 @@ export function EventsPanel() {
       {events.length === 0 && !error ? (
         <p className="text-muted-foreground text-sm">No events yet.</p>
       ) : (
-        <div className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0">
+        <div
+          ref={containerRef}
+          onScroll={handleScroll}
+          className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
+        >
           {events.map((event, i) => (
             <EventCard key={`${event.timestamp}-${i}`} event={event} />
           ))}

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -67,10 +67,10 @@ export function LogsPanel() {
           const merged = [...prev, ...fresh];
           merged.sort(
             (a, b) =>
-              new Date(b.timestamp).getTime() -
-              new Date(a.timestamp).getTime()
+              new Date(a.timestamp).getTime() -
+              new Date(b.timestamp).getTime()
           );
-          return merged.slice(0, MAX_BLOCKS);
+          return merged.slice(-MAX_BLOCKS);
         });
       }
     } else {
@@ -119,20 +119,20 @@ export function LogsPanel() {
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
-    // Container scrolls; top = 0 means at newest (top)
-    if (el.scrollTop < prevScrollTop.current && el.scrollTop > 10) {
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 20;
+    if (!atBottom && el.scrollTop < prevScrollTop.current) {
       setAutoScroll(false);
     }
-    if (el.scrollTop <= 5) {
+    if (atBottom) {
       setAutoScroll(true);
     }
     prevScrollTop.current = el.scrollTop;
   }, []);
 
-  // Scroll to top when new blocks arrive and autoScroll is on
+  // Scroll to bottom when new blocks arrive and autoScroll is on
   useEffect(() => {
     if (autoScroll && containerRef.current) {
-      containerRef.current.scrollTop = 0;
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
   }, [blocks, autoScroll]);
 


### PR DESCRIPTION
**@worker-03**

## Summary
- Reverse log and event display order so newest entries appear at the bottom (like a terminal)
- Auto-scroll now pins to bottom; scrolling up disables auto-scroll, returning to bottom re-enables it
- Events API returns chronological order instead of reversed
- `MAX_BLOCKS` limit keeps the latest N blocks instead of the oldest N

## Test plan
- [ ] Verify logs panel shows oldest runs at top, newest at bottom
- [ ] Verify events panel shows oldest events at top, newest at bottom
- [ ] Confirm auto-scroll keeps view pinned to bottom on new content
- [ ] Scroll up in logs/events — auto-scroll should disengage
- [ ] Scroll back to bottom — auto-scroll should re-engage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
