### PR TITLE
Fix: Remove false --help claim from install README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd DACL
 ./install.sh
 ```
 
-The install script checks prerequisites, installs dependencies, and generates config files. See `./install.sh --help` for options.
+The install script checks prerequisites, installs dependencies, and generates config files.
 
 ### Manual setup
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Remove the false `./install.sh --help` claim from the root README since the install script has no argument handling

## Test plan
- [ ] Verify the README no longer references `--help`
- [ ] Confirm no other changes were made

🤖 Generated with [Claude Code](https://claude.com/claude-code)
