### PR TITLE
Fix lock preflight: planners/supers never exit early

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -220,7 +220,7 @@ if [[ "$IS_WORKER" == true ]]; then
   fi
 fi
 
-# ── preflight: skip idle planner runs ────────────────────────
+# ── preflight: planner lock (never exits early) ──────────────
 IS_PLANNER=false
 for ctx in "${CONTEXTS[@]}"; do
   if [[ "$ctx" == *PLANNER.md ]]; then
@@ -240,16 +240,9 @@ if [[ "$IS_PLANNER" == true ]]; then
   ISSUES=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
 
   if [[ "$ISSUES" == "error" ]]; then
-    # gh failed (network error, etc.) — proceed without pre-assignment
     echo "[preflight] gh issue list failed — proceeding without lock"
   elif [[ -z "$ISSUES" ]]; then
-    echo "No open issues with role:planner — skipping run"
-    if [[ -n "${WORKSPACE_ID:-}" ]]; then
-      SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
-      mkdir -p "$(dirname "$SYSTEM_LOG")"
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (no role:planner issues)" >> "$SYSTEM_LOG"
-    fi
-    exit 0
+    echo "[preflight] No open role:planner issues — proceeding without assignment"
   else
     # Try to lock one issue
     FORGE_LOCKED_ISSUE=""
@@ -261,17 +254,53 @@ if [[ "$IS_PLANNER" == true ]]; then
     done
 
     if [[ -z "$FORGE_LOCKED_ISSUE" ]]; then
-      echo "No unlocked planner issues available — skipping run"
-      if [[ -n "${WORKSPACE_ID:-}" ]]; then
-        SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
-        mkdir -p "$(dirname "$SYSTEM_LOG")"
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (all planner issues locked)" >> "$SYSTEM_LOG"
-      fi
-      exit 0
+      echo "[preflight] All planner issues locked — proceeding without assignment"
+    else
+      export FORGE_LOCKED_ISSUE
+      echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
     fi
+  fi
+fi
 
-    export FORGE_LOCKED_ISSUE
-    echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
+# ── preflight: super lock (never exits early) ────────────────
+IS_SUPER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *SUPER.md ]]; then
+    IS_SUPER=true
+    break
+  fi
+done
+
+if [[ "$IS_SUPER" == true ]]; then
+  GH_ARGS=(issue list --label "role:super" --state open --json number --jq '.[].number')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  ISSUES=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$ISSUES" == "error" ]]; then
+    echo "[preflight] gh issue list failed — proceeding without lock"
+  elif [[ -z "$ISSUES" ]]; then
+    echo "[preflight] No open role:super issues — proceeding without assignment"
+  else
+    # Try to lock one issue
+    FORGE_LOCKED_ISSUE=""
+    for ISSUE_NUM in $ISSUES; do
+      if lock_acquire issue "$ISSUE_NUM" "$WORKSPACE_ID" 2>/dev/null; then
+        FORGE_LOCKED_ISSUE="$ISSUE_NUM"
+        break
+      fi
+    done
+
+    if [[ -z "$FORGE_LOCKED_ISSUE" ]]; then
+      echo "[preflight] All super issues locked — proceeding without assignment"
+    else
+      export FORGE_LOCKED_ISSUE
+      echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
+    fi
   fi
 fi
 

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -12,7 +12,13 @@ Work on this issue directly — do not search for other issues to pick up.
 3. Announce pickup and relabel as normal.
 4. Proceed with planning/review.
 
-If `ASSIGNED_ISSUE` is not present, use the standard intake flow below.
+If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Instead, perform review and maintenance duties:
+
+1. Check open PRs targeting your epic branches for pending reviews.
+2. Process any `@ADMIN` comments that haven't been acknowledged.
+3. Monitor worker handoff comments and replan based on new information.
+4. Run stuck detection within your epics.
+5. Update epic checklists and label state as needed.
 
 ## Role
 

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -2,6 +2,23 @@
 
 You are a super agent. You are the final quality gate before epic PRs reach the human admin for merge to `main`. You see the entire project — not just one epic, but all of them simultaneously.
 
+## Pre-assigned issues
+
+If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
+Work on this issue directly — do not search for other issues to pick up.
+
+1. Read the issue: `gh issue view <N> --comments`
+2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:super`.
+3. Announce pickup and relabel as normal.
+4. Proceed with review.
+
+If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Instead, perform review and maintenance duties:
+
+1. Check for epic PRs labeled `status:needs-review` + `role:super` and review them.
+2. Process any `@ADMIN` comments that haven't been acknowledged.
+3. Run cross-epic sweeps: stale issues, orphaned PRs, label hygiene, branch cleanup.
+4. Flag cross-epic conflicts between in-flight PRs.
+
 ## Role
 
 - Review epic parent PRs that are labeled `status:needs-review` and `role:super`.


### PR DESCRIPTION
**@worker-01**

## Summary
- Planner preflight no longer exits early when no `role:planner` issues exist or all are locked — proceeds without assignment
- Added super preflight section to `run.sh` with the same never-exit-early pattern
- Workers retain existing behavior: exit early when no lockable work exists
- Updated `PLANNER.md` and `SUPER.md` with pre-assigned issue sections and no-assignment behavior (reviews/sweeps only, no claiming)

## Test plan
- [ ] Verify planner runs proceed when no `role:planner` issues exist (no `exit 0`)
- [ ] Verify planner runs proceed when all planner issues are locked
- [ ] Verify super runs proceed when no `role:super` issues exist
- [ ] Verify super runs proceed when all super issues are locked
- [ ] Verify worker runs still exit early when no lockable work exists
- [ ] Verify `ASSIGNED_ISSUE` is only injected when a lock is acquired
- [ ] Verify `WORKER.md` is unchanged

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
