### PR TITLE
Simplify forge clear to config-only operation

### DIFF
--- a/apps/forge-cli/src/forge_cli/clear_cmd.py
+++ b/apps/forge-cli/src/forge_cli/clear_cmd.py
@@ -1,25 +1,14 @@
-"""forge clear — remove active cron entries or staged config."""
-
-from types import SimpleNamespace
+"""Clear staged config (wipe all agents from cron-jobs.json)."""
 
 import click
 
-from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, save_cron_jobs
+from forge_cli.paths import cron_jobs_path, load_cron_jobs, save_cron_jobs
 
 
 @click.command("clear")
-@click.option("--staged", is_flag=True, help="Clear only staged config (cron-jobs.json).")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
-def clear_cmd(staged, yes):
-    """Remove active cron entries, or staged config with --staged."""
-    if staged:
-        _clear_staged(yes)
-    else:
-        _clear_active(yes)
-
-
-def _clear_staged(yes):
-    """Clear staged config (cron-jobs.json)."""
+def clear_cmd(yes):
+    """Clear staged config (wipe all agents from cron-jobs.json)."""
     path = cron_jobs_path()
     data = load_cron_jobs(path)
     jobs = data.get("jobs", [])
@@ -39,14 +28,4 @@ def _clear_staged(yes):
     data["jobs"] = []
     save_cron_jobs(path, data)
 
-    click.echo(f"Cleared {count} staged agent{'s' if count != 1 else ''} from config.")
-    click.echo("Run `forge apply` to deactivate them.")
-
-
-def _clear_active(yes):
-    """Clear active crontab entries and cron-state.json."""
-    if not yes:
-        click.confirm("Remove all active cron entries and state?", abort=True)
-
-    m = _get_manage()
-    m.cmd_clear(SimpleNamespace())
+    click.echo(f"Cleared {count} agent{'s' if count != 1 else ''} from config. Run 'forge apply' to tear down.")


### PR DESCRIPTION
**@worker-03**

## Summary
- Simplify `forge clear` to only clear `cron-jobs.json` jobs array (config-only operation)
- Remove `--staged` flag (now the default and only behavior)
- Remove `_clear_active()` function and `_get_manage`/`SimpleNamespace` imports
- Output message now tells user to run `forge apply` to tear down

## Test plan
- [ ] Run `forge clear` — verify it clears `cron-jobs.json` jobs array
- [ ] Run `forge clear -y` — verify confirmation is skipped
- [ ] Run `forge clear` with empty config — verify "Nothing to clear" message
- [ ] Verify `--staged` flag no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
