### PR TITLE
Add branch field to agent API response

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -8,6 +8,7 @@ import {
   getForgeRoot,
   lockFilePath,
   templatePath,
+  worktreePath,
 } from "@/lib/paths";
 
 interface CronJob {
@@ -62,6 +63,23 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function getWorktreeBranch(agentId: string): string | null {
+  try {
+    const wtPath = worktreePath(agentId);
+    const dotGit = fs.readFileSync(path.join(wtPath, ".git"), "utf-8").trim();
+    // Format: "gitdir: /path/to/.git/worktrees/<name>"
+    const gitdir = dotGit.replace("gitdir: ", "");
+    const head = fs.readFileSync(path.join(gitdir, "HEAD"), "utf-8").trim();
+    // Format: "ref: refs/heads/<branch>"
+    if (head.startsWith("ref: refs/heads/")) {
+      return head.replace("ref: refs/heads/", "");
+    }
+    return null; // detached HEAD
+  } catch {
+    return null;
+  }
+}
+
 function inferRole(id: string): string {
   const match = id.match(/^([a-zA-Z]+)-\d+$/);
   return match?.[1] ?? "worker";
@@ -100,6 +118,7 @@ function buildAgentFromJob(
   return {
     id: job.id,
     role: inferRole(job.id),
+    branch: getWorktreeBranch(job.id),
     interval: job.interval,
     intervalSeconds,
     enabled: job.enabled !== false,

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -19,6 +19,10 @@ export function cronStatePath(): string {
   return path.join(getForgeRoot(), "agent-kernel/cron/cron-state.json");
 }
 
+export function worktreePath(agentId: string): string {
+  return path.join(getForgeRoot(), `.worktrees/${agentId}`);
+}
+
 export function lockFilePath(agentId: string): string {
   return path.join(getForgeRoot(), `.worktrees/${agentId}/.agent.lock`);
 }


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `worktreePath()` helper to `apps/web/src/lib/paths.ts`
- Add `getWorktreeBranch()` function that reads branch from worktree `.git` file → gitdir → HEAD
- Include `branch` field (string | null) in `buildAgentFromJob` return value

## Test plan
- [ ] Verify `GET /api/agents` returns `branch` field for each agent
- [ ] Confirm branch is a valid string for agents with active worktrees
- [ ] Confirm branch is `null` for agents without worktrees or with detached HEAD

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
