### PR TITLE
Multi-arg support and --apply flag for forge add/rm

### DIFF
--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -1,13 +1,14 @@
-"""forge add / forge remove — template-based agent management."""
+"""forge add / forge rm — template-based agent management."""
 
 import json
 import os
 import re
 import sys
+from types import SimpleNamespace
 
 import click
 
-from forge_cli.paths import cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
+from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
 
 
 def _templates_dir():
@@ -42,14 +43,15 @@ def _next_id(agent_type, existing_ids):
 
 
 @click.command()
-@click.argument("agent_type", required=False, default=None)
+@click.argument("agent_types", nargs=-1)
 @click.option("--id", "agent_id", default=None, help="Custom agent ID (default: auto-generate).")
 @click.option("--interval", default=None, help="Override template interval (e.g. 5m, 1h).")
 @click.option("--list", "list_templates", is_flag=True, help="List available templates.")
-def add(agent_type, agent_id, interval, list_templates):
-    """Add an agent from a template.
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after adding.")
+def add(agent_types, agent_id, interval, list_templates, apply_flag):
+    """Add agents from templates.
 
-    AGENT_TYPE is the template name (e.g. worker, planner).
+    AGENT_TYPES is one or more template names (e.g. worker, planner).
     """
     if list_templates:
         templates = _available_templates()
@@ -61,79 +63,105 @@ def add(agent_type, agent_id, interval, list_templates):
             click.echo(f"  {name}")
         return
 
-    if not agent_type:
+    if not agent_types:
         click.echo("Error: AGENT_TYPE is required (e.g. forge add worker).", err=True)
         click.echo("Use --list to see available templates.", err=True)
         sys.exit(1)
 
-    templates = _available_templates()
-    if agent_type not in templates:
-        click.echo(f"Error: no template '{agent_type}' found.", err=True)
-        click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+    if agent_id is not None and len(agent_types) > 1:
+        click.echo("Error: --id cannot be used with multiple agent types.", err=True)
         sys.exit(1)
 
-    with open(templates[agent_type]) as f:
-        template = json.load(f)
+    templates = _available_templates()
+    for agent_type in agent_types:
+        if agent_type not in templates:
+            click.echo(f"Error: no template '{agent_type}' found.", err=True)
+            click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+            sys.exit(1)
 
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
     existing_ids = [j["id"] for j in cron_data.get("jobs", [])]
 
-    if agent_id is None:
-        agent_id = _next_id(agent_type, existing_ids)
+    for agent_type in agent_types:
+        with open(templates[agent_type]) as f:
+            template = json.load(f)
 
-    if agent_id in existing_ids:
-        click.echo(f"Error: agent '{agent_id}' already exists.", err=True)
-        sys.exit(1)
+        if agent_id is not None:
+            aid = agent_id
+        else:
+            aid = _next_id(agent_type, existing_ids)
 
-    job = {"id": agent_id}
-    job["interval"] = interval if interval else template["interval"]
-    job["prompt"] = template["prompt"]
-    job["contexts"] = template.get("contexts", [])
-    job["agentic"] = template.get("agentic", False)
-    job["workspace"] = template.get("workspace", False)
+        if aid in existing_ids:
+            click.echo(f"Error: agent '{aid}' already exists.", err=True)
+            sys.exit(1)
 
-    cron_data.setdefault("jobs", []).append(job)
+        job = {"id": aid}
+        job["interval"] = interval if interval else template["interval"]
+        job["prompt"] = template["prompt"]
+        job["contexts"] = template.get("contexts", [])
+        job["agentic"] = template.get("agentic", False)
+        job["workspace"] = template.get("workspace", False)
+
+        cron_data.setdefault("jobs", []).append(job)
+        existing_ids.append(aid)
+
+        click.echo(click.style(
+            f"Staged {aid} (template: {agent_type}, interval: {job['interval']})",
+            fg="green",
+        ))
+        prompt_display = job["prompt"]
+        if len(prompt_display) > 60:
+            prompt_display = prompt_display[:57] + "..."
+        click.echo(f"  prompt:    \"{prompt_display}\"")
+        if job["contexts"]:
+            click.echo(f"  contexts:  {', '.join(job['contexts'])}")
+        click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
+        click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+
     save_cron_jobs(cron_path, cron_data)
 
-    click.echo(click.style(
-        f"Staged {agent_id} (template: {agent_type}, interval: {job['interval']})",
-        fg="green",
-    ))
-    prompt_display = job["prompt"]
-    if len(prompt_display) > 60:
-        prompt_display = prompt_display[:57] + "..."
-    click.echo(f"  prompt:    \"{prompt_display}\"")
-    if job["contexts"]:
-        click.echo(f"  contexts:  {', '.join(job['contexts'])}")
-    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
-    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
-    click.echo()
-    click.echo("Run `forge apply` to activate.")
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to activate.")
 
 
 @click.command()
-@click.argument("agent_id")
-def remove(agent_id):
-    """Remove an agent by ID."""
+@click.argument("agent_ids", nargs=-1, required=True)
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after removing.")
+def rm(agent_ids, apply_flag):
+    """Remove agents by ID."""
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
 
     jobs = cron_data.get("jobs", [])
-    removed = [j for j in jobs if j["id"] == agent_id]
-    new_jobs = [j for j in jobs if j["id"] != agent_id]
+    known_ids = {j["id"] for j in jobs}
 
-    if len(new_jobs) == len(jobs):
-        click.echo(f"Error: no agent '{agent_id}' found.", err=True)
+    missing = [aid for aid in agent_ids if aid not in known_ids]
+    if missing:
+        click.echo(f"Error: agents not found: {', '.join(missing)}", err=True)
         sys.exit(1)
 
-    cron_data["jobs"] = new_jobs
+    ids_to_remove = set(agent_ids)
+    removed = [j for j in jobs if j["id"] in ids_to_remove]
+    cron_data["jobs"] = [j for j in jobs if j["id"] not in ids_to_remove]
     save_cron_jobs(cron_path, cron_data)
 
-    interval = removed[0].get("interval", "?") if removed else "?"
-    click.echo(click.style(
-        f"Unstaged {agent_id} (was: interval {interval})",
-        fg="red",
-    ))
-    click.echo()
-    click.echo("Run `forge apply` to deactivate.")
+    for j in removed:
+        interval = j.get("interval", "?")
+        click.echo(click.style(
+            f"Unstaged {j['id']} (was: interval {interval})",
+            fg="red",
+        ))
+
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to deactivate.")

--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from forge_cli.agents import add, remove
+from forge_cli.agents import add, rm
 from forge_cli.apply_cmd import apply_cmd
 from forge_cli.clear_cmd import clear_cmd
 from forge_cli.list_cmd import list_cmd
@@ -20,7 +20,7 @@ main.add_command(apply_cmd, name="apply")
 main.add_command(clear_cmd, name="clear")
 main.add_command(list_cmd, name="list")
 main.add_command(logs)
-main.add_command(remove)
+main.add_command(rm)
 main.add_command(run_cmd, name="run")
 main.add_command(list_cmd, name="status")
 main.add_command(ui)


### PR DESCRIPTION
**@worker-03**

## Summary
- `forge add` now accepts multiple agent types (`forge add worker worker planner`)
- `forge remove` renamed to `forge rm` with multi-arg support
- Both commands gain `--apply` flag for immediate deployment
- `--id` errors when used with multiple types
- `forge rm` validates all IDs exist before removing any

## Test plan
- [ ] `forge add worker worker planner` adds 3 agents with correct auto-incremented IDs
- [ ] `forge add worker --apply` adds and deploys
- [ ] `forge add worker worker --id custom` errors
- [ ] `forge rm worker-01 worker-02` removes both
- [ ] `forge rm worker-01 --apply` removes and deploys
- [ ] `forge rm nonexistent` shows clear error
- [ ] `forge remove` no longer works (renamed to `rm`)

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)
