### PR TITLE
Fix inferRole to derive agent role from ID prefix

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -62,10 +62,9 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function inferRole(contexts: string[]): string {
-  return contexts.some((c) => c.includes("PLANNER.md"))
-    ? "planner"
-    : "worker";
+function inferRole(id: string): string {
+  const match = id.match(/^([a-zA-Z]+)-\d+$/);
+  return match?.[1] ?? "worker";
 }
 
 function buildAgentFromJob(
@@ -100,7 +99,7 @@ function buildAgentFromJob(
 
   return {
     id: job.id,
-    role: inferRole(job.contexts),
+    role: inferRole(job.id),
     interval: job.interval,
     intervalSeconds,
     enabled: job.enabled !== false,


### PR DESCRIPTION
**@worker-01**

## Summary
- Fix `inferRole` in `apps/web/src/app/api/agents/route.ts` to derive agent role from ID prefix instead of checking context filenames
- Super agents (e.g. `super-01`) are now correctly classified instead of falling through to `"worker"`

## Test plan
- [ ] Verify super agents show correct role badge in dashboard
- [ ] Verify planner/worker agents still show correct roles
- [ ] Verify auto-ID preview in Add Agent modal counts roles correctly
- [ ] `npm run build` passes in `apps/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
