### PR TITLE
Fix rebase regression: re-apply #564 preflight behavioral changes

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -243,13 +243,7 @@ if [[ "$IS_PLANNER" == true ]]; then
     # gh failed (network error, etc.) — proceed without pre-assignment
     echo "[preflight] gh issue list failed — proceeding without lock"
   elif [[ -z "$ISSUES" ]]; then
-    echo "No open issues with role:planner — skipping run"
-    if [[ -n "${WORKSPACE_ID:-}" ]]; then
-      SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
-      mkdir -p "$(dirname "$SYSTEM_LOG")"
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (no role:planner issues)" >> "$SYSTEM_LOG"
-    fi
-    exit 0
+    echo "[preflight] No open issues with role:planner — proceeding without lock"
   else
     # Try to lock one issue
     FORGE_LOCKED_ISSUE=""
@@ -261,17 +255,53 @@ if [[ "$IS_PLANNER" == true ]]; then
     done
 
     if [[ -z "$FORGE_LOCKED_ISSUE" ]]; then
-      echo "No unlocked planner issues available — skipping run"
-      if [[ -n "${WORKSPACE_ID:-}" ]]; then
-        SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
-        mkdir -p "$(dirname "$SYSTEM_LOG")"
-        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (all planner issues locked)" >> "$SYSTEM_LOG"
-      fi
-      exit 0
+      echo "[preflight] No unlocked planner issues available — proceeding without lock"
+    else
+      export FORGE_LOCKED_ISSUE
+      echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
     fi
+  fi
+fi
 
-    export FORGE_LOCKED_ISSUE
-    echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
+# ── preflight: skip idle super runs ──────────────────────────
+IS_SUPER=false
+for ctx in "${CONTEXTS[@]}"; do
+  if [[ "$ctx" == *SUPER.md ]]; then
+    IS_SUPER=true
+    break
+  fi
+done
+
+if [[ "$IS_SUPER" == true ]]; then
+  GH_ARGS=(issue list --label "role:super" --state open --json number --jq '.[].number')
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    GH_REPO="${TARGET_REPO#github.com/}"
+    GH_ARGS+=(--repo "$GH_REPO")
+  fi
+
+  ISSUES=$(gh "${GH_ARGS[@]}" 2>/dev/null || echo "error")
+
+  if [[ "$ISSUES" == "error" ]]; then
+    echo "[preflight] gh issue list failed — proceeding without lock"
+  elif [[ -z "$ISSUES" ]]; then
+    echo "[preflight] No open issues with role:super — proceeding without lock"
+  else
+    # Try to lock one issue
+    FORGE_LOCKED_ISSUE=""
+    for ISSUE_NUM in $ISSUES; do
+      if lock_acquire issue "$ISSUE_NUM" "$WORKSPACE_ID" 2>/dev/null; then
+        FORGE_LOCKED_ISSUE="$ISSUE_NUM"
+        break
+      fi
+    done
+
+    if [[ -z "$FORGE_LOCKED_ISSUE" ]]; then
+      echo "[preflight] No unlocked super issues available — proceeding without lock"
+    else
+      export FORGE_LOCKED_ISSUE
+      echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
+    fi
   fi
 fi
 

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -12,7 +12,7 @@ Work on this issue directly — do not search for other issues to pick up.
 3. Announce pickup and relabel as normal.
 4. Proceed with planning/review.
 
-If `ASSIGNED_ISSUE` is not present, use the standard intake flow below.
+If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Proceed with reviews, sweeps, and @ADMIN processing only.
 
 ## Role
 

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -2,6 +2,18 @@
 
 You are a super agent. You are the final quality gate before epic PRs reach the human admin for merge to `main`. You see the entire project — not just one epic, but all of them simultaneously.
 
+## Pre-assigned issues
+
+If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
+Work on this issue directly — do not search for other issues to pick up.
+
+1. Read the issue: `gh issue view <N> --comments`
+2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:super`.
+3. Announce pickup and relabel as normal.
+4. Proceed with review.
+
+If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Proceed with sweeps and @ADMIN processing only.
+
 ## Role
 
 - Review epic parent PRs that are labeled `status:needs-review` and `role:super`.


### PR DESCRIPTION
**@worker-01**

## Summary
- Remove `exit 0` from planner preflight so planners never exit early (proceed without lock instead)
- Add `IS_SUPER` preflight block in `run.sh` with same lock-but-don't-skip pattern as planners
- Update PLANNER.md: when `ASSIGNED_ISSUE` is absent, do not claim new issues — proceed with reviews/sweeps/@ADMIN only
- Add pre-assigned issue section to SUPER.md with same "do not claim" fallback

## Test plan
- [ ] Verify planner runs proceed when no `role:planner` issues exist (no early exit)
- [ ] Verify planner runs proceed when all planner issues are locked (no early exit)
- [ ] Verify super runs proceed when no `role:super` issues exist (no early exit)
- [ ] Verify super runs proceed when all super issues are locked (no early exit)
- [ ] Verify worker preflight still exits early when no worker issues exist (unchanged)
- [ ] Verify PLANNER.md instructs no self-claiming without ASSIGNED_ISSUE
- [ ] Verify SUPER.md has pre-assigned issue section with no self-claiming

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
