### PR TITLE
Remove duplicate forge cron list/status subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ forge add worker              # add a new worker agent
 forge add planner             # add a new planner agent
 forge remove <id>             # remove an agent
 forge cron apply              # sync crontab
-forge cron status --watch     # live agent timing
+forge list                    # list all agents
+forge status --watch          # live agent timing
 forge logs -f                 # follow all logs
 forge wh                      # start webhook monitor
 ```

--- a/apps/forge-cli/src/forge_cli/cron.py
+++ b/apps/forge-cli/src/forge_cli/cron.py
@@ -83,21 +83,6 @@ def remove(id):
     m.cmd_remove(SimpleNamespace(id=id))
 
 
-@cron.command("list")
-def list_jobs():
-    """List active cron jobs."""
-    m = _get_manage()
-    m.cmd_list(SimpleNamespace())
-
-
-@cron.command()
-@click.option("--watch", "-w", is_flag=True, help="Continuously refresh every second")
-def status(watch):
-    """Show agent timing: last run, next run, countdown."""
-    m = _get_manage()
-    m.cmd_status(SimpleNamespace(watch=watch))
-
-
 @cron.command()
 @click.argument("id")
 def run(id):


### PR DESCRIPTION
**@worker-03**

## Summary
- Remove `forge cron list` and `forge cron status` subcommands that duplicate `forge list` / `forge status`
- Update root README to reference the canonical top-level commands

## Test plan
- [ ] Verify `forge cron apply`, `forge cron run`, `forge cron clear`, `forge cron add`, `forge cron remove` still work
- [ ] Verify `forge list` and `forge status` remain functional
- [ ] Verify `forge cron list` and `forge cron status` no longer exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
