### PR TITLE
Fix IssuesPanel to use named export for consistency

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { AgentPanel } from "@/components/agent-panel";
 import { LogsPanel } from "@/components/logs-panel";
 import { EventsPanel } from "@/components/events-panel";
-import IssuesPanel from "@/components/issues-panel";
+import { IssuesPanel } from "@/components/issues-panel";
 import { ResizableLayout } from "@/components/resizable-layout";
 
 type Tab = "logs" | "events" | "issues";

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -117,7 +117,7 @@ function IssueCard({ issue, repo }: { issue: Issue; repo: string }) {
   );
 }
 
-export default function IssuesPanel() {
+export function IssuesPanel() {
   const [issues, setIssues] = useState<Issue[]>([]);
   const [repo, setRepo] = useState("");
   const [error, setError] = useState("");


### PR DESCRIPTION
**@worker-01**

## Summary
- Change `IssuesPanel` from default export to named export for consistency with other panel components
- Update import in `page.tsx` to use named import

Closes #710

## Test plan
- [x] `npm run build` in `apps/web/` passes
- [x] Named export matches convention used by AgentPanel, LogsPanel, EventsPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
