### PR TITLE
Extract shared CronJob/CronState/CronJobsData interfaces

### DIFF
--- a/apps/web/src/app/api/agents/[id]/adopt/route.ts
+++ b/apps/web/src/app/api/agents/[id]/adopt/route.ts
@@ -7,31 +7,9 @@ import {
   templatePath,
 } from "@/lib/paths";
 
+import { CronJob, CronJobsData, CronState } from "@/lib/cron-types";
+
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
-
-interface CronJob {
-  id: string;
-  interval: string;
-  prompt: string;
-  contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
-}
-
-interface CronJobsData {
-  jobs: CronJob[];
-  [key: string]: unknown;
-}
-
-interface CronState {
-  jobs: Record<
-    string,
-    {
-      interval?: string;
-      contexts?: string[];
-    }
-  >;
-}
 
 function inferTemplateType(id: string): string {
   if (id.startsWith("planner")) return "planner";

--- a/apps/web/src/app/api/agents/[id]/force-run/route.ts
+++ b/apps/web/src/app/api/agents/[id]/force-run/route.ts
@@ -9,17 +9,9 @@ import {
   agentLogPath,
 } from "@/lib/paths";
 
-const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+import { CronJob } from "@/lib/cron-types";
 
-interface CronJob {
-  id: string;
-  interval: string;
-  prompt: string;
-  contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
-  repo?: string;
-}
+const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
 export async function POST(
   _request: NextRequest,

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -1,17 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import { atomicWriteJsonSync, cronJobsPath } from "@/lib/paths";
+import { CronJob, CronJobsData } from "@/lib/cron-types";
 
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
-
-interface CronJob {
-  id: string;
-}
-
-interface CronJobsData {
-  jobs: CronJob[];
-  [key: string]: unknown;
-}
 
 export async function DELETE(
   _request: NextRequest,

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -7,30 +7,7 @@ import {
   lockFilePath,
   templatePath,
 } from "@/lib/paths";
-
-interface CronJob {
-  id: string;
-  interval: string;
-  prompt: string;
-  contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
-  enabled?: boolean;
-  repo?: string;
-}
-
-interface CronState {
-  jobs: Record<
-    string,
-    {
-      interval?: string;
-      last_run?: string;
-      stagger_offset?: number;
-      installed_at?: string;
-      contexts?: string[];
-    }
-  >;
-}
+import { CronJob, CronState } from "@/lib/cron-types";
 
 function parseIntervalSeconds(interval: string): number {
   const match = interval.match(/^(\d+)(s|m|h)$/);

--- a/apps/web/src/lib/cron-types.ts
+++ b/apps/web/src/lib/cron-types.ts
@@ -1,0 +1,28 @@
+export interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+  enabled?: boolean;
+  repo?: string;
+}
+
+export interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      last_run?: string;
+      stagger_offset?: number;
+      installed_at?: string;
+      contexts?: string[];
+    }
+  >;
+}
+
+export interface CronJobsData {
+  jobs: CronJob[];
+  [key: string]: unknown;
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- Extract duplicated `CronJob`, `CronState`, and `CronJobsData` interfaces into a shared `apps/web/src/lib/cron-types.ts` module
- Update all 4 API route files under `apps/web/src/app/api/agents/` to import from the shared module
- Remove all local duplicate interface declarations

## Test plan
- [x] `npm run build` passes in `apps/web` with no type errors
- [ ] Verify API routes still function correctly (GET/POST/DELETE agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
