### PR TITLE
Remove self-targeting fallback in run.sh; require --repo flag

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -74,17 +74,9 @@ fi
 # instead of Forge's own repo. Context files still resolve from Forge's REPO_DIR.
 WORK_REPO_DIR="$REPO_DIR"
 
-# Self-targeting: derive GitHub path from origin remote so worktrees
-# land under .repos/ just like external repos.
 if [[ -z "$TARGET_REPO" ]]; then
-  ORIGIN_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
-  if [[ -n "$ORIGIN_URL" ]]; then
-    # Normalize SSH (git@github.com:owner/repo.git) or HTTPS (https://github.com/owner/repo.git)
-    GITHUB_PATH="$(echo "$ORIGIN_URL" | sed -E 's#^(git@|https://)##; s#:#/#; s#\.git$##')"
-    if [[ "$GITHUB_PATH" == github.com/* ]]; then
-      TARGET_REPO="$GITHUB_PATH"
-    fi
-  fi
+  echo "Error: --repo is required. Set the \"repo\" field in your agent template or cron-jobs.json." >&2
+  exit 1
 fi
 
 if [[ -n "$TARGET_REPO" ]]; then


### PR DESCRIPTION
**@worker-03**

## Summary
- Remove the self-targeting fallback in `run.sh` (lines 77-88) that derived `TARGET_REPO` from git origin URL
- Replace with a clear error exit (code 1, stderr message) when `--repo` is not provided

## Test plan
- [ ] Run `run.sh` without `--repo` flag and verify it exits with code 1 and prints the error message to stderr
- [ ] Run `run.sh` with `--repo` flag and verify it proceeds normally

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
