### PR TITLE
Add contexts/ and templates/ README files

### DIFF
--- a/contexts/README.md
+++ b/contexts/README.md
@@ -1,0 +1,23 @@
+# Contexts
+
+Markdown files that define agent behavior, constraints, and protocols. They are composed into agent system prompts via the template system (see `../templates/`).
+
+## File inventory
+
+| File | Purpose |
+|------|---------|
+| `CONSTRAINTS.md` | Shared rules all agents must follow (GitHub protocol, code quality, scope discipline, git safety) |
+| `HANDOFF.md` | Structured handoff comment format for task completion |
+| `IDENTITY.md` | Agent identity and GitHub comment signing requirements |
+| `LABELS.md` | GitHub label definitions, lifecycle rules, and epic flow |
+| `PLANNER.md` | Planner agent role — scoping, issue creation, PR review |
+| `REVIEWER.md` | Code review protocol and quality standards |
+| `SUPER.md` | Super agent role — cross-epic review and final quality gate |
+| `WORKER.md` | Worker agent role — claim tasks, implement, hand off |
+| `WORKSPACE.md` | Worktree isolation, branching, and push conventions |
+
+## How contexts compose
+
+Each agent role uses a subset of these files. Templates (`../templates/*.json`) declare a `contexts` array that lists which context files to include. At run time, the selected contexts are concatenated into the agent's system prompt.
+
+For example, a worker agent receives `IDENTITY`, `WORKER`, `CONSTRAINTS`, `LABELS`, `HANDOFF`, and `WORKSPACE` — but not `PLANNER`, `SUPER`, or `REVIEWER`.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,35 @@
+# Templates
+
+JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling and execution settings.
+
+## Template format
+
+```json
+{
+  "interval": "2m",
+  "prompt": "The instruction given to the agent each run.",
+  "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "..."],
+  "agentic": true,
+  "workspace": true
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `interval` | Cron scheduling interval between runs |
+| `prompt` | The task prompt passed to the agent |
+| `contexts` | Ordered list of context files composed into the system prompt |
+| `agentic` | Whether the agent runs in agentic mode with tool access |
+| `workspace` | Whether the agent gets an isolated git worktree |
+
+## Available templates
+
+| Template | Role | Contexts |
+|----------|------|----------|
+| `worker.json` | Claim and implement a single task | Identity, Worker, Constraints, Labels, Handoff, Workspace |
+| `planner.json` | Review state, create issues, process handoffs | Identity, Planner, Constraints, Labels, Handoff, Workspace |
+| `super.json` | Cross-epic review and quality gate | Identity, Super, Reviewer, Constraints, Labels, Workspace |
+
+## Usage
+
+Templates are loaded by the Forge CLI (`apps/forge-cli`) and web dashboard (`apps/web`) to launch agent runs via `agent-kernel/run.sh`.


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `contexts/README.md` with file inventory table and composition explanation
- Add `templates/README.md` with format documentation, field descriptions, and available templates

Closes #573

## Test plan
- [ ] Verify `contexts/README.md` lists all 9 context files with accurate descriptions
- [ ] Verify `templates/README.md` documents the correct JSON structure and all 3 templates
- [ ] Confirm descriptions match actual file contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)
