### PR TITLE
Add repo field to templates, cron-jobs.json, and web API layer

### DIFF
--- a/agent-kernel/cron/cron-jobs.json
+++ b/agent-kernel/cron/cron-jobs.json
@@ -7,7 +7,8 @@
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "worker-01",
@@ -15,7 +16,8 @@
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "worker-02",
@@ -23,7 +25,8 @@
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "planner-02",
@@ -31,7 +34,8 @@
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "worker-03",
@@ -39,7 +43,8 @@
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "planner-03",
@@ -47,7 +52,8 @@
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "worker-04",
@@ -55,7 +61,8 @@
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     },
     {
       "id": "planner-04",
@@ -63,7 +70,8 @@
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
-      "workspace": true
+      "workspace": true,
+      "repo": "github.com/alexjaniak/Forge"
     }
   ]
 }

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -267,6 +267,7 @@ export async function POST(request: NextRequest) {
       contexts: template.contexts ?? [],
       agentic: template.agentic ?? true,
       workspace: template.workspace ?? true,
+      repo: template.repo ?? "",
     };
 
     data.jobs.push(newJob);

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -25,6 +25,7 @@ export async function GET() {
       contexts: data.contexts ?? [],
       agentic: data.agentic ?? true,
       workspace: data.workspace ?? true,
+      repo: data.repo ?? "",
     };
   });
 

--- a/templates/planner.json
+++ b/templates/planner.json
@@ -3,5 +3,6 @@
   "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
   "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
-  "workspace": true
+  "workspace": true,
+  "repo": "github.com/alexjaniak/Forge"
 }

--- a/templates/super.json
+++ b/templates/super.json
@@ -3,5 +3,6 @@
   "prompt": "Review epic PRs labeled status:needs-review and role:super. Check for cohesion, DRY code, and cross-cutting conflicts with other open PRs and issues. Approve to admin or send back to planner. Sweep for stale, stuck, or orphaned issues and PRs.",
   "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
   "agentic": true,
-  "workspace": true
+  "workspace": true,
+  "repo": "github.com/alexjaniak/Forge"
 }

--- a/templates/worker.json
+++ b/templates/worker.json
@@ -3,5 +3,6 @@
   "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
-  "workspace": true
+  "workspace": true,
+  "repo": "github.com/alexjaniak/Forge"
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `"repo": "github.com/alexjaniak/Forge"` to all 3 templates (`worker.json`, `planner.json`, `super.json`)
- Add `"repo": "github.com/alexjaniak/Forge"` to all 8 jobs in `cron-jobs.json`
- Pass `repo` from template into new jobs in `POST /api/agents`
- Return `repo` field in `GET /api/templates`

## Test plan
- [ ] Verify all templates contain `repo` field
- [ ] Verify all 8 cron jobs contain `repo` field
- [ ] Verify POST /api/agents creates jobs with `repo` from template
- [ ] Verify GET /api/templates returns `repo` for each template

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)
