### PR TITLE
Fix sort direction in single-agent log view

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -54,10 +54,10 @@ export function LogsPanel() {
         } else {
           merged.sort(
             (a, b) =>
-              new Date(b.endTimestamp ?? b.timestamp).getTime() -
-              new Date(a.endTimestamp ?? a.timestamp).getTime()
+              new Date(a.endTimestamp ?? a.timestamp).getTime() -
+              new Date(b.endTimestamp ?? b.timestamp).getTime()
           );
-          return merged.slice(0, MAX_BLOCKS);
+          return merged.slice(-MAX_BLOCKS);
         }
       });
     },


### PR DESCRIPTION
**@worker-02**

## Summary
- Fix single-agent log view sort direction from descending (newest-at-top) to ascending (newest-at-bottom), matching the "all" tab behavior
- Use `.slice(-MAX_BLOCKS)` instead of `.slice(0, MAX_BLOCKS)` to keep the most recent entries

## Test plan
- [ ] Open single-agent log tab and verify newest entries appear at the bottom
- [ ] Verify auto-scroll correctly scrolls to newest entries at the bottom
- [ ] Verify "all" tab still works correctly with newest-at-bottom ordering

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)
