### PR TITLE
Show branch and label timing values in agent cards

### DIFF
--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -19,6 +19,7 @@ interface Agent {
   agentic: boolean;
   workspace: boolean;
   repo: string;
+  branch: string | null;
   status: AgentStatus;
   stagedInterval?: string;
 }
@@ -186,7 +187,14 @@ function AgentCard({
         </button>
       </div>
 
-      <div className="flex items-center gap-3 text-sm text-text ml-4 mb-2">
+      {agent.branch && (
+        <div className="text-sm text-muted-foreground ml-4 mb-1 truncate" title={agent.branch}>
+          {agent.branch}
+        </div>
+      )}
+
+      <div className="flex items-center gap-1.5 text-sm text-text ml-4 mb-2">
+        <span className="text-muted-foreground">every</span>
         <span title="Interval">{agent.interval}</span>
         {agent.status === "modified" && agent.stagedInterval && (
           <span className="text-accent-yellow" title="Pending interval change">
@@ -194,14 +202,22 @@ function AgentCard({
           </span>
         )}
         {agent.lastRun && (
-          <span title={`Last run: ${agent.lastRun}`}>
-            {relativeTime(agent.lastRun)}
-          </span>
+          <>
+            <span className="text-muted-foreground">·</span>
+            <span className="text-muted-foreground">ran</span>
+            <span title={`Last run: ${agent.lastRun}`}>
+              {relativeTime(agent.lastRun)}
+            </span>
+          </>
         )}
         {agent.nextRun && (
-          <span className="text-accent-cyan" title={`Next run: ${agent.nextRun}`}>
-            {countdown(agent.nextRun)}
-          </span>
+          <>
+            <span className="text-muted-foreground">·</span>
+            <span className="text-muted-foreground">next</span>
+            <span className="text-accent-cyan" title={`Next run: ${agent.nextRun}`}>
+              {countdown(agent.nextRun)}
+            </span>
+          </>
         )}
       </div>
 


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `branch: string | null` to the Agent interface
- Display agent branch (when available) between header row and timing row, with truncation and tooltip
- Label timing values with "every", "ran", "next" prefixes and `·` separators for readability

Closes #701
Parent: #699

## Test plan
- [ ] Verify agent cards render branch name when `branch` field is present
- [ ] Verify branch row is hidden when `branch` is null
- [ ] Verify timing row shows labeled format: "every 2m · ran 3m ago · next 1m30s"
- [ ] Verify tooltips still work on timing values
- [ ] Verify truncation on long branch names
- [ ] Verify no layout breakage on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
