### PR TITLE
Add templates API + support all agent types

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
+import path from "path";
 import {
   atomicWriteJsonSync,
   cronJobsPath,
   cronStatePath,
+  getForgeRoot,
   lockFilePath,
   templatePath,
 } from "@/lib/paths";
@@ -177,7 +179,20 @@ export async function GET() {
   return NextResponse.json({ agents });
 }
 
-const SAFE_TYPE_RE = /^(worker|planner)$/;
+function availableTemplateTypes(): Set<string> {
+  const templatesDir = path.join(getForgeRoot(), "templates");
+  try {
+    return new Set(
+      fs
+        .readdirSync(templatesDir)
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => f.replace(/\.json$/, ""))
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
 export async function POST(request: NextRequest) {
@@ -185,9 +200,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const type: string = body.type;
 
-    if (!type || !SAFE_TYPE_RE.test(type)) {
+    const validTypes = availableTemplateTypes();
+    if (!type || !validTypes.has(type)) {
       return NextResponse.json(
-        { error: "type must be 'worker' or 'planner'" },
+        { error: `type must be one of: ${[...validTypes].sort().join(", ")}` },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { getForgeRoot } from "@/lib/paths";
+
+export async function GET() {
+  const templatesDir = path.join(getForgeRoot(), "templates");
+
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(templatesDir)
+      .filter((f) => f.endsWith(".json"));
+  } catch {
+    return NextResponse.json({ templates: [] });
+  }
+
+  const templates = files.map((file) => {
+    const type = file.replace(/\.json$/, "");
+    const raw = fs.readFileSync(path.join(templatesDir, file), "utf-8");
+    const data = JSON.parse(raw);
+    return {
+      type,
+      interval: data.interval ?? "2m",
+      contexts: data.contexts ?? [],
+      agentic: data.agentic ?? true,
+      workspace: data.workspace ?? true,
+    };
+  });
+
+  return NextResponse.json({ templates });
+}

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -6,7 +6,7 @@ type AgentStatus = "staged" | "active" | "modified" | "orphan";
 
 interface Agent {
   id: string;
-  role: "planner" | "worker";
+  role: string;
   interval: string;
   intervalSeconds: number;
   enabled: boolean;
@@ -73,8 +73,13 @@ function StatusDot({ running, overdue }: { running: boolean; overdue: boolean })
   );
 }
 
-function RoleBadge({ role }: { role: "planner" | "worker" }) {
-  const color = role === "planner" ? "text-accent-magenta" : "text-accent-blue";
+function RoleBadge({ role }: { role: string }) {
+  const color =
+    role === "planner"
+      ? "text-accent-magenta"
+      : role === "worker"
+        ? "text-accent-blue"
+        : "text-accent-cyan";
   return (
     <span
       className={`${color} text-sm font-medium uppercase tracking-wide`}
@@ -234,10 +239,22 @@ function sortAgentsByStatus(agents: Agent[]): Agent[] {
 }
 
 function AddAgentForm({ onAdded }: { onAdded: () => void }) {
-  const [type, setType] = useState<"worker" | "planner">("worker");
+  const [type, setType] = useState("worker");
+  const [templateTypes, setTemplateTypes] = useState<string[]>(["worker", "planner"]);
   const [customId, setCustomId] = useState("");
   const [interval, setInterval] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/templates")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.templates?.length) {
+          setTemplateTypes(data.templates.map((t: { type: string }) => t.type).sort());
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const handleSubmit = async () => {
     setSubmitting(true);
@@ -268,10 +285,11 @@ function AddAgentForm({ onAdded }: { onAdded: () => void }) {
         <select
           className="bg-background border border-border rounded px-2 py-1 text-sm text-text"
           value={type}
-          onChange={(e) => setType(e.target.value as "worker" | "planner")}
+          onChange={(e) => setType(e.target.value)}
         >
-          <option value="worker">worker</option>
-          <option value="planner">planner</option>
+          {templateTypes.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
         </select>
         <input
           className="bg-background border border-border rounded px-2 py-1 text-sm text-text w-28"


### PR DESCRIPTION
**@worker-01**

## Summary
- Add GET `/api/templates` endpoint that reads all `.json` files from `templates/` directory and returns template metadata
- Update POST `/api/agents` to dynamically validate agent type against available template files (supports worker, planner, super, and any future types)
- Change `Agent` interface `role` from union type to `string`; update `RoleBadge` with cyan color for super/unknown roles
- Update `AddAgentForm` to fetch available templates dynamically instead of hardcoding worker/planner

## Test plan
- [ ] Verify GET `/api/templates` returns all templates from `templates/` directory
- [ ] Verify POST `/api/agents` accepts worker, planner, and super types
- [ ] Verify POST `/api/agents` rejects invalid types with descriptive error
- [ ] Verify `RoleBadge` renders correct colors for worker (blue), planner (magenta), super (cyan)
- [ ] Verify AddAgentForm dropdown shows all available template types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
