### PR TITLE
Extract atomicWriteJsonSync to shared @/lib/paths utility

### DIFF
--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
-import { cronJobsPath } from "@/lib/paths";
+import { atomicWriteJsonSync, cronJobsPath } from "@/lib/paths";
 
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
@@ -12,14 +11,6 @@ interface CronJob {
 interface CronJobsData {
   jobs: CronJob[];
   [key: string]: unknown;
-}
-
-function atomicWriteJsonSync(filePath: string, data: unknown): void {
-  const dir = path.dirname(filePath);
-  const content = JSON.stringify(data, null, 2) + "\n";
-  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
-  fs.writeFileSync(tmpPath, content, "utf-8");
-  fs.renameSync(tmpPath, filePath);
 }
 
 export async function DELETE(

--- a/apps/web/src/app/api/agents/clear/route.ts
+++ b/apps/web/src/app/api/agents/clear/route.ts
@@ -1,15 +1,6 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
-import { cronJobsPath } from "@/lib/paths";
-
-function atomicWriteJsonSync(filePath: string, data: unknown): void {
-  const dir = path.dirname(filePath);
-  const content = JSON.stringify(data, null, 2) + "\n";
-  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
-  fs.writeFileSync(tmpPath, content, "utf-8");
-  fs.renameSync(tmpPath, filePath);
-}
+import { atomicWriteJsonSync, cronJobsPath } from "@/lib/paths";
 
 export async function POST() {
   try {

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
 import {
+  atomicWriteJsonSync,
   cronJobsPath,
   cronStatePath,
   lockFilePath,
@@ -179,14 +179,6 @@ export async function GET() {
 
 const SAFE_TYPE_RE = /^(worker|planner)$/;
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
-
-function atomicWriteJsonSync(filePath: string, data: unknown): void {
-  const dir = path.dirname(filePath);
-  const content = JSON.stringify(data, null, 2) + "\n";
-  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
-  fs.writeFileSync(tmpPath, content, "utf-8");
-  fs.renameSync(tmpPath, filePath);
-}
 
 export async function POST(request: NextRequest) {
   try {

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import fs from "fs";
 
 /**
  * Resolve the repo root from which all data files are located.
@@ -44,4 +45,12 @@ export function managePyPath(): string {
 
 export function runShPath(): string {
   return path.join(getForgeRoot(), "agent-kernel/run.sh");
+}
+
+export function atomicWriteJsonSync(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  const content = JSON.stringify(data, null, 2) + "\n";
+  const tmpPath = path.join(dir, `.cron-jobs.tmp.${process.pid}`);
+  fs.writeFileSync(tmpPath, content, "utf-8");
+  fs.renameSync(tmpPath, filePath);
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- Extract duplicated `atomicWriteJsonSync` function into shared `@/lib/paths` utility
- Remove local definitions from `agents/route.ts`, `agents/clear/route.ts`, and `agents/[id]/route.ts`
- Import the shared function in all three route files

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify agent CRUD operations still work via dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
