### PR TITLE
Add manual refresh button to dashboard tab bar

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -119,3 +119,12 @@
     @apply font-mono;
   }
 }
+
+@keyframes spin-once {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.animate-spin-once {
+  animation: spin-once 0.5s ease-in-out;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { AgentPanel } from "@/components/agent-panel";
 import { LogsPanel } from "@/components/logs-panel";
 import { EventsPanel } from "@/components/events-panel";
@@ -40,7 +40,42 @@ function TabButton({
   );
 }
 
-function RightPanel() {
+function RefreshButton({ onClick }: { onClick: () => void }) {
+  const [spinning, setSpinning] = useState(false);
+
+  const handleClick = () => {
+    setSpinning(true);
+    onClick();
+    setTimeout(() => setSpinning(false), 500);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="text-muted-foreground hover:text-text-bright transition-colors p-1"
+      title="Refresh all panels"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={spinning ? "animate-spin-once" : ""}
+      >
+        <path d="M14 2v4h-4" />
+        <path d="M2 14v-4h4" />
+        <path d="M13.5 6A6 6 0 0 0 3.8 3.8L2 6" />
+        <path d="M2.5 10a6 6 0 0 0 9.7 2.2L14 10" />
+      </svg>
+    </button>
+  );
+}
+
+function RightPanel({ refreshKey, onRefresh }: { refreshKey: number; onRefresh: () => void }) {
   const [activeTab, setActiveTab] = useState<Tab>(getInitialTab);
 
   const switchTab = (tab: Tab) => {
@@ -67,21 +102,33 @@ function RightPanel() {
           active={activeTab === "issues"}
           onClick={() => switchTab("issues")}
         />
+        <div className="ml-auto">
+          <RefreshButton onClick={onRefresh} />
+        </div>
       </div>
 
       {/* Active panel */}
       <div className="flex-1 overflow-hidden min-h-0">
-        {activeTab === "logs" ? <LogsPanel /> : activeTab === "events" ? <EventsPanel /> : <IssuesPanel />}
+        {activeTab === "logs" ? (
+          <LogsPanel refreshKey={refreshKey} />
+        ) : activeTab === "events" ? (
+          <EventsPanel refreshKey={refreshKey} />
+        ) : (
+          <IssuesPanel />
+        )}
       </div>
     </div>
   );
 }
 
 export default function Home() {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const handleRefresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
   return (
     <ResizableLayout
-      sidebar={<AgentPanel />}
-      rightPanel={<RightPanel />}
+      sidebar={<AgentPanel refreshKey={refreshKey} />}
+      rightPanel={<RightPanel refreshKey={refreshKey} onRefresh={handleRefresh} />}
     />
   );
 }

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -456,7 +456,7 @@ function AddAgentModal({
   );
 }
 
-export function AgentPanel() {
+export function AgentPanel({ refreshKey }: { refreshKey?: number }) {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
@@ -491,6 +491,13 @@ export function AgentPanel() {
       if (clearTimeoutRef.current) clearTimeout(clearTimeoutRef.current);
     };
   }, [fetchAgents]);
+
+  // Manual refresh via refreshKey
+  useEffect(() => {
+    if (refreshKey && refreshKey > 0) {
+      fetchAgents();
+    }
+  }, [refreshKey, fetchAgents]);
 
   const showFeedback = (msg: string) => {
     setActionFeedback(msg);

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -88,7 +88,7 @@ function EventCard({ event }: { event: NormalizedEvent }) {
   );
 }
 
-export function EventsPanel() {
+export function EventsPanel({ refreshKey }: { refreshKey?: number }) {
   const [events, setEvents] = useState<NormalizedEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -124,6 +124,13 @@ export function EventsPanel() {
       clearInterval(id);
     };
   }, [fetchEvents]);
+
+  // Manual refresh via refreshKey
+  useEffect(() => {
+    if (refreshKey && refreshKey > 0) {
+      fetchEvents();
+    }
+  }, [refreshKey, fetchEvents]);
 
   const handleScroll = useCallback(() => {
     const el = containerRef.current;

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -41,7 +41,7 @@ const ROLE_COLORS: Record<string, string> = {
   super: "var(--accent-yellow)",
 };
 
-export function LogsPanel() {
+export function LogsPanel({ refreshKey }: { refreshKey?: number }) {
   const [blocks, setBlocks] = useState<LogBlock[]>([]);
   const [agents, setAgents] = useState<string[]>([]);
   const [filter, setFilter] = useState("");
@@ -264,6 +264,13 @@ export function LogsPanel() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mergeBlocks, startFallbackPolling, stopFallbackPolling]);
+
+  // Manual refresh via refreshKey
+  useEffect(() => {
+    if (refreshKey && refreshKey > 0) {
+      fetchInitialLogs();
+    }
+  }, [refreshKey, fetchInitialLogs]);
 
   // Auto-scroll detection
   const handleScroll = useCallback(() => {


### PR DESCRIPTION
**@worker-02**

## Summary
- Add a manual refresh button (circular arrow icon) to the dashboard tab bar, right-aligned
- Clicking it force-refreshes all panel data (agents, events, logs) via a `refreshKey` prop pattern
- Button shows a 0.5s spin animation on click for visual feedback
- Existing auto-refresh/SSE behavior is unchanged

## Test plan
- [ ] Verify refresh button is visible in the tab bar, right-aligned
- [ ] Click the button and confirm agents, events, and logs reload immediately
- [ ] Verify the button spins briefly on click
- [ ] Confirm auto-refresh polling and SSE continue working as before

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
