### PR TITLE
Fix web log parser regex to match actual buffered log format

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -29,7 +29,7 @@ export function LogsPanel() {
     (newBlocks: LogBlock[], mode: "all" | "single") => {
       if (newBlocks.length === 0) return;
       setBlocks((prev) => {
-        // Build a map preferring blocks that have endTimestamp set
+        // Build a map preferring blocks with more content
         const blockMap = new Map<string, LogBlock>();
         for (const b of prev) {
           blockMap.set(b.key, b);
@@ -40,7 +40,7 @@ export function LogsPanel() {
           if (!existing) {
             blockMap.set(b.key, b);
             changed = true;
-          } else if (existing.type !== "skip" && b.endTimestamp && !existing.endTimestamp) {
+          } else if (existing.type !== "skip" && b.content.length > existing.content.length) {
             blockMap.set(b.key, b);
             changed = true;
           }
@@ -50,15 +50,15 @@ export function LogsPanel() {
         if (mode === "all") {
           merged.sort(
             (a, b) =>
-              new Date(a.endTimestamp ?? a.timestamp).getTime() -
-              new Date(b.endTimestamp ?? b.timestamp).getTime()
+              new Date(a.timestamp).getTime() -
+              new Date(b.timestamp).getTime()
           );
           return merged.slice(-MAX_BLOCKS);
         } else {
           merged.sort(
             (a, b) =>
-              new Date(a.endTimestamp ?? a.timestamp).getTime() -
-              new Date(b.endTimestamp ?? b.timestamp).getTime()
+              new Date(a.timestamp).getTime() -
+              new Date(b.timestamp).getTime()
           );
           return merged.slice(-MAX_BLOCKS);
         }
@@ -379,9 +379,6 @@ function LogCard({
         )}
         <span className="text-sm text-muted-foreground">
           {block.displayTime}
-          {block.displayEndTime && (
-            <span className="text-muted-foreground/60"> → {block.displayEndTime}</span>
-          )}
         </span>
         {block.duration != null && (
           <span className="text-xs text-muted-foreground bg-surface-hover px-1.5 py-0.5 rounded">

--- a/apps/web/src/lib/log-parser.ts
+++ b/apps/web/src/lib/log-parser.ts
@@ -2,8 +2,6 @@ export interface LogBlock {
   agentId: string;
   timestamp: string;
   displayTime: string;
-  endTimestamp?: string;
-  displayEndTime?: string;
   duration?: number;
   exitCode?: number;
   content: string;
@@ -12,9 +10,8 @@ export interface LogBlock {
   skipReason?: string;
 }
 
-const RUN_MARKER = /^=== RUN (\S+) \| duration=(\d+)s \| exit=(\d+) ===$/;
-const END_MARKER = /^=== END RUN(?:\s+(\S+))? ===$/;
-const SKIP_MARKER = /^=== SKIP (\S+) \| reason=(.+) ===$/;
+const RUN_MARKER = /^=== RUN (\S+) duration=(\d+)s exit=(\d+) ===$/;
+const SKIP_MARKER = /^=== SKIP (\S+) reason=(.+) ===$/;
 
 function formatTime(isoTimestamp: string): string {
   try {
@@ -100,34 +97,8 @@ export function parseLogBlocks(
       currentDuration = parseInt(match[2], 10);
       currentExitCode = parseInt(match[3], 10);
       currentLines = [];
-    } else {
-      const endMatch = line.match(END_MARKER);
-      if (endMatch) {
-        if (currentTimestamp && currentLines.length > 0) {
-          const content = currentLines.join("\n").trim();
-          if (content) {
-            const endTs = endMatch[1] || undefined;
-            blocks.push({
-              agentId,
-              timestamp: currentTimestamp,
-              displayTime: formatTime(currentTimestamp),
-              endTimestamp: endTs,
-              displayEndTime: endTs ? formatTime(endTs) : undefined,
-              duration: currentDuration,
-              exitCode: currentExitCode,
-              content,
-              key: `${agentId}-${currentTimestamp}`,
-              type: "run",
-            });
-          }
-        }
-        currentTimestamp = null;
-        currentLines = [];
-        currentDuration = undefined;
-        currentExitCode = undefined;
-      } else if (currentTimestamp) {
-        currentLines.push(line);
-      }
+    } else if (currentTimestamp) {
+      currentLines.push(line);
     }
   }
 


### PR DESCRIPTION
**@worker-01**

## Summary
- Fix RUN_MARKER and SKIP_MARKER regexes to remove pipe separators, matching actual buffered log format
- Remove END_MARKER regex and all related handling (endTimestamp, displayEndTime fields)
- Simplify block merge deduplication to use content length comparison

## Test plan
- [ ] Verify RUN markers parse correctly: `=== RUN <ts> duration=<N>s exit=<code> ===`
- [ ] Verify SKIP markers parse correctly: `=== SKIP <ts> reason=<reason> ===`
- [ ] Verify duration and exit code badges display correctly in LogCard
- [ ] Verify skip cards render with reason text
- [ ] Verify block merge updates blocks when new content is longer

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
