### PR TITLE
Epic #629: Consolidate log tabs — unified logs + events with agent filtering

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,14 +1,68 @@
+"use client";
+
+import { useState } from "react";
 import { AgentPanel } from "@/components/agent-panel";
 import { LogsPanel } from "@/components/logs-panel";
 import { EventsPanel } from "@/components/events-panel";
 import { ResizableLayout } from "@/components/resizable-layout";
 
+type Tab = "logs" | "events";
+
+function TabButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
+        active
+          ? "text-text-bright border-accent-blue"
+          : "text-muted-foreground border-transparent hover:text-text"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function RightPanel() {
+  const [activeTab, setActiveTab] = useState<Tab>("logs");
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 px-4 py-0 bg-surface border-b border-border shrink-0">
+        <TabButton
+          label="Logs"
+          active={activeTab === "logs"}
+          onClick={() => setActiveTab("logs")}
+        />
+        <TabButton
+          label="Events"
+          active={activeTab === "events"}
+          onClick={() => setActiveTab("events")}
+        />
+      </div>
+
+      {/* Active panel */}
+      <div className="flex-1 overflow-hidden min-h-0">
+        {activeTab === "logs" ? <LogsPanel /> : <EventsPanel />}
+      </div>
+    </div>
+  );
+}
+
 export default function Home() {
   return (
     <ResizableLayout
       sidebar={<AgentPanel />}
-      topRight={<LogsPanel />}
-      bottomRight={<EventsPanel />}
+      rightPanel={<RightPanel />}
     />
   );
 }

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -6,30 +6,124 @@ import { getAgentColor } from "@/lib/colors";
 
 const MAX_BLOCKS = 200;
 const POLL_INTERVAL = 5000; // Fallback polling interval (only used when SSE drops)
+const STORAGE_KEY = "forge-log-agent-filter";
+const COLLAPSED_HEIGHT = 144;
 
 interface AgentOffset {
   [agentId: string]: number;
 }
 
