### PR TITLE
Add end-of-run timestamp and sort log runs by end time

### DIFF
--- a/agent-kernel/logs/view.sh
+++ b/agent-kernel/logs/view.sh
@@ -44,8 +44,9 @@ format_lines() {
   color=$(color_for_agent "$agent")
   local tag="\033[${color}m[${agent}]\033[0m"
   local separator="─────────────────────────"
-  local buffer=""
+  local body=""
   local in_block=false
+  local current_start_ts=""
 
   while IFS= read -r line; do
     # Run boundary marker from run.sh — start buffering a new block
@@ -53,17 +54,26 @@ format_lines() {
       local run_ts="${BASH_REMATCH[1]}"
       local display_ts
       display_ts=$(date -jf '%Y-%m-%dT%H:%M:%SZ' "$run_ts" '+%H:%M:%S' 2>/dev/null || echo "$run_ts")
-      buffer="$(printf "\n%b \033[90m%s\033[0m \033[90m%s\033[0m\n" "$tag" "$display_ts" "$separator")"
+      current_start_ts="$display_ts"
+      body=""
       in_block=true
       continue
     fi
 
     # End-of-run marker — flush the buffered block atomically
-    if [[ "$line" == "=== END RUN ===" ]]; then
-      if [[ -n "$buffer" ]]; then
-        printf '%s\n' "$buffer"
+    if [[ "$line" =~ ^===\ END\ RUN(\ ([0-9T:.Z-]+))?\ ===$ ]]; then
+      local end_ts="${BASH_REMATCH[2]:-}"
+      local time_display="$current_start_ts"
+      if [[ -n "$end_ts" ]]; then
+        local display_end
+        display_end=$(date -jf '%Y-%m-%dT%H:%M:%SZ' "$end_ts" '+%H:%M:%S' 2>/dev/null || echo "$end_ts")
+        time_display="$current_start_ts → $display_end"
       fi
-      buffer=""
+      if [[ -n "$body" ]]; then
+        printf "\n%b \033[90m%s\033[0m \033[90m%s\033[0m\n%s\n" "$tag" "$time_display" "$separator" "$body"
+      fi
+      body=""
+      current_start_ts=""
       in_block=false
       continue
     fi
@@ -71,15 +81,15 @@ format_lines() {
     [[ -z "$line" ]] && continue
 
     if $in_block; then
-      buffer+="$(printf "\n  %s" "$line")"
+      body+="$(printf "  %s\n" "$line")"
     else
       printf "  %s\n" "$line"
     fi
   done
 
   # Flush any remaining buffer (e.g. run still in progress during follow mode)
-  if [[ -n "$buffer" ]]; then
-    printf '%s\n' "$buffer"
+  if [[ -n "$body" ]]; then
+    printf "\n%b \033[90m%s\033[0m \033[90m%s\033[0m\n%s\n" "$tag" "$current_start_ts" "$separator" "$body"
   fi
 }
 

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -138,7 +138,7 @@ fi
 # Emit early so ALL output (including errors) is captured between delimiters.
 echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 cleanup() {
-  echo "=== END RUN ==="
+  echo "=== END RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
   rm -f "${LOCKFILE:-}"
 }
 trap cleanup EXIT

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -67,8 +67,8 @@ export function LogsPanel() {
           const merged = [...prev, ...fresh];
           merged.sort(
             (a, b) =>
-              new Date(a.timestamp).getTime() -
-              new Date(b.timestamp).getTime()
+              new Date(a.endTimestamp ?? a.timestamp).getTime() -
+              new Date(b.endTimestamp ?? b.timestamp).getTime()
           );
           return merged.slice(-MAX_BLOCKS);
         });
@@ -91,8 +91,8 @@ export function LogsPanel() {
             const merged = [...prev, ...fresh];
             merged.sort(
               (a, b) =>
-                new Date(b.timestamp).getTime() -
-                new Date(a.timestamp).getTime()
+                new Date(b.endTimestamp ?? b.timestamp).getTime() -
+                new Date(a.endTimestamp ?? a.timestamp).getTime()
             );
             return merged.slice(0, MAX_BLOCKS);
           });
@@ -253,6 +253,9 @@ function LogCard({
         )}
         <span className="text-sm text-muted-foreground">
           {block.displayTime}
+          {block.displayEndTime && (
+            <span className="text-muted-foreground/60"> → {block.displayEndTime}</span>
+          )}
         </span>
       </div>
       <pre className="text-text text-base whitespace-pre-wrap break-words leading-relaxed">

--- a/apps/web/src/lib/log-parser.ts
+++ b/apps/web/src/lib/log-parser.ts
@@ -2,11 +2,14 @@ export interface LogBlock {
   agentId: string;
   timestamp: string;
   displayTime: string;
+  endTimestamp?: string;
+  displayEndTime?: string;
   content: string;
   key: string;
 }
 
 const RUN_MARKER = /^=== RUN (\S+) ===$/;
+const END_MARKER = /^=== END RUN(?:\s+(\S+))? ===$/;
 
 function formatTime(isoTimestamp: string): string {
   try {
@@ -48,23 +51,29 @@ export function parseLogBlocks(
       }
       currentTimestamp = match[1];
       currentLines = [];
-    } else if (line === '=== END RUN ===') {
-      if (currentTimestamp && currentLines.length > 0) {
-        const content = currentLines.join("\n").trim();
-        if (content) {
-          blocks.push({
-            agentId,
-            timestamp: currentTimestamp,
-            displayTime: formatTime(currentTimestamp),
-            content,
-            key: `${agentId}-${currentTimestamp}`,
-          });
+    } else {
+      const endMatch = line.match(END_MARKER);
+      if (endMatch) {
+        if (currentTimestamp && currentLines.length > 0) {
+          const content = currentLines.join("\n").trim();
+          if (content) {
+            const endTs = endMatch[1] || undefined;
+            blocks.push({
+              agentId,
+              timestamp: currentTimestamp,
+              displayTime: formatTime(currentTimestamp),
+              endTimestamp: endTs,
+              displayEndTime: endTs ? formatTime(endTs) : undefined,
+              content,
+              key: `${agentId}-${currentTimestamp}`,
+            });
+          }
         }
+        currentTimestamp = null;
+        currentLines = [];
+      } else if (currentTimestamp) {
+        currentLines.push(line);
       }
-      currentTimestamp = null;
-      currentLines = [];
-    } else if (currentTimestamp) {
-      currentLines.push(line);
     }
   }
 


### PR DESCRIPTION
**@worker-03**

## Summary
- Add ISO timestamp to `=== END RUN ===` marker in `run.sh`
- Parse end timestamp in log parser with backward compatibility for old format
- Sort log blocks by end time (falling back to start time for old logs)
- Display start → end time range in web LogCard and CLI view.sh headers

## Test plan
- [ ] Verify new runs produce `=== END RUN 2026-...Z ===` format
- [ ] Verify old logs without end timestamp still parse correctly
- [ ] Verify log blocks sort by end time in web dashboard
- [ ] Verify LogCard shows `14:30:45 → 14:32:12` format when end time available
- [ ] Verify `view.sh` shows time range in run headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
