### PR TITLE
SSE streaming for live log updates

### DIFF
--- a/apps/web/src/app/api/logs/stream/route.ts
+++ b/apps/web/src/app/api/logs/stream/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { agentLogPath, logsDir } from "@/lib/paths";
 
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+const MAX_CHUNK = 64 * 1024;
 
 export const dynamic = "force-dynamic";
 
@@ -52,7 +53,7 @@ export async function GET(request: NextRequest) {
       return;
     }
 
-    const bytesToRead = fileSize - currentOffset;
+    const bytesToRead = Math.min(fileSize - currentOffset, MAX_CHUNK);
     if (bytesToRead <= 0) {
       offsets.set(agent, fileSize);
       return;
@@ -63,8 +64,9 @@ export async function GET(request: NextRequest) {
     fs.readSync(fd, buffer, 0, bytesToRead, currentOffset);
     fs.closeSync(fd);
 
-    offsets.set(agent, fileSize);
-    sendEvent(controller, agent, buffer.toString("utf-8"), fileSize);
+    const newOffset = currentOffset + bytesToRead;
+    offsets.set(agent, newOffset);
+    sendEvent(controller, agent, buffer.toString("utf-8"), newOffset);
   }
 
   function watchAgent(
@@ -135,6 +137,7 @@ export async function GET(request: NextRequest) {
           const files = fs.readdirSync(dir).filter((f) => f.endsWith(".log"));
           for (const file of files) {
             const agent = path.basename(file, ".log");
+            if (!SAFE_ID_RE.test(agent)) continue;
             watchAgent(controller, agent);
           }
         } catch {
@@ -152,6 +155,7 @@ export async function GET(request: NextRequest) {
           )
             return;
           const agent = path.basename(filename, ".log");
+          if (!SAFE_ID_RE.test(agent)) return;
           if (agentId && agent !== agentId) return;
           if (offsets.has(agent)) return; // already watching
 

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -29,10 +29,21 @@ export function LogsPanel() {
     (newBlocks: LogBlock[], mode: "all" | "single") => {
       if (newBlocks.length === 0) return;
       setBlocks((prev) => {
-        const existingKeys = new Set(prev.map((b) => b.key));
-        const fresh = newBlocks.filter((b) => !existingKeys.has(b.key));
-        if (fresh.length === 0) return prev;
-        const merged = [...prev, ...fresh];
+        // Build a map preferring blocks that have endTimestamp set
+        const blockMap = new Map<string, LogBlock>();
+        for (const b of prev) {
+          blockMap.set(b.key, b);
+        }
+        let changed = false;
+        for (const b of newBlocks) {
+          const existing = blockMap.get(b.key);
+          if (!existing || (b.endTimestamp && !existing.endTimestamp)) {
+            blockMap.set(b.key, b);
+            changed = true;
+          }
+        }
+        if (!changed) return prev;
+        const merged = Array.from(blockMap.values());
         if (mode === "all") {
           merged.sort(
             (a, b) =>
@@ -159,7 +170,7 @@ export function LogsPanel() {
     setBlocks([]);
     offsetsRef.current = {};
 
-    // Load initial history
+    // Load initial history — called once per tab switch, not on every agent change.
     fetchInitialLogs();
 
     // Open SSE connection
@@ -204,7 +215,8 @@ export function LogsPanel() {
       eventSourceRef.current = null;
       stopFallbackPolling();
     };
-  }, [activeTab, fetchInitialLogs, mergeBlocks, startFallbackPolling, stopFallbackPolling]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, mergeBlocks, startFallbackPolling, stopFallbackPolling]);
 
   // Auto-scroll detection
   const handleScroll = useCallback(() => {


### PR DESCRIPTION
**@worker-01**

## Summary
- Add SSE streaming endpoint (`/api/logs/stream`) using `fs.watch()` to push log data in real-time
- Replace 2-second polling in `logs-panel.tsx` with `EventSource`, falling back to polling on connection drop
- Initial page load still uses existing GET endpoint for recent log history

## Test plan
- [ ] Verify log updates appear within ~100ms of being written to log files
- [ ] Verify switching agent tabs closes old SSE connection and opens new one
- [ ] Verify auto-reconnect works after simulated connection drop
- [ ] Verify initial load shows recent log history from GET endpoint
- [ ] Verify new agent log files are picked up by directory watcher
- [ ] Verify no resource leaks (watchers cleaned up on disconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