+type AgentFilterState = Record<string, boolean>;
+
+function loadFilterState(): AgentFilterState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return {};
+}
+
+function saveFilterState(state: AgentFilterState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {}
+}
+
+function getRole(agentId: string): string | null {
+  const match = agentId.match(/^(worker|planner|super)/);
+  return match ? match[1] : null;
+}
+
+const ROLES = ["worker", "planner", "super"] as const;
+const ROLE_COLORS: Record<string, string> = {
+  worker: "var(--accent-green)",
+  planner: "var(--accent-magenta)",
+  super: "var(--accent-yellow)",
+};
+
 export function LogsPanel() {
   const [blocks, setBlocks] = useState<LogBlock[]>([]);
   const [agents, setAgents] = useState<string[]>([]);
-  const [activeTab, setActiveTab] = useState("all");
   const [filter, setFilter] = useState("");
   const [autoScroll, setAutoScroll] = useState(true);
+  const [agentFilter, setAgentFilter] = useState<AgentFilterState>(loadFilterState);
+  const [filterOpen, setFilterOpen] = useState(false);
 
   const offsetsRef = useRef<AgentOffset>({});
   const containerRef = useRef<HTMLDivElement>(null);
   const prevScrollTop = useRef(0);
   const eventSourceRef = useRef<EventSource | null>(null);
   const fallbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Persist filter state on change
+  useEffect(() => {
+    saveFilterState(agentFilter);
+  }, [agentFilter]);
+
+  // Ensure new agents default to visible
+  useEffect(() => {
+    setAgentFilter((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const id of agents) {
+        if (!(id in next)) {
+          next[id] = true;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [agents]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!filterOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setFilterOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [filterOpen]);
+
+  const isAgentVisible = useCallback(
+    (agentId: string) => agentFilter[agentId] !== false,
+    [agentFilter]
+  );
+
+  const toggleAgent = useCallback((agentId: string) => {
+    setAgentFilter((prev) => {
+      const next = { ...prev };
+      next[agentId] = prev[agentId] === false ? true : false;
+      return next;
+    });
+  }, []);
+
+  const toggleRole = useCallback(
+    (role: string) => {
+      const roleAgents = agents.filter((a) => getRole(a) === role);
+      if (roleAgents.length === 0) return;
+      const allVisible = roleAgents.every((a) => agentFilter[a] !== false);
+      setAgentFilter((prev) => {
+        const next = { ...prev };
+        for (const a of roleAgents) {
+          next[a] = !allVisible;
+        }
+        return next;
+      });
+    },
+    [agents, agentFilter]
+  );
+
+  const hiddenCount = agents.filter((a) => agentFilter[a] === false).length;
 
   // Merge new blocks into state
   const mergeBlocks = useCallback(
-    (newBlocks: LogBlock[], mode: "all" | "single") => {
+    (newBlocks: LogBlock[]) => {
       if (newBlocks.length === 0) return;
       setBlocks((prev) => {
-        // Build a map preferring blocks that have endTimestamp set
         const blockMap = new Map<string, LogBlock>();
         for (const b of prev) {
           blockMap.set(b.key, b);
@@ -44,21 +138,12 @@ export function LogsPanel() {
         }
         if (!changed) return prev;
         const merged = Array.from(blockMap.values());
-        if (mode === "all") {
-          merged.sort(
-            (a, b) =>
-              new Date(a.endTimestamp ?? a.timestamp).getTime() -
-              new Date(b.endTimestamp ?? b.timestamp).getTime()
-          );
-          return merged.slice(-MAX_BLOCKS);
-        } else {
-          merged.sort(
-            (a, b) =>
-              new Date(a.endTimestamp ?? a.timestamp).getTime() -
-              new Date(b.endTimestamp ?? b.timestamp).getTime()
-          );
-          return merged.slice(-MAX_BLOCKS);
-        }
+        merged.sort(
+          (a, b) =>
+            new Date(a.endTimestamp ?? a.timestamp).getTime() -
+            new Date(b.endTimestamp ?? b.timestamp).getTime()
+        );
+        return merged.slice(-MAX_BLOCKS);
       });
     },
     []
@@ -66,89 +151,63 @@ export function LogsPanel() {
 
   // Initial load via existing GET endpoint
   const fetchInitialLogs = useCallback(async () => {
-    if (activeTab === "all") {
-      let agentIds = agents;
-      if (agentIds.length === 0) {
-        const agentsRes = await fetch("/api/agents");
-        if (!agentsRes.ok) return;
-        const agentsData = await agentsRes.json();
-        agentIds = (agentsData.agents as { id: string }[]).map((a) => a.id);
-        agentIds.sort();
-        setAgents(agentIds);
-      }
-
-      const results = await Promise.all(
-        agentIds.map(async (agentId) => {
-          const res = await fetch(
-            `/api/logs/${encodeURIComponent(agentId)}?offset=0`
-          );
-          if (!res.ok) return { agentId, data: "", offset: 0 };
-          const data = await res.json();
-          return { agentId, ...data };
-        })
-      );
-
-      const newBlocks: LogBlock[] = [];
-      for (const result of results) {
-        if (result.data) {
-          newBlocks.push(...parseLogBlocks(result.agentId, result.data));
-        }
-        offsetsRef.current[result.agentId] = result.offset;
-      }
-      mergeBlocks(newBlocks, "all");
-    } else {
-      const res = await fetch(
-        `/api/logs/${encodeURIComponent(activeTab)}?offset=0`
-      );
-      if (!res.ok) return;
-      const data = await res.json();
-      if (data.data) {
-        const parsed = parseLogBlocks(activeTab, data.data);
-        mergeBlocks(parsed, "single");
-      }
-      offsetsRef.current[activeTab] = data.offset;
+    let agentIds = agents;
+    if (agentIds.length === 0) {
+      const agentsRes = await fetch("/api/agents");
+      if (!agentsRes.ok) return;
+      const agentsData = await agentsRes.json();
+      agentIds = (agentsData.agents as { id: string }[]).map((a) => a.id);
+      agentIds.sort();
+      setAgents(agentIds);
     }
-  }, [activeTab, agents, mergeBlocks]);
+
+    const results = await Promise.all(
+      agentIds.map(async (agentId) => {
+        const res = await fetch(
+          `/api/logs/${encodeURIComponent(agentId)}?offset=0`
+        );
+        if (!res.ok) return { agentId, data: "", offset: 0 };
+        const data = await res.json();
+        return { agentId, ...data };
+      })
+    );
+
+    const newBlocks: LogBlock[] = [];
+    for (const result of results) {
+      if (result.data) {
+        newBlocks.push(...parseLogBlocks(result.agentId, result.data));
+      }
+      offsetsRef.current[result.agentId] = result.offset;
+    }
+    mergeBlocks(newBlocks);
+  }, [agents, mergeBlocks]);
 
   // Fallback polling fetch (incremental)
   const fetchLogsPoll = useCallback(async () => {
-    if (activeTab === "all") {
-      const agentIds = agents;
-      if (agentIds.length === 0) return;
+    const agentIds = agents;
+    if (agentIds.length === 0) return;
 
-      const results = await Promise.all(
-        agentIds.map(async (agentId) => {
-          const offset = offsetsRef.current[agentId] ?? 0;
-          const res = await fetch(
-            `/api/logs/${encodeURIComponent(agentId)}?offset=${offset}`
-          );
-          if (!res.ok) return { agentId, data: "", offset: 0 };
-          const data = await res.json();
-          return { agentId, ...data };
-        })
-      );
+    const results = await Promise.all(
+      agentIds.map(async (agentId) => {
+        const offset = offsetsRef.current[agentId] ?? 0;
+        const res = await fetch(
+          `/api/logs/${encodeURIComponent(agentId)}?offset=${offset}`
+        );
+        if (!res.ok) return { agentId, data: "", offset: 0 };
+        const data = await res.json();
+        return { agentId, ...data };
+      })
+    );
 
-      const newBlocks: LogBlock[] = [];
-      for (const result of results) {
-        if (result.data) {
-          newBlocks.push(...parseLogBlocks(result.agentId, result.data));
-        }
-        offsetsRef.current[result.agentId] = result.offset;
+    const newBlocks: LogBlock[] = [];
+    for (const result of results) {
+      if (result.data) {
+        newBlocks.push(...parseLogBlocks(result.agentId, result.data));
       }
-      mergeBlocks(newBlocks, "all");
-    } else {
-      const offset = offsetsRef.current[activeTab] ?? 0;
-      const res = await fetch(
-        `/api/logs/${encodeURIComponent(activeTab)}?offset=${offset}`
-      );
-      if (!res.ok) return;
-      const data = await res.json();
-      if (data.data) {
-        mergeBlocks(parseLogBlocks(activeTab, data.data), "single");
-      }
-      offsetsRef.current[activeTab] = data.offset;
+      offsetsRef.current[result.agentId] = result.offset;
     }
-  }, [activeTab, agents, mergeBlocks]);
+    mergeBlocks(newBlocks);
+  }, [agents, mergeBlocks]);
 
   // Start fallback polling
   const startFallbackPolling = useCallback(() => {
@@ -166,43 +225,31 @@ export function LogsPanel() {
 
   // Set up SSE connection
   useEffect(() => {
-    // Reset state on tab switch
     setBlocks([]);
     offsetsRef.current = {};
 
-    // Load initial history — called once per tab switch, not on every agent change.
     fetchInitialLogs();
 
-    // Open SSE connection
-    const sseUrl =
-      activeTab === "all"
-        ? "/api/logs/stream"
-        : `/api/logs/stream?agentId=${encodeURIComponent(activeTab)}`;
-
-    const es = new EventSource(sseUrl);
+    const es = new EventSource("/api/logs/stream");
     eventSourceRef.current = es;
 
     es.addEventListener("log", (event) => {
       const { agentId, data, offset } = JSON.parse(event.data);
       if (data) {
         const parsed = parseLogBlocks(agentId, data);
-        mergeBlocks(parsed, activeTab === "all" ? "all" : "single");
+        mergeBlocks(parsed);
       }
       offsetsRef.current[agentId] = offset;
 
-      // If we're getting SSE events, discover new agents for tabs
-      if (activeTab === "all") {
-        setAgents((prev) => {
-          if (prev.includes(agentId)) return prev;
-          const next = [...prev, agentId];
-          next.sort();
-          return next;
-        });
-      }
+      setAgents((prev) => {
+        if (prev.includes(agentId)) return prev;
+        const next = [...prev, agentId];
+        next.sort();
+        return next;
+      });
     });
 
     es.onerror = () => {
-      // EventSource auto-reconnects; start fallback polling in the meantime
       startFallbackPolling();
     };
 
@@ -216,7 +263,7 @@ export function LogsPanel() {
       stopFallbackPolling();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTab, mergeBlocks, startFallbackPolling, stopFallbackPolling]);
+  }, [mergeBlocks, startFallbackPolling, stopFallbackPolling]);
 
   // Auto-scroll detection
   const handleScroll = useCallback(() => {
@@ -239,43 +286,104 @@ export function LogsPanel() {
     }
   }, [blocks, autoScroll]);
 
-  const filteredBlocks =
-    activeTab === "all"
-      ? blocks
-      : blocks.filter((b) => b.agentId === activeTab);
-
-  const displayBlocks = filter
-    ? filteredBlocks.filter((b) =>
-        b.content.toLowerCase().includes(filter.toLowerCase())
-      )
-    : filteredBlocks;
+  const displayBlocks = blocks.filter((b) => {
+    if (!isAgentVisible(b.agentId)) return false;
+    if (filter && !b.content.toLowerCase().includes(filter.toLowerCase())) return false;
+    return true;
+  });
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Header with tabs */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-2 shrink-0">
-        <div className="flex items-center gap-1 overflow-x-auto">
-          <TabButton
-            label="All"
-            active={activeTab === "all"}
-            onClick={() => setActiveTab("all")}
-          />
-          {agents.map((id) => (
-            <TabButton
-              key={id}
-              label={id}
-              active={activeTab === id}
-              onClick={() => setActiveTab(id)}
-              color={getAgentColor(id)}
-            />
-          ))}
+      {/* Filter bar */}
+      <div className="flex items-center justify-end gap-2 border-b border-border px-4 py-2 shrink-0">
+        <div className="relative" ref={dropdownRef}>
+          <button
+            onClick={() => setFilterOpen((v) => !v)}
+            className="text-muted-foreground hover:text-text-bright text-sm px-2 py-1 rounded border border-border flex items-center gap-1.5"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M1 2h14l-5.5 6.5V14l-3-2V8.5L1 2z" />
+            </svg>
+            Agents
+            {hiddenCount > 0 && (
+              <span className="text-xs bg-accent-blue/20 text-accent-blue px-1.5 rounded-full">
+                {agents.length - hiddenCount}/{agents.length}
+              </span>
+            )}
+          </button>
+          {filterOpen && (
+            <div className="absolute top-full left-0 mt-1 z-50 bg-surface border border-border rounded-md shadow-lg min-w-[200px]">
+              {/* Role pills */}
+              {ROLES.some((r) => agents.some((a) => getRole(a) === r)) && (
+                <div className="flex items-center gap-1.5 px-3 py-2 border-b border-border">
+                  {ROLES.map((role) => {
+                    const roleAgents = agents.filter((a) => getRole(a) === role);
+                    if (roleAgents.length === 0) return null;
+                    const allVisible = roleAgents.every((a) => agentFilter[a] !== false);
+                    return (
+                      <button
+                        key={role}
+                        onClick={() => toggleRole(role)}
+                        className="text-xs px-2 py-0.5 rounded-full border transition-colors"
+                        style={{
+                          borderColor: ROLE_COLORS[role],
+                          backgroundColor: allVisible ? ROLE_COLORS[role] + "30" : "transparent",
+                          color: ROLE_COLORS[role],
+                          opacity: allVisible ? 1 : 0.5,
+                        }}
+                      >
+                        {role}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {/* Agent checkboxes */}
+              <div className="py-1 max-h-[240px] overflow-y-auto">
+                {agents.length === 0 ? (
+                  <div className="px-3 py-2 text-sm text-muted-foreground">No agents</div>
+                ) : (
+                  agents.map((agentId) => {
+                    const color = getAgentColor(agentId);
+                    const visible = agentFilter[agentId] !== false;
+                    return (
+                      <button
+                        key={agentId}
+                        onClick={() => toggleAgent(agentId)}
+                        className="flex items-center gap-2 w-full px-3 py-1.5 text-sm text-left hover:bg-surface-hover transition-colors"
+                      >
+                        <span
+                          className="w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0"
+                          style={{
+                            borderColor: visible ? "var(--accent-blue)" : "var(--color-border)",
+                            backgroundColor: visible ? "var(--accent-blue)" : "transparent",
+                          }}
+                        >
+                          {visible && (
+                            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="white" strokeWidth="1.5">
+                              <path d="M2 5l2 2 4-4" />
+                            </svg>
+                          )}
+                        </span>
+                        <span
+                          className="w-2.5 h-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: color }}
+                        />
+                        <span className="text-text truncate">{agentId}</span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          )}
         </div>
         <input
           type="text"
           placeholder="Filter..."
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="bg-surface-hover text-text text-sm px-2 py-1 rounded border border-border outline-none focus:border-accent-blue w-40 shrink-0 ml-2"
+          className="bg-surface-hover text-text text-sm px-2 py-1 rounded border border-border outline-none focus:border-accent-blue w-40 shrink-0"
         />
       </div>
 
@@ -291,7 +399,7 @@ export function LogsPanel() {
           </div>
         ) : (
           displayBlocks.map((block) => (
-            <LogCard key={block.key} block={block} showAgent={activeTab === "all"} />
+            <LogCard key={block.key} block={block} />
           ))
         )}
       </div>
@@ -299,48 +407,30 @@ export function LogsPanel() {
   );
 }
 
-function TabButton({
-  label,
-  active,
-  onClick,
-  color,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-  color?: string;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-3 py-1.5 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
-        active
-          ? "text-text-bright border-accent-blue"
-          : "text-muted-foreground border-transparent hover:text-text"
-      }`}
-      style={active && color ? { borderColor: color } : undefined}
-    >
-      {color && (
-        <span
-          className="inline-block w-2 h-2 rounded-full mr-1.5"
-          style={{ backgroundColor: color }}
-        />
-      )}
-      {label}
-    </button>
-  );
+function getRoleDotColor(agentId: string): string {
+  if (agentId.startsWith("worker")) return "#98c379";
+  if (agentId.startsWith("planner")) return "#c678dd";
+  if (agentId.startsWith("super")) return "#e5c07b";
+  return "#abb2bf";
 }
 
-const COLLAPSED_HEIGHT = 144;
+function formatDuration(startIso: string, endIso: string): string {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (ms < 0) return "";
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min > 0) return `${min}m ${sec}s`;
+  return `${sec}s`;
+}
 
-function LogCard({
-  block,
-  showAgent,
-}: {
-  block: LogBlock;
-  showAgent: boolean;
-}) {
+function LogCard({ block }: { block: LogBlock }) {
   const agentColor = getAgentColor(block.agentId);
+  const dotColor = getRoleDotColor(block.agentId);
+  const duration =
+    block.endTimestamp && block.timestamp
+      ? formatDuration(block.timestamp, block.endTimestamp)
+      : "";
   const [expanded, setExpanded] = useState(false);
   const [overflows, setOverflows] = useState(false);
   const contentRef = useRef<HTMLPreElement>(null);
@@ -353,23 +443,39 @@ function LogCard({
   }, [block.content]);
 
   return (
-    <div className="bg-surface border border-border rounded-md p-3">
+    <div
+      className="bg-surface border border-border rounded-md p-3 border-l-2"
+      style={{ borderLeftColor: agentColor }}
+    >
       <div className="flex items-center gap-2 mb-2">
-        {showAgent && (
+        <span
+          className="inline-flex items-center gap-1.5 text-sm font-semibold px-2 py-0.5 rounded"
+          style={{
+            backgroundColor: agentColor + "26",
+            color: agentColor,
+            border: `1px solid ${agentColor}4D`,
+          }}
+        >
           <span
-            className="text-sm font-semibold px-2 py-0.5 rounded"
-            style={{
-              backgroundColor: agentColor + "20",
-              color: agentColor,
-            }}
-          >
-            {block.agentId}
-          </span>
-        )}
+            className="inline-block w-2 h-2 rounded-full shrink-0"
+            style={{ backgroundColor: dotColor }}
+          />
+          {block.agentId}
+        </span>
         <span className="text-sm text-muted-foreground">
           {block.displayTime}
           {block.displayEndTime && (
-            <span className="text-muted-foreground/60"> → {block.displayEndTime}</span>
+            <>
+              <span className="text-muted-foreground/60">
+                {" "}
+                → {block.displayEndTime}
+              </span>
+              {duration && (
+                <span className="text-muted-foreground text-xs ml-1">
+                  ({duration})
+                </span>
+              )}
+            </>
           )}
         </span>
       </div>

--- a/apps/web/src/components/resizable-layout.tsx
+++ b/apps/web/src/components/resizable-layout.tsx
@@ -5,19 +5,11 @@ import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 const STORAGE_KEY = "dacl-panel-sizes";
 const SIDEBAR_MIN = 200;
 const SIDEBAR_MAX = 500;
-const PANEL_MIN = 100;
 const HANDLE_SIZE = 4;
 const SIDEBAR_COLLAPSE_THRESHOLD = 120; // px — below this, auto-collapse
-const EVENTS_COLLAPSE_THRESHOLD = 60;   // px — below this, auto-collapse
 
 interface PanelSizes {
   sidebarWidth: number;
-  topRightRatio: number; // 0-1, fraction of right area used by top panel
-}
-
-interface CollapsedState {
-  sidebar: boolean;
-  bottom: boolean;
 }
 
 function loadSizes(): PanelSizes {
@@ -27,13 +19,12 @@ function loadSizes(): PanelSizes {
       const parsed = JSON.parse(stored);
       return {
         sidebarWidth: Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, parsed.sidebarWidth ?? 300)),
-        topRightRatio: Math.max(0.1, Math.min(0.9, parsed.topRightRatio ?? 0.7)),
       };
     }
   } catch {
     // ignore
   }
-  return { sidebarWidth: 300, topRightRatio: 0.7 };
+  return { sidebarWidth: 300 };
 }
 
 function saveSizes(sizes: PanelSizes) {
@@ -46,44 +37,39 @@ function saveSizes(sizes: PanelSizes) {
 
 export function ResizableLayout({
   sidebar,
-  topRight,
-  bottomRight,
+  rightPanel,
 }: {
   sidebar: ReactNode;
-  topRight: ReactNode;
-  bottomRight: ReactNode;
+  rightPanel: ReactNode;
 }) {
-  const [sizes, setSizes] = useState<PanelSizes>({ sidebarWidth: 300, topRightRatio: 0.7 });
-  const [collapsed, setCollapsed] = useState<CollapsedState>({ sidebar: false, bottom: false });
+  const [sizes, setSizes] = useState<PanelSizes>({ sidebarWidth: 300 });
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [hydrated, setHydrated] = useState(false);
 
-  const [dragging, setDragging] = useState<"vertical" | "horizontal" | null>(null);
+  const [dragging, setDragging] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const draggingRef = useRef<"vertical" | "horizontal" | null>(null);
-  const sizesBeforeCollapseRef = useRef<PanelSizes>(sizes);
+  const draggingRef = useRef(false);
 
   // Load sizes from localStorage after mount
   useEffect(() => {
     const loaded = loadSizes();
     setSizes(loaded);
-    sizesBeforeCollapseRef.current = loaded;
     setHydrated(true);
   }, []);
 
   // Persist sizes on change
   useEffect(() => {
-    if (hydrated && !collapsed.sidebar && !collapsed.bottom) {
+    if (hydrated && !sidebarCollapsed) {
       saveSizes(sizes);
-      sizesBeforeCollapseRef.current = sizes;
     }
-  }, [sizes, hydrated, collapsed]);
+  }, [sizes, hydrated, sidebarCollapsed]);
 
   const handlePointerDown = useCallback(
-    (axis: "vertical" | "horizontal") => (e: React.PointerEvent) => {
+    (e: React.PointerEvent) => {
       e.preventDefault();
-      draggingRef.current = axis;
-      setDragging(axis);
+      draggingRef.current = true;
+      setDragging(true);
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
     []
@@ -94,60 +80,28 @@ export function ResizableLayout({
       if (!draggingRef.current || !containerRef.current) return;
 
       const rect = containerRef.current.getBoundingClientRect();
-
-      if (draggingRef.current === "vertical") {
-        const rawWidth = e.clientX - rect.left;
-        if (rawWidth < SIDEBAR_COLLAPSE_THRESHOLD) {
-          setCollapsed((prev) => ({ ...prev, sidebar: true }));
-        } else {
-          const newWidth = Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, rawWidth));
-          setSizes((prev) => ({ ...prev, sidebarWidth: newWidth }));
-          setCollapsed((prev) => (prev.sidebar ? { ...prev, sidebar: false } : prev));
-        }
-      } else if (draggingRef.current === "horizontal") {
-        const rightHeight = rect.height;
-        const relativeY = e.clientY - rect.top;
-        const bottomPx = rightHeight - relativeY - HANDLE_SIZE;
-        if (bottomPx < EVENTS_COLLAPSE_THRESHOLD) {
-          setCollapsed((prev) => ({ ...prev, bottom: true }));
-        } else {
-          const ratio = Math.max(0.1, Math.min(0.9, relativeY / rightHeight));
-          const topPx = ratio * rightHeight;
-          const clampedBottomPx = rightHeight - topPx - HANDLE_SIZE;
-          if (topPx >= PANEL_MIN && clampedBottomPx >= PANEL_MIN) {
-            setSizes((prev) => ({ ...prev, topRightRatio: ratio }));
-          }
-          setCollapsed((prev) => (prev.bottom ? { ...prev, bottom: false } : prev));
-        }
+      const rawWidth = e.clientX - rect.left;
+      if (rawWidth < SIDEBAR_COLLAPSE_THRESHOLD) {
+        setSidebarCollapsed(true);
+      } else {
+        const newWidth = Math.max(SIDEBAR_MIN, Math.min(SIDEBAR_MAX, rawWidth));
+        setSizes((prev) => ({ ...prev, sidebarWidth: newWidth }));
+        setSidebarCollapsed(false);
       }
     },
-    [collapsed.sidebar, sizes.sidebarWidth]
+    []
   );
 
   const handlePointerUp = useCallback(() => {
-    draggingRef.current = null;
-    setDragging(null);
+    draggingRef.current = false;
+    setDragging(false);
   }, []);
 
-  const handleDoubleClickVertical = useCallback(() => {
-    setCollapsed((prev) => {
-      if (!prev.sidebar) {
-        return { ...prev, sidebar: true };
-      }
-      return { ...prev, sidebar: false };
-    });
+  const handleDoubleClick = useCallback(() => {
+    setSidebarCollapsed((prev) => !prev);
   }, []);
 
-  const handleDoubleClickHorizontal = useCallback(() => {
-    setCollapsed((prev) => {
-      if (!prev.bottom) {
-        return { ...prev, bottom: true };
-      }
-      return { ...prev, bottom: false };
-    });
-  }, []);
-
-  const sidebarWidth = collapsed.sidebar ? 0 : sizes.sidebarWidth;
+  const sidebarWidth = sidebarCollapsed ? 0 : sizes.sidebarWidth;
 
   return (
     <div
@@ -155,14 +109,14 @@ export function ResizableLayout({
       className={`h-screen w-screen overflow-hidden flex bg-border${dragging ? " select-none" : ""}`}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
-      style={{ cursor: dragging === "vertical" ? "col-resize" : dragging === "horizontal" ? "row-resize" : undefined }}
+      style={{ cursor: dragging ? "col-resize" : undefined }}
     >
       {/* Sidebar */}
-      {collapsed.sidebar ? (
+      {sidebarCollapsed ? (
         <div
           className="bg-surface flex items-center justify-center shrink-0 cursor-pointer hover:bg-surface-hover transition-colors gap-1"
           style={{ width: 36 }}
-          onClick={() => setCollapsed((prev) => ({ ...prev, sidebar: false }))}
+          onClick={() => setSidebarCollapsed(false)}
         >
           <span className="text-muted-foreground text-xs uppercase tracking-widest [writing-mode:vertical-lr]">
             ▶ Agents
@@ -177,7 +131,7 @@ export function ResizableLayout({
             <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide">Agents</h2>
             <button
               className="text-muted-foreground hover:text-text-bright text-sm px-1"
-              onClick={() => setCollapsed((prev) => ({ ...prev, sidebar: true }))}
+              onClick={() => setSidebarCollapsed(true)}
               title="Collapse sidebar"
             >
               ◀
@@ -191,65 +145,13 @@ export function ResizableLayout({
       <div
         className="shrink-0 bg-border hover:bg-accent-blue transition-colors"
         style={{ width: HANDLE_SIZE, cursor: "col-resize" }}
-        onPointerDown={handlePointerDown("vertical")}
-        onDoubleClick={handleDoubleClickVertical}
+        onPointerDown={handlePointerDown}
+        onDoubleClick={handleDoubleClick}
       />
 
-      {/* Right area: top + handle + bottom */}
-      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        {/* Top right (Logs) */}
-        {collapsed.bottom ? (
-          <div className="flex-1 overflow-hidden bg-background">
-            {topRight}
-          </div>
-        ) : (
-          <div
-            className="overflow-hidden bg-background"
-            style={{ flex: `0 0 calc(${sizes.topRightRatio * 100}% - ${HANDLE_SIZE / 2}px)` }}
-          >
-            {topRight}
-          </div>
-        )}
-
-        {/* Horizontal resize handle */}
-        {collapsed.bottom ? (
-          <div
-            className="shrink-0 bg-surface flex items-center justify-center cursor-pointer hover:bg-surface-hover transition-colors"
-            style={{ height: 24 }}
-            onClick={() => setCollapsed((prev) => ({ ...prev, bottom: false }))}
-          >
-            <span className="text-muted-foreground text-xs uppercase tracking-wide">
-              ▲ Events
-            </span>
-          </div>
-        ) : (
-          <div
-            className="shrink-0 bg-border hover:bg-accent-blue transition-colors"
-            style={{ height: HANDLE_SIZE, cursor: "row-resize" }}
-            onPointerDown={handlePointerDown("horizontal")}
-            onDoubleClick={handleDoubleClickHorizontal}
-          />
-        )}
-
-        {/* Bottom right (Events) */}
-        {!collapsed.bottom && (
-          <div
-            className="overflow-hidden flex flex-col min-h-0"
-            style={{ flex: `0 0 calc(${(1 - sizes.topRightRatio) * 100}% - ${HANDLE_SIZE / 2}px)` }}
-          >
-            <div className="flex items-center justify-between px-3 pt-2 pb-1 shrink-0 bg-surface">
-              <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide">Events</h2>
-              <button
-                className="text-muted-foreground hover:text-text-bright text-sm px-1"
-                onClick={() => setCollapsed((prev) => ({ ...prev, bottom: true }))}
-                title="Collapse events"
-              >
-                ▼
-              </button>
-            </div>
-            <div className="flex-1 overflow-hidden min-h-0">{bottomRight}</div>
-          </div>
-        )}
+      {/* Right panel */}
+      <div className="flex-1 min-w-0 overflow-hidden bg-background">
+        {rightPanel}
       </div>
     </div>
   );


### PR DESCRIPTION
**@planner-02**

## Summary
Consolidates the dashboard's per-agent log tabs into two unified tabs — **Logs** (all agents in one stream, with filtering) and **Events** (webhook events). Adds agent/role filtering with session-persisted state.

## Epic
Closes #629

## Subtasks
- [ ] #634 — Restructure layout: replace log/event split with tabbed panel
- [ ] #635 — Add agent filter dropdown to unified LogsPanel (blocked on #634)
- [ ] #636 — Enhance LogCard agent badges and visual distinction
