### PR TITLE
Add agent management actions (add/apply/clear) to web dashboard

### DIFF
--- a/apps/web/src/app/api/agents/apply/route.ts
+++ b/apps/web/src/app/api/agents/apply/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { spawnSync } from "child_process";
+import { managePyPath, getForgeRoot } from "@/lib/paths";
+
+export async function POST() {
+  try {
+    const result = spawnSync(
+      "python3",
+      [managePyPath(), "apply"],
+      {
+        cwd: getForgeRoot(),
+        timeout: 30_000,
+        encoding: "utf-8",
+      }
+    );
+
+    return NextResponse.json({
+      ok: result.status === 0,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/clear/route.ts
+++ b/apps/web/src/app/api/agents/clear/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { cronJobsPath } from "@/lib/paths";
+
+function atomicWriteJsonSync(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  const content = JSON.stringify(data, null, 2) + "\n";
+  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
+  fs.writeFileSync(tmpPath, content, "utf-8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+export async function POST() {
+  try {
+    const filePath = cronJobsPath();
+    let count = 0;
+
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const data = JSON.parse(raw);
+      count = Array.isArray(data.jobs) ? data.jobs.length : 0;
+    } catch {
+      // file doesn't exist or is invalid — will write fresh
+    }
+
+    atomicWriteJsonSync(filePath, { stagger: true, jobs: [] });
+
+    return NextResponse.json({ ok: true, removed: count });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,9 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
+import path from "path";
 import {
   cronJobsPath,
   cronStatePath,
   lockFilePath,
+  templatePath,
 } from "@/lib/paths";
 
 interface CronJob {
@@ -173,4 +175,102 @@ export async function GET() {
   }
 
   return NextResponse.json({ agents });
+}
+
+const SAFE_TYPE_RE = /^(worker|planner)$/;
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+function atomicWriteJsonSync(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  const content = JSON.stringify(data, null, 2) + "\n";
+  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
+  fs.writeFileSync(tmpPath, content, "utf-8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const type: string = body.type;
+
+    if (!type || !SAFE_TYPE_RE.test(type)) {
+      return NextResponse.json(
+        { error: "type must be 'worker' or 'planner'" },
+        { status: 400 }
+      );
+    }
+
+    let template;
+    try {
+      const raw = fs.readFileSync(templatePath(type), "utf-8");
+      template = JSON.parse(raw);
+    } catch {
+      return NextResponse.json(
+        { error: `Template not found: ${type}` },
+        { status: 500 }
+      );
+    }
+
+    const filePath = cronJobsPath();
+    let data: { stagger?: boolean; jobs: CronJob[] } = { stagger: true, jobs: [] };
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      data = JSON.parse(raw);
+      if (!Array.isArray(data.jobs)) data.jobs = [];
+    } catch {
+      // fresh config
+    }
+
+    let id: string = body.id ?? "";
+    if (id && !SAFE_ID_RE.test(id)) {
+      return NextResponse.json(
+        { error: "Invalid agent ID format" },
+        { status: 400 }
+      );
+    }
+
+    if (!id) {
+      const existingIds = new Set(data.jobs.map((j) => j.id));
+      for (let n = 1; n <= 99; n++) {
+        const candidate = `${type}-${String(n).padStart(2, "0")}`;
+        if (!existingIds.has(candidate)) {
+          id = candidate;
+          break;
+        }
+      }
+      if (!id) {
+        return NextResponse.json(
+          { error: "Too many agents of this type" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (data.jobs.some((j) => j.id === id)) {
+      return NextResponse.json(
+        { error: `Agent ${id} already exists` },
+        { status: 409 }
+      );
+    }
+
+    const newJob: CronJob = {
+      id,
+      interval: body.interval ?? template.interval ?? "2m",
+      prompt: template.prompt ?? "",
+      contexts: template.contexts ?? [],
+      agentic: template.agentic ?? true,
+      workspace: template.workspace ?? true,
+    };
+
+    data.jobs.push(newJob);
+    atomicWriteJsonSync(filePath, data);
+
+    return NextResponse.json({ ok: true, agent: newJob });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 }
+    );
+  }
 }

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -233,9 +233,77 @@ function sortAgentsByStatus(agents: Agent[]): Agent[] {
   );
 }
 
+function AddAgentForm({ onAdded }: { onAdded: () => void }) {
+  const [type, setType] = useState<"worker" | "planner">("worker");
+  const [customId, setCustomId] = useState("");
+  const [interval, setInterval] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const body: Record<string, string> = { type };
+      if (customId.trim()) body.id = customId.trim();
+      if (interval.trim()) body.interval = interval.trim();
+      const res = await fetch("/api/agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        setCustomId("");
+        setInterval("");
+        onAdded();
+      }
+    } catch {
+      // best-effort
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-surface border border-border rounded-md p-2 mb-2">
+      <div className="flex items-center gap-2">
+        <select
+          className="bg-background border border-border rounded px-2 py-1 text-sm text-text"
+          value={type}
+          onChange={(e) => setType(e.target.value as "worker" | "planner")}
+        >
+          <option value="worker">worker</option>
+          <option value="planner">planner</option>
+        </select>
+        <input
+          className="bg-background border border-border rounded px-2 py-1 text-sm text-text w-28"
+          placeholder="ID (auto)"
+          value={customId}
+          onChange={(e) => setCustomId(e.target.value)}
+        />
+        <input
+          className="bg-background border border-border rounded px-2 py-1 text-sm text-text w-20"
+          placeholder="2m"
+          value={interval}
+          onChange={(e) => setInterval(e.target.value)}
+        />
+        <button
+          className="text-xs rounded px-2 py-1 border border-accent-green text-accent-green hover:bg-accent-green/20 transition-colors disabled:opacity-50"
+          onClick={handleSubmit}
+          disabled={submitting}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function AgentPanel() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [clearConfirming, setClearConfirming] = useState(false);
+  const clearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
 
   const fetchAgents = useCallback(async () => {
@@ -261,8 +329,14 @@ export function AgentPanel() {
     return () => {
       mountedRef.current = false;
       clearInterval(id);
+      if (clearTimeoutRef.current) clearTimeout(clearTimeoutRef.current);
     };
   }, [fetchAgents]);
+
+  const showFeedback = (msg: string) => {
+    setActionFeedback(msg);
+    setTimeout(() => setActionFeedback(null), 3000);
+  };
 
   const handleForceRun = async (agentId: string) => {
     try {
@@ -283,8 +357,89 @@ export function AgentPanel() {
     }
   };
 
+  const handleApply = async () => {
+    try {
+      const res = await fetch("/api/agents/apply", { method: "POST" });
+      const data = await res.json();
+      showFeedback(data.ok ? "Applied" : `Error: ${data.error || data.stderr}`);
+      fetchAgents();
+    } catch {
+      showFeedback("Apply failed");
+    }
+  };
+
+  const handleClear = async () => {
+    if (!clearConfirming) {
+      setClearConfirming(true);
+      clearTimeoutRef.current = setTimeout(() => setClearConfirming(false), 3000);
+      return;
+    }
+    if (clearTimeoutRef.current) clearTimeout(clearTimeoutRef.current);
+    setClearConfirming(false);
+    try {
+      const res = await fetch("/api/agents/clear", { method: "POST" });
+      const data = await res.json();
+      showFeedback(data.ok ? `Cleared ${data.removed} agent(s)` : "Clear failed");
+      fetchAgents();
+    } catch {
+      showFeedback("Clear failed");
+    }
+  };
+
+  const stagedCount = agents.filter(
+    (a) => a.status === "staged" || a.status === "modified"
+  ).length;
+  const orphanCount = agents.filter((a) => a.status === "orphan").length;
+  const hasPendingChanges = stagedCount > 0 || orphanCount > 0;
+  const hasStagedAgents = agents.filter((a) => a.status !== "orphan").length > 0;
+
   return (
     <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
+      <div className="flex items-center gap-2 py-2">
+        <button
+          className="text-xs rounded px-2 py-1 border border-border text-text hover:bg-surface-hover transition-colors"
+          onClick={() => setShowAddForm((v) => !v)}
+        >
+          + Add
+        </button>
+        <button
+          className={`text-xs rounded px-2 py-1 border transition-colors ${
+            hasPendingChanges
+              ? "border-accent-green text-accent-green hover:bg-accent-green/20"
+              : "border-border text-muted-foreground cursor-not-allowed opacity-50"
+          }`}
+          onClick={hasPendingChanges ? handleApply : undefined}
+          disabled={!hasPendingChanges}
+          title={hasPendingChanges ? "Apply staged config" : "No pending changes"}
+        >
+          Apply
+        </button>
+        <button
+          className={`text-xs rounded px-2 py-1 border transition-colors ${
+            !hasStagedAgents
+              ? "border-border text-muted-foreground cursor-not-allowed opacity-50"
+              : clearConfirming
+                ? "border-accent-red bg-accent-red text-background"
+                : "border-accent-red text-accent-red hover:bg-accent-red/20"
+          }`}
+          onClick={hasStagedAgents ? handleClear : undefined}
+          disabled={!hasStagedAgents}
+          title={
+            !hasStagedAgents
+              ? "No staged agents"
+              : clearConfirming
+                ? "Click again to confirm"
+                : "Clear all staged config"
+          }
+        >
+          {clearConfirming ? "Confirm?" : "Clear"}
+        </button>
+        {actionFeedback && (
+          <span className="text-xs text-accent-cyan ml-auto">{actionFeedback}</span>
+        )}
+      </div>
+
+      {showAddForm && <AddAgentForm onAdded={() => { setShowAddForm(false); fetchAgents(); }} />}
 
       {error && (
         <p className="text-accent-red text-sm mb-2">{error}</p>

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -30,6 +30,10 @@ export function logsDir(): string {
   return path.join(getForgeRoot(), "agent-kernel/logs");
 }
 
+export function templatePath(type: string): string {
+  return path.join(getForgeRoot(), `templates/${type}.json`);
+}
+
 export function eventsPath(): string {
   return path.join(getForgeRoot(), "events.jsonl");
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- Add agent management actions (add, apply, clear) to the web dashboard
- Three new API routes: POST /api/agents (add), POST /api/agents/apply, POST /api/agents/clear
- Agent panel toolbar with Add, Apply, Clear buttons and inline add form
- Apply/Clear buttons respect staging state (disabled when no pending changes)

## Test plan
- [ ] Click "+ Add" to show inline form, select template type, submit to add agent to cron-jobs.json
- [ ] Verify new agent appears as STAGED in the panel after adding
- [ ] Click "Apply" to run manage.py apply and verify agents become ACTIVE
- [ ] Click "Clear" (2-click confirm) to reset cron-jobs.json and verify agents become ORPHAN
- [ ] Verify Apply is disabled when no staged/modified/orphan agents exist
- [ ] Verify Clear is disabled when no staged agents exist
- [ ] Verify delete still only removes from cron-jobs.json (staging model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
