### PR TITLE
Add diff/reset API endpoints and update status terminology

### DIFF
--- a/apps/web/src/app/api/agents/diff/route.ts
+++ b/apps/web/src/app/api/agents/diff/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import { cronJobsPath, cronStatePath } from "@/lib/paths";
+
+interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+  repo?: string;
+  runtime?: string;
+  model?: string;
+}
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      prompt?: string;
+      contexts?: string[];
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
+    }
+  >;
+}
+
+type DiffStatus = "new" | "modified" | "deleted";
+
+interface FieldChange {
+  from: unknown;
+  to: unknown;
+}
+
+interface AgentDiff {
+  id: string;
+  status: DiffStatus;
+  fields?: Record<string, unknown>;
+  changes?: Record<string, FieldChange>;
+}
+
+const COMPARE_FIELDS = [
+  "interval",
+  "prompt",
+  "contexts",
+  "agentic",
+  "workspace",
+  "repo",
+  "runtime",
+  "model",
+] as const;
+
+function fieldsEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export async function GET() {
+  try {
+    let jobs: CronJob[] = [];
+    try {
+      const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+      jobs = JSON.parse(raw).jobs ?? [];
+    } catch {
+      // no config file
+    }
+
+    let state: CronState = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch {
+      // no state file
+    }
+
+    const stagedIds = new Set(jobs.map((j) => j.id));
+    const activeIds = new Set(Object.keys(state.jobs ?? {}));
+    const agents: AgentDiff[] = [];
+
+    // New agents: in staged but not in applied state
+    for (const job of jobs) {
+      if (!activeIds.has(job.id)) {
+        const fields: Record<string, unknown> = {};
+        for (const field of COMPARE_FIELDS) {
+          if (job[field] !== undefined) {
+            fields[field] = job[field];
+          }
+        }
+        agents.push({ id: job.id, status: "new", fields });
+        continue;
+      }
+
+      // Modified agents: in both but with different fields
+      const applied = state.jobs[job.id];
+      const changes: Record<string, FieldChange> = {};
+      for (const field of COMPARE_FIELDS) {
+        const stagedVal = job[field];
+        const appliedVal = applied[field];
+        if (!fieldsEqual(stagedVal, appliedVal)) {
+          changes[field] = { from: appliedVal, to: stagedVal };
+        }
+      }
+      if (Object.keys(changes).length > 0) {
+        agents.push({ id: job.id, status: "modified", changes });
+      }
+    }
+
+    // Deleted agents: in applied state but not in staged config
+    for (const id of activeIds) {
+      if (!stagedIds.has(id)) {
+        agents.push({ id, status: "deleted" });
+      }
+    }
+
+    return NextResponse.json({
+      hasDiff: agents.length > 0,
+      agents,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/reset/route.ts
+++ b/apps/web/src/app/api/agents/reset/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import { atomicWriteJsonSync, cronJobsPath, cronStatePath } from "@/lib/paths";
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      prompt?: string;
+      contexts?: string[];
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
+    }
+  >;
+}
+
+interface CronJobsConfig {
+  stagger?: boolean;
+  jobs: Array<{
+    id: string;
+    interval: string;
+    prompt: string;
+    contexts: string[];
+    agentic: boolean;
+    workspace: boolean;
+    repo?: string;
+    runtime?: string;
+    model?: string;
+  }>;
+}
+
+export async function POST() {
+  try {
+    let state: CronState = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch {
+      return NextResponse.json(
+        { error: "No applied state found" },
+        { status: 400 }
+      );
+    }
+
+    // Read current config to preserve stagger setting
+    let stagger = true;
+    let currentJobs: CronJobsConfig["jobs"] = [];
+    try {
+      const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+      const data = JSON.parse(raw);
+      stagger = data.stagger ?? true;
+      currentJobs = data.jobs ?? [];
+    } catch {
+      // fresh config
+    }
+
+    const activeIds = new Set(Object.keys(state.jobs ?? {}));
+    const currentIds = new Set(currentJobs.map((j) => j.id));
+
+    // Rebuild jobs array from applied state
+    const jobs: CronJobsConfig["jobs"] = [];
+    for (const [id, entry] of Object.entries(state.jobs ?? {})) {
+      // Find the existing job to use as base for fields not in state
+      const existingJob = currentJobs.find((j) => j.id === id);
+
+      jobs.push({
+        id,
+        interval: entry.interval ?? existingJob?.interval ?? "2m",
+        prompt: entry.prompt ?? existingJob?.prompt ?? "",
+        contexts: entry.contexts ?? existingJob?.contexts ?? [],
+        agentic: entry.agentic ?? existingJob?.agentic ?? true,
+        workspace: entry.workspace ?? existingJob?.workspace ?? true,
+        ...(entry.repo !== undefined ? { repo: entry.repo } : existingJob?.repo !== undefined ? { repo: existingJob.repo } : {}),
+        ...(entry.runtime !== undefined ? { runtime: entry.runtime } : existingJob?.runtime !== undefined ? { runtime: existingJob.runtime } : {}),
+        ...(entry.model !== undefined ? { model: entry.model } : existingJob?.model !== undefined ? { model: existingJob.model } : {}),
+      });
+    }
+
+    atomicWriteJsonSync(cronJobsPath(), { stagger, jobs });
+
+    // Compute what changed
+    const restored = [...activeIds].filter((id) => !currentIds.has(id));
+    const removed = [...currentIds].filter((id) => !activeIds.has(id));
+
+    return NextResponse.json({ success: true, restored, removed });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -70,7 +70,7 @@ function inferRole(id: string): string {
 function buildAgentFromJob(
   job: CronJob,
   jobState: CronState["jobs"][string] | undefined,
-  status: "staged" | "active" | "modified" | "orphan",
+  status: "new" | "active" | "modified" | "deleted",
   stagedInterval?: string
 ) {
   const intervalSeconds = parseIntervalSeconds(job.interval);
@@ -145,7 +145,7 @@ export async function GET() {
     const inState = activeIds.has(job.id);
 
     if (!hasState || !inState) {
-      return buildAgentFromJob(job, undefined, "staged");
+      return buildAgentFromJob(job, undefined, "new");
     }
 
     const activeInterval = jobState?.interval;
@@ -171,7 +171,7 @@ export async function GET() {
         agentic: false,
         workspace: false,
       };
-      agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
+      agents.push(buildAgentFromJob(orphanJob, jobState, "deleted"));
     }
   }
 

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-type AgentStatus = "staged" | "active" | "modified" | "orphan";
+type AgentStatus = "new" | "active" | "modified" | "deleted";
 
 interface Agent {
   id: string;
@@ -90,10 +90,10 @@ function RoleBadge({ role }: { role: string }) {
 }
 
 const statusBadgeConfig: Record<AgentStatus, { label: string; bg: string }> = {
-  staged: { label: "STAGED", bg: "bg-accent-yellow" },
+  new: { label: "NEW", bg: "bg-accent-yellow" },
   active: { label: "ACTIVE", bg: "bg-accent-green" },
   modified: { label: "MODIFIED", bg: "bg-accent-yellow" },
-  orphan: { label: "ORPHAN", bg: "bg-accent-red" },
+  deleted: { label: "DELETED", bg: "bg-accent-red" },
 };
 
 function StatusBadge({ status, agent }: { status: AgentStatus; agent: Agent }) {
@@ -162,7 +162,7 @@ function AgentCard({
   };
 
   const isStarted = feedback === "Started";
-  const isStaged = agent.status === "staged";
+  const isStaged = agent.status === "new";
 
   return (
     <div className="rounded-md bg-surface p-2 border border-border hover:bg-surface-hover transition-colors">
@@ -228,8 +228,8 @@ function AgentCard({
 const statusOrder: Record<AgentStatus, number> = {
   active: 0,
   modified: 1,
-  staged: 2,
-  orphan: 3,
+  new: 2,
+  deleted: 3,
 };
 
 function sortAgentsByStatus(agents: Agent[]): Agent[] {
@@ -529,12 +529,30 @@ export function AgentPanel() {
     }
   };
 
-  const stagedCount = agents.filter(
-    (a) => a.status === "staged" || a.status === "modified"
+  const handleReset = async () => {
+    try {
+      const res = await fetch("/api/agents/reset", { method: "POST" });
+      const data = await res.json();
+      if (data.success) {
+        const parts: string[] = [];
+        if (data.restored?.length) parts.push(`restored ${data.restored.length}`);
+        if (data.removed?.length) parts.push(`removed ${data.removed.length}`);
+        showFeedback(parts.length > 0 ? `Reset: ${parts.join(", ")}` : "Reset (no changes)");
+      } else {
+        showFeedback(`Reset failed: ${data.error ?? "unknown"}`);
+      }
+      fetchAgents();
+    } catch {
+      showFeedback("Reset failed");
+    }
+  };
+
+  const newCount = agents.filter(
+    (a) => a.status === "new" || a.status === "modified"
   ).length;
-  const orphanCount = agents.filter((a) => a.status === "orphan").length;
-  const hasPendingChanges = stagedCount > 0 || orphanCount > 0;
-  const hasStagedAgents = agents.filter((a) => a.status !== "orphan").length > 0;
+  const deletedCount = agents.filter((a) => a.status === "deleted").length;
+  const hasPendingChanges = newCount > 0 || deletedCount > 0;
+  const hasStagedAgents = agents.filter((a) => a.status !== "deleted").length > 0;
 
   return (
     <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
@@ -576,6 +594,18 @@ export function AgentPanel() {
           }
         >
           {clearConfirming ? "Confirm?" : "Clear"}
+        </button>
+        <button
+          className={`text-xs rounded px-2 py-1 border transition-colors ${
+            hasPendingChanges
+              ? "border-accent-yellow text-accent-yellow hover:bg-accent-yellow/20"
+              : "border-border text-muted-foreground cursor-not-allowed opacity-50"
+          }`}
+          onClick={hasPendingChanges ? handleReset : undefined}
+          disabled={!hasPendingChanges}
+          title={hasPendingChanges ? "Reset config to match applied state" : "No pending changes to reset"}
+        >
+          Reset
         </button>
         {actionFeedback && (
           <span className="text-xs text-accent-cyan ml-auto">{actionFeedback}</span>


### PR DESCRIPTION
**@worker-02**

## Summary
- Add `GET /api/agents/diff` endpoint that compares staged config (`cron-jobs.json`) against applied state (`cron-state.json`), returning new/modified/deleted agents with field-level changes
- Add `POST /api/agents/reset` endpoint that reverts `cron-jobs.json` to match `cron-state.json`, preserving the `stagger` setting
- Update status terminology: `"staged"` → `"new"`, `"orphan"` → `"deleted"` across API route and UI component
- Add Reset button to agent panel toolbar (yellow-themed, disabled when no pending changes)

## Test plan
- [ ] Verify `GET /api/agents/diff` returns correct diff when agents are added, modified, or removed from config
- [ ] Verify `POST /api/agents/reset` restores config to match applied state
- [ ] Verify Reset button is disabled when no pending changes exist
- [ ] Verify Reset button is enabled and functional when there are pending changes
- [ ] Verify status badges show "NEW" and "DELETED" instead of "STAGED" and "ORPHAN"
- [ ] Verify Apply button still works correctly with new terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)
