### PR TITLE
Buffer run.sh output to temp file with atomic append

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -94,7 +94,7 @@ def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False, 
         cmd += f" --model '{model}'"
     for ctx in (contexts or []):
         cmd += f" --context {ctx}"
-    cmd += f' "{prompt}" >> {LOGS_DIR}/{job_id}.log 2>&1'
+    cmd += f' "{prompt}" > /dev/null 2>&1'
     return cmd
 
 

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -126,6 +126,8 @@ if [[ -n "$WORKSPACE_ID" ]]; then
       SYSTEM_LOG="$KERNEL_DIR/logs/system.log"
       mkdir -p "$(dirname "$SYSTEM_LOG")"
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $WORKSPACE_ID: skipped (pid $OLD_PID still running)" >> "$SYSTEM_LOG"
+      mkdir -p "$KERNEL_DIR/logs"
+      echo "=== SKIP $(date -u +%Y-%m-%dT%H:%M:%SZ) | reason=lock-contention pid=$OLD_PID ===" >> "$KERNEL_DIR/logs/${WORKSPACE_ID}.log"
       exit 0
     fi
   fi
@@ -134,11 +136,30 @@ if [[ -n "$WORKSPACE_ID" ]]; then
   echo $$ > "$LOCKFILE"
 fi
 
-# ── run boundary markers (used by logs/view.sh to group output) ──
-# Emit early so ALL output (including errors) is captured between delimiters.
-echo "=== RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+# ── buffered output with atomic append ───────────────────────
+# Buffer all output to a temp file, then atomically append header + content + footer
+# to the agent log on exit. This ensures no partial output appears in the log.
+TMPLOG=$(mktemp /tmp/forge-${WORKSPACE_ID:-$$}-$$.log)
+RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+RUN_START_SECS=$SECONDS
+exec > "$TMPLOG" 2>&1
+
 cleanup() {
-  echo "=== END RUN $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  local exit_code=$?
+  local end_ts
+  end_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local duration=$(( SECONDS - ${RUN_START_SECS:-0} ))
+
+  local LOG_FILE="$KERNEL_DIR/logs/${WORKSPACE_ID:-agent}.log"
+  mkdir -p "$(dirname "$LOG_FILE")"
+
+  {
+    echo "=== RUN ${RUN_START} | duration=${duration}s | exit=${exit_code} ==="
+    cat "$TMPLOG"
+    echo "=== END RUN ${end_ts} ==="
+  } >> "$LOG_FILE"
+
+  rm -f "$TMPLOG"
   rm -f "${LOCKFILE:-}"
 }
 trap cleanup EXIT

--- a/apps/web/src/app/api/agents/[id]/force-run/route.ts
+++ b/apps/web/src/app/api/agents/[id]/force-run/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
 import { spawn } from "child_process";
 import {
   cronJobsPath,
   runShPath,
   getForgeRoot,
-  agentLogPath,
 } from "@/lib/paths";
 
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
@@ -56,20 +54,12 @@ export async function POST(
   if (agent.repo) args.push("--repo", agent.repo);
   args.push(agent.prompt);
 
-  const logPath = agentLogPath(agent.id);
-  const logDir = path.dirname(logPath);
-  if (!fs.existsSync(logDir)) {
-    fs.mkdirSync(logDir, { recursive: true });
-  }
-  const logFd = fs.openSync(logPath, "a");
-
   const child = spawn("bash", [runShPath(), ...args], {
     cwd: getForgeRoot(),
     detached: true,
-    stdio: ["ignore", logFd, logFd],
+    stdio: ["ignore", "ignore", "ignore"],
   });
   child.unref();
-  fs.closeSync(logFd);
 
   return NextResponse.json({ status: "started" });
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- Buffer run.sh output to temp file instead of writing directly to log
- Cleanup trap atomically appends header + buffered content + footer to agent log
- Header now includes duration and exit code metadata
- Lock-contention skips write `=== SKIP ... ===` entries to agent log
- Removed stdout/stderr redirect from manage.py crontab commands
- Removed log file fd handling from force-run/route.ts

## Test plan
- [ ] Verify run.sh creates temp file and redirects output to it
- [ ] Verify cleanup trap atomically appends to agent log with correct format
- [ ] Verify lock-contention skip writes SKIP entry to agent log
- [ ] Verify crontab entries no longer have `>> .log 2>&1` redirect
- [ ] Verify force-run API spawns run.sh without passing log fd
- [ ] Verify temp file is cleaned up after run completes

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
