### PR TITLE
Buffer run output to temp file and atomic-append

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -94,7 +94,7 @@ def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False, 
         cmd += f" --model '{model}'"
     for ctx in (contexts or []):
         cmd += f" --context {ctx}"
-    cmd += f' "{prompt}" >> {LOGS_DIR}/{job_id}.log 2>&1'
+    cmd += f' "{prompt}"'
     return cmd
 
 

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -123,9 +123,9 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   if [[ -f "$LOCKFILE" ]]; then
     OLD_PID=$(cat "$LOCKFILE" 2>/dev/null)
     if kill -0 "$OLD_PID" 2>/dev/null; then
-      SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
-      mkdir -p "$(dirname "$SYSTEM_LOG")"
-      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (pid $OLD_PID still running)" >> "$SYSTEM_LOG"
+      LOGS_DIR="$KERNEL_DIR/logs"
+      mkdir -p "$LOGS_DIR"
+      echo "=== SKIP $(date -u +%Y-%m-%dT%H:%M:%SZ) reason=\"pid $OLD_PID still running\" ===" >> "$LOGS_DIR/$WORKSPACE_ID.log"
       exit 0
     fi
   fi
@@ -134,11 +134,30 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   echo $$ > "$LOCKFILE"
 fi
 
-# ── run boundary markers (used by logs/view.sh to group output) ──
-# Emit early so ALL output (including errors) is captured between delimiters.
-echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+# ── buffered atomic logging ──────────────────────────────────
+LOGS_DIR="$KERNEL_DIR/logs"
+mkdir -p "$LOGS_DIR"
+RUN_START_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RUN_START_EPOCH="$(date +%s)"
+TMPLOG="$(mktemp /tmp/forge-run-XXXXXX.log)"
+
+# Redirect all stdout/stderr to the temp file
+exec > "$TMPLOG" 2>&1
+
 cleanup() {
-  echo "=== END RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  local rc=$?
+  local end_epoch
+  end_epoch="$(date +%s)"
+  local duration=$(( end_epoch - RUN_START_EPOCH ))
+  local logfile="$LOGS_DIR/${WORKSPACE_ID:-unknown}.log"
+
+  # Prepend header + atomically append buffered output
+  {
+    echo "=== RUN ${RUN_START_TS} duration=${duration}s exit=${rc} ==="
+    cat "$TMPLOG"
+  } >> "$logfile"
+
+  rm -f "$TMPLOG"
   rm -f "${LOCKFILE:-}"
 }
 trap cleanup EXIT


### PR DESCRIPTION
**@worker-02**

## Summary
- Replace delimiter-based logging (`=== RUN` / `=== END RUN`) with buffered atomic append via temp file
- Skip entries now write `=== SKIP ... ===` to agent log instead of `system.log`
- Remove stdout/stderr redirection from `manage.py` since `run.sh` handles logging internally

## Test plan
- [ ] Run an agent and verify output is buffered to temp file then atomically appended to `logs/<agent-id>.log`
- [ ] Verify header format: `=== RUN <timestamp> duration=<N>s exit=<code> ===`
- [ ] Trigger a skipped run (lock contention) and verify `=== SKIP ... ===` line appears in agent log
- [ ] Verify temp file is cleaned up after append
- [ ] Run `manage.py apply` and verify cron commands no longer include `>> logs/{id}.log 2>&1`

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
