### PR TITLE
Add Codex auth preflight and explicit login in run.sh

### DIFF
--- a/agent-kernel/.env.example
+++ b/agent-kernel/.env.example
@@ -18,6 +18,9 @@ INNIES_TOKEN=in_live_...
 # Claude CLI auth (from `claude setup-token`)
 # CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."
 #
+# Codex CLI auth
+# OPENAI_API_KEY="sk-..."
+#
 # Optional: override claude binary path
 # CLAUDE_BIN="/path/to/claude"
 

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -204,6 +204,16 @@ if [[ "$AGENT_RUNTIME" == "codex" ]] && [[ "${USE_INNIES:-false}" != "true" ]]; 
   fi
 fi
 
+# ── preflight: Codex auth (direct mode) ──────────────────────
+if [[ "$AGENT_RUNTIME" == "codex" ]] && [[ "${USE_INNIES:-false}" != "true" ]]; then
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    echo "[preflight] OPENAI_API_KEY is not set. Add it to agent-kernel/.env or export it." >&2
+    exit 1
+  fi
+  # Pipe key to codex login so the CLI has valid credentials for this session
+  printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key 2>/dev/null || true
+fi
+
 # ── preflight: Innies proxy connectivity ─────────────────────
 if [[ "${USE_INNIES:-false}" == "true" ]]; then
   if ! command -v innies &>/dev/null; then


### PR DESCRIPTION
**@worker-03**

## Summary
- Add Codex auth preflight check in `run.sh` for direct mode (`USE_INNIES=false`)
- When `OPENAI_API_KEY` is missing, exits with code 1 and clear error message to stderr
- When set, pipes the key to `codex login --with-api-key` (stderr suppressed)
- Document `OPENAI_API_KEY` in `.env.example` under the direct auth section

## Test plan
- [ ] Set `AGENT_RUNTIME=codex`, `USE_INNIES=false`, unset `OPENAI_API_KEY` → verify exit 1 with error message
- [ ] Set `AGENT_RUNTIME=codex`, `USE_INNIES=false`, set `OPENAI_API_KEY` → verify `codex login` is called silently
- [ ] Set `USE_INNIES=true` → verify no auth preflight runs
- [ ] Set `AGENT_RUNTIME=claude` → verify no auth preflight runs
- [ ] Verify `.env.example` documents `OPENAI_API_KEY`

Closes #669
