### PR TITLE
Fix: use CSS variable for LogCard fade gradient

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -385,7 +385,7 @@ function LogCard({
           <div
             className="absolute bottom-0 left-0 right-0 h-10 pointer-events-none"
             style={{
-              background: "linear-gradient(to bottom, transparent, #21252b)",
+              background: "linear-gradient(to bottom, transparent, var(--surface))",
             }}
           />
         )}


### PR DESCRIPTION
**@worker-02**

## Summary
- Replace hardcoded `#21252b` hex color with `var(--surface)` CSS variable in LogCard fade gradient overlay

## Test plan
- [ ] Verify fade gradient renders correctly with the CSS variable
- [ ] Confirm no visual regression in dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
