### PR TITLE
Support Codex subscription auth (OAuth) as alternative to OPENAI_API_KEY

### DIFF
--- a/agent-kernel/.env.example
+++ b/agent-kernel/.env.example
@@ -18,7 +18,7 @@ INNIES_TOKEN=in_live_...
 # Claude CLI auth (from `claude setup-token`)
 # CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."
 #
-# Codex CLI auth
+# Codex CLI auth (API key — alternative to 'codex login' subscription auth)
 # OPENAI_API_KEY="sk-..."
 #
 # Optional: override claude binary path

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -206,12 +206,18 @@ fi
 
 # ── preflight: Codex auth (direct mode) ──────────────────────
 if [[ "$AGENT_RUNTIME" == "codex" ]] && [[ "${USE_INNIES:-false}" != "true" ]]; then
-  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
-    echo "[preflight] OPENAI_API_KEY is not set. Add it to agent-kernel/.env or export it." >&2
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    # API-key auth: pipe key to codex login
+    printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key 2>/dev/null || true
+  elif codex login status &>/dev/null; then
+    # Existing session tokens (ChatGPT subscription via ~/.codex/auth.json) — nothing to do
+    :
+  else
+    echo "[preflight] No Codex credentials found." >&2
+    echo "  Option 1: Set OPENAI_API_KEY in agent-kernel/.env (API key auth)" >&2
+    echo "  Option 2: Run 'codex login' first (ChatGPT subscription auth)" >&2
     exit 1
   fi
-  # Pipe key to codex login so the CLI has valid credentials for this session
-  printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key 2>/dev/null || true
 fi
 
 # ── preflight: Innies proxy connectivity ─────────────────────


### PR DESCRIPTION
**@worker-01**

## Summary
- Codex auth preflight in `run.sh` now supports both API key and OAuth (subscription) auth
- When `OPENAI_API_KEY` is set, uses it via `codex login --with-api-key` (existing behavior)
- When unset, checks `codex login status` for existing OAuth session tokens
- If neither method available, exits with clear error listing both options
- Updated `.env.example` comment to clarify API key is one of two auth methods

Closes #696

## Test plan
- [ ] Verify `OPENAI_API_KEY` set → `codex login --with-api-key` called (existing path)
- [ ] Verify `OPENAI_API_KEY` unset + valid `codex login` session → preflight passes
- [ ] Verify neither auth method → exit 1 with dual-option error message
- [ ] Verify `.env.example` comment updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
