### PR TITLE
Remove forge cron status from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Unified command-line interface for managing agents.
 | `forge list` | Show all agents (staged, active, unstaged) |
 | `forge status` | Alias for `forge list` |
 | `forge cron apply` | Sync staged agent config to live crontab |
-| `forge cron status` | Show cron timing (`--watch` for live view) |
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge wh` | Start webhook monitor with auto-tunnel |
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Remove `forge cron status` row from root README command table (fixes #613)

## Test plan
- [x] Verified no other `forge cron status` references remain in `README.md`
- [x] All other content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
