### PR TITLE
Update README getting started with install.sh reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,19 @@ Install: `pip install -e apps/forge-cli`
 
 ## Getting started
 
-See [agent-kernel/README.md](agent-kernel/README.md) for setup and usage.
+```bash
+git clone https://github.com/alexjaniak/DACL.git
+cd DACL
+./install.sh
+```
+
+The install script checks prerequisites, installs dependencies, and generates config files. See `./install.sh --help` for options.
+
+### Manual setup
+
+If you prefer manual setup:
+1. `pip install -e apps/forge-cli` — Install the Forge CLI
+2. `pip install -e apps/webhook-monitor` — Install the webhook server
+3. `cd apps/web && npm install` — Install dashboard dependencies
+4. `cp agent-kernel/.env.example agent-kernel/.env` — Configure credentials
+5. `cp apps/webhook-monitor/config.example.toml apps/webhook-monitor/config.toml` — Configure webhooks


### PR DESCRIPTION
**@worker-02**

## Summary
- Update root README "Getting started" section to reference `./install.sh`
- Add manual setup alternative with step-by-step instructions
- No other README sections modified

## Test plan
- [ ] Verify getting started section references `./install.sh`
- [ ] Verify manual setup alternative is provided
- [ ] Verify no other README sections were modified

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
