### PR TITLE
Add adopt endpoint and UI button for orphaned agents

### DIFF
--- a/apps/web/src/app/api/agents/[id]/adopt/route.ts
+++ b/apps/web/src/app/api/agents/[id]/adopt/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import {
+  atomicWriteJsonSync,
+  cronJobsPath,
+  cronStatePath,
+  templatePath,
+} from "@/lib/paths";
+
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+}
+
+interface CronJobsData {
+  jobs: CronJob[];
+  [key: string]: unknown;
+}
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      contexts?: string[];
+    }
+  >;
+}
+
+function inferTemplateType(id: string): string {
+  if (id.startsWith("planner")) return "planner";
+  if (id.startsWith("super")) return "super";
+  return "worker";
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!SAFE_ID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid agent ID" }, { status: 400 });
+  }
+
+  try {
+    // Read cron-state.json to verify agent exists in state
+    let state: CronState = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch {
+      return NextResponse.json(
+        { error: "No cron state found" },
+        { status: 404 }
+      );
+    }
+
+    if (!state.jobs?.[id]) {
+      return NextResponse.json(
+        { error: `Agent ${id} not found in cron state` },
+        { status: 404 }
+      );
+    }
+
+    // Read cron-jobs.json — verify agent is not already staged
+    const filePath = cronJobsPath();
+    let data: CronJobsData = { jobs: [] };
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      data = JSON.parse(raw);
+      if (!Array.isArray(data.jobs)) data.jobs = [];
+    } catch {
+      // fresh config
+    }
+
+    if (data.jobs.some((j) => j.id === id)) {
+      return NextResponse.json(
+        { error: `Agent ${id} is already staged` },
+        { status: 409 }
+      );
+    }
+
+    // Infer template type from ID prefix
+    const type = inferTemplateType(id);
+
+    // Load template
+    let template;
+    try {
+      const raw = fs.readFileSync(templatePath(type), "utf-8");
+      template = JSON.parse(raw);
+    } catch {
+      return NextResponse.json(
+        { error: `Template not found: ${type}` },
+        { status: 500 }
+      );
+    }
+
+    // Reconstruct job entry with state data + template defaults
+    const jobState = state.jobs[id];
+    const newJob: CronJob = {
+      id,
+      interval: jobState.interval ?? template.interval ?? "2m",
+      prompt: template.prompt ?? "",
+      contexts: jobState.contexts ?? template.contexts ?? [],
+      agentic: template.agentic ?? true,
+      workspace: template.workspace ?? true,
+    };
+
+    data.jobs.push(newJob);
+    atomicWriteJsonSync(filePath, data);
+
+    return NextResponse.json({
+      ok: true,
+      agent: { id: newJob.id, interval: newJob.interval },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -112,10 +112,12 @@ function AgentCard({
   agent,
   onForceRun,
   onDelete,
+  onAdopt,
 }: {
   agent: Agent;
   onForceRun: (id: string) => void;
   onDelete: (id: string) => void;
+  onAdopt: (id: string) => void;
 }) {
   const [feedback, setFeedback] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
@@ -145,6 +147,12 @@ function AgentCard({
     setTimeout(() => setFeedback(null), 2000);
   };
 
+  const handleAdopt = () => {
+    onAdopt(agent.id);
+    setFeedback("Adopted");
+    setTimeout(() => setFeedback(null), 2000);
+  };
+
   const handleDelete = () => {
     if (!confirming) {
       setConfirming(true);
@@ -157,7 +165,9 @@ function AgentCard({
   };
 
   const isStarted = feedback === "Started";
+  const isAdopted = feedback === "Adopted";
   const isStaged = agent.status === "staged";
+  const isOrphan = agent.status === "orphan";
 
   return (
     <div className="rounded-md bg-surface p-2 border border-border hover:bg-surface-hover transition-colors">
@@ -201,20 +211,34 @@ function AgentCard({
       </div>
 
       <div className="flex justify-end mr-1">
-        <button
-          className={`text-xs rounded px-2 py-0.5 border transition-colors ${
-            isStaged
-              ? "text-muted-foreground bg-surface border-border cursor-not-allowed opacity-50"
-              : isStarted
-                ? "text-accent-green bg-accent-green/10 border-accent-green/20"
-                : "text-accent-green bg-surface-hover hover:bg-accent-green/20 border-border"
-          }`}
-          onClick={isStaged ? undefined : handleForceRun}
-          disabled={isStaged}
-          title={isStaged ? "Apply config first to run this agent" : undefined}
-        >
-          {feedback ?? "\u25B6 Run"}
-        </button>
+        {isOrphan ? (
+          <button
+            className={`text-xs rounded px-2 py-0.5 border transition-colors ${
+              isAdopted
+                ? "text-accent-cyan bg-accent-cyan/10 border-accent-cyan/20"
+                : "border-accent-cyan text-accent-cyan hover:bg-accent-cyan/20"
+            }`}
+            onClick={isAdopted ? undefined : handleAdopt}
+            disabled={isAdopted}
+          >
+            {feedback ?? "Adopt"}
+          </button>
+        ) : (
+          <button
+            className={`text-xs rounded px-2 py-0.5 border transition-colors ${
+              isStaged
+                ? "text-muted-foreground bg-surface border-border cursor-not-allowed opacity-50"
+                : isStarted
+                  ? "text-accent-green bg-accent-green/10 border-accent-green/20"
+                  : "text-accent-green bg-surface-hover hover:bg-accent-green/20 border-border"
+            }`}
+            onClick={isStaged ? undefined : handleForceRun}
+            disabled={isStaged}
+            title={isStaged ? "Apply config first to run this agent" : undefined}
+          >
+            {feedback ?? "\u25B6 Run"}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -357,6 +381,17 @@ export function AgentPanel() {
     }
   };
 
+  const handleAdopt = async (agentId: string) => {
+    try {
+      const res = await fetch(`/api/agents/${agentId}/adopt`, { method: "POST" });
+      if (res.ok) {
+        fetchAgents();
+      }
+    } catch {
+      // best-effort
+    }
+  };
+
   const handleApply = async () => {
     try {
       const res = await fetch("/api/agents/apply", { method: "POST" });
@@ -455,6 +490,7 @@ export function AgentPanel() {
               agent={agent}
               onForceRun={handleForceRun}
               onDelete={handleDelete}
+              onAdopt={handleAdopt}
             />
           ))}
         </div>


### PR DESCRIPTION
**@worker-03**

## Summary
- Add `POST /api/agents/{id}/adopt` endpoint that restores orphaned agents to `cron-jobs.json` by inferring template type from ID prefix and reconstructing the job entry with state data + template defaults
- Replace "Run" button with cyan-styled "Adopt" button on orphan agent cards in the dashboard
- Show "Adopted" feedback on success, then refresh agent list

## Test plan
- [ ] Create an orphan agent (add entry to cron-state.json without corresponding cron-jobs.json entry)
- [ ] Verify orphan card shows "Adopt" button instead of "Run"
- [ ] Click Adopt — verify agent moves to "staged" status
- [ ] Verify POST to non-orphan agent returns 409
- [ ] Verify POST with invalid ID returns 400
- [ ] Verify missing template returns 500

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
