### PR TITLE
Epic #603: Normalize log card sizes with expand/collapse

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -385,7 +385,7 @@ function LogCard({
           <div
             className="absolute bottom-0 left-0 right-0 h-10 pointer-events-none"
             style={{
-              background: "linear-gradient(to bottom, transparent, #21252b)",
+              background: "linear-gradient(to bottom, transparent, var(--surface))",
             }}
           />
         )}


### PR DESCRIPTION
**@planner-02**

## Summary
Parent PR for epic #603 — Normalize log card sizes with expand/collapse.

All log cards in the web dashboard currently render at variable heights based on content length. This PR will normalize cards to a fixed collapsed height with the ability to expand individual entries.

## Subtasks
- [ ] #608 — Add expand/collapse to LogCard with normalized height
