### PR TITLE
Extract _get_manage helper from cron.py to paths.py

### DIFF
--- a/apps/forge-cli/src/forge_cli/cron.py
+++ b/apps/forge-cli/src/forge_cli/cron.py
@@ -1,48 +1,10 @@
 """forge cron — agent cron job management."""
 
-import importlib.util
-import os
-import subprocess
 from types import SimpleNamespace
 
 import click
 
-_manage_cache = None
-
-
-def _get_manage():
-    """Import and configure manage.py with correct paths resolved via git."""
-    global _manage_cache
-    if _manage_cache is not None:
-        return _manage_cache
-
-    try:
-        repo_dir = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        click.echo("Error: not inside a git repository", err=True)
-        raise SystemExit(1)
-
-    cron_dir = os.path.join(repo_dir, "agent-kernel", "cron")
-
-    spec = importlib.util.spec_from_file_location(
-        "forge_manage", os.path.join(cron_dir, "manage.py")
-    )
-    manage = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(manage)
-
-    # Patch path constants so manage.py works from any directory
-    manage.SCRIPT_DIR = cron_dir
-    manage.KERNEL_DIR = os.path.join(repo_dir, "agent-kernel")
-    manage.REPO_DIR = repo_dir
-    manage.JOBS_FILE = os.path.join(cron_dir, "cron-jobs.json")
-    manage.STATE_FILE = os.path.join(cron_dir, "cron-state.json")
-    manage.LOGS_DIR = os.path.join(repo_dir, "agent-kernel", "logs")
-
-    _manage_cache = manage
-    return manage
+from forge_cli.paths import _get_manage
 
 
 @click.group()

--- a/apps/forge-cli/src/forge_cli/list_cmd.py
+++ b/apps/forge-cli/src/forge_cli/list_cmd.py
@@ -5,7 +5,7 @@ import re
 
 import click
 
-from forge_cli.cron import _get_manage
+from forge_cli.paths import _get_manage
 
 
 def _role_from_id(agent_id):

--- a/apps/forge-cli/src/forge_cli/paths.py
+++ b/apps/forge-cli/src/forge_cli/paths.py
@@ -1,5 +1,6 @@
 """Shared path and config helpers for forge-cli."""
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -39,3 +40,41 @@ def save_cron_jobs(path, data):
         json.dump(data, f, indent=2)
         f.write("\n")
     os.rename(tmp_path, path)
+
+
+_manage_cache = None
+
+
+def _get_manage():
+    """Import and configure manage.py with correct paths resolved via git."""
+    global _manage_cache
+    if _manage_cache is not None:
+        return _manage_cache
+
+    try:
+        repo_dir = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError:
+        click.echo("Error: not inside a git repository", err=True)
+        raise SystemExit(1)
+
+    cron_dir = os.path.join(repo_dir, "agent-kernel", "cron")
+
+    spec = importlib.util.spec_from_file_location(
+        "forge_manage", os.path.join(cron_dir, "manage.py")
+    )
+    manage = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(manage)
+
+    # Patch path constants so manage.py works from any directory
+    manage.SCRIPT_DIR = cron_dir
+    manage.KERNEL_DIR = os.path.join(repo_dir, "agent-kernel")
+    manage.REPO_DIR = repo_dir
+    manage.JOBS_FILE = os.path.join(cron_dir, "cron-jobs.json")
+    manage.STATE_FILE = os.path.join(cron_dir, "cron-state.json")
+    manage.LOGS_DIR = os.path.join(repo_dir, "agent-kernel", "logs")
+
+    _manage_cache = manage
+    return manage


### PR DESCRIPTION
**@worker-03**

## Summary
- Move `_get_manage()` and `_manage_cache` from `cron.py` to `paths.py`
- Update imports in `cron.py` and `list_cmd.py` to use `forge_cli.paths`

## Test plan
- [ ] Verify `forge list` works
- [ ] Verify `forge cron apply`, `forge cron run`, `forge cron clear` still work

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
