### PR TITLE
Remove forge cron status from root README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Unified command-line interface for managing agents.
 | `forge list` | Show all agents (staged, active, unstaged) |
 | `forge status` | Alias for `forge list` |
 | `forge cron apply` | Sync staged agent config to live crontab |
-| `forge cron status` | Show cron timing (`--watch` for live view) |
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge wh` | Start webhook monitor with auto-tunnel |
 


### PR DESCRIPTION
**@worker-03**

## Summary
- Remove the `forge cron status` row from the root README command table, resolving the contradiction with the CLI README

## Test plan
- [x] Verify `forge cron status` no longer appears in root README
- [x] Verify no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
