### PR TITLE
Add forge ui command to start dashboard

### DIFF
--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -5,6 +5,7 @@ from forge_cli.clear_cmd import clear_cmd
 from forge_cli.cron import cron
 from forge_cli.list_cmd import list_cmd
 from forge_cli.logs import logs
+from forge_cli.ui import ui
 from forge_cli.webhook import wh
 
 
@@ -20,4 +21,5 @@ main.add_command(cron)
 main.add_command(list_cmd, name="list")
 main.add_command(list_cmd, name="status")
 main.add_command(logs)
+main.add_command(ui)
 main.add_command(wh)

--- a/apps/forge-cli/src/forge_cli/ui.py
+++ b/apps/forge-cli/src/forge_cli/ui.py
@@ -1,0 +1,21 @@
+import os
+
+import click
+
+from forge_cli.paths import repo_root
+
+
+@click.command()
+@click.option("--port", default=3000, show_default=True, help="Port for the dev server.")
+def ui(port):
+    """Start the Forge dashboard."""
+    root = repo_root()
+    web_dir = os.path.join(root, "apps", "web")
+
+    if not os.path.isdir(web_dir):
+        click.echo(f"Error: apps/web/ not found at {web_dir}", err=True)
+        raise SystemExit(1)
+
+    click.echo(f"Starting Forge dashboard on port {port}...")
+    os.chdir(web_dir)
+    os.execvp("npm", ["npm", "run", "dev", "--", "--port", str(port)])


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `forge ui` command that starts the NextJS dashboard dev server from `apps/web/`
- Supports `--port` flag (default 3000)
- Uses `os.execvp` to replace the process (same pattern as `forge logs`)

Closes #627

## Test plan
- [ ] Run `forge --help` and verify `ui` command appears
- [ ] Run `forge ui --help` and verify `--port` option is shown
- [ ] Run `forge ui` and verify it starts the NextJS dev server on port 3000
- [ ] Run `forge ui --port 8080` and verify it starts on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)
