### PR TITLE
Enhance LogCard agent badges and visual distinction

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -229,25 +229,65 @@ export function LogsPanel() {
   );
 }
 
+function getRoleDotColor(agentId: string): string {
+  if (agentId.startsWith("worker")) return "#98c379";
+  if (agentId.startsWith("planner")) return "#c678dd";
+  if (agentId.startsWith("super")) return "#e5c07b";
+  return "#abb2bf";
+}
+
+function formatDuration(startIso: string, endIso: string): string {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (ms < 0) return "";
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min > 0) return `${min}m ${sec}s`;
+  return `${sec}s`;
+}
+
 function LogCard({ block }: { block: LogBlock }) {
   const agentColor = getAgentColor(block.agentId);
+  const dotColor = getRoleDotColor(block.agentId);
+  const duration =
+    block.endTimestamp && block.timestamp
+      ? formatDuration(block.timestamp, block.endTimestamp)
+      : "";
 
   return (
-    <div className="bg-surface border border-border rounded-md p-3">
+    <div
+      className="bg-surface border border-border rounded-md p-3 border-l-2"
+      style={{ borderLeftColor: agentColor }}
+    >
       <div className="flex items-center gap-2 mb-2">
         <span
-          className="text-sm font-semibold px-2 py-0.5 rounded"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold px-2 py-0.5 rounded"
           style={{
-            backgroundColor: agentColor + "20",
+            backgroundColor: agentColor + "26",
             color: agentColor,
+            border: `1px solid ${agentColor}4D`,
           }}
         >
+          <span
+            className="inline-block w-2 h-2 rounded-full shrink-0"
+            style={{ backgroundColor: dotColor }}
+          />
           {block.agentId}
         </span>
         <span className="text-sm text-muted-foreground">
           {block.displayTime}
           {block.displayEndTime && (
-            <span className="text-muted-foreground/60"> → {block.displayEndTime}</span>
+            <>
+              <span className="text-muted-foreground/60">
+                {" "}
+                → {block.displayEndTime}
+              </span>
+              {duration && (
+                <span className="text-muted-foreground text-xs ml-1">
+                  ({duration})
+                </span>
+              )}
+            </>
           )}
         </span>
       </div>


### PR DESCRIPTION
**@worker-01**

## Summary
- Add role-colored dot indicator (green for workers, magenta for planners, yellow for super) to agent badges
- Add 2px colored left border to each LogCard using the agent's assigned color for quick visual scanning
- Add border and background opacity to agent badge (30% border, 15% background)
- Show computed duration (e.g. "2m 23s") when both start and end timestamps exist

## Test plan
- [ ] Verify log cards from different agents have distinct left border colors
- [ ] Verify each badge shows a colored role dot matching the agent type
- [ ] Verify duration is displayed when both start and end timestamps exist
- [ ] Verify cards without end timestamps show no duration
- [ ] Verify visual style matches One Dark theme

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)
