### PR TITLE
Dashboard: unify sidebar and right-panel scrollbar styling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -119,3 +119,28 @@
     @apply font-mono;
   }
 }
+
+@layer utilities {
+  .dashboard-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border: 2px solid var(--surface);
+    border-radius: 9999px;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: var(--muted-foreground);
+  }
+}

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -543,7 +543,7 @@ export function AgentPanel() {
   const hasStagedAgents = agents.filter((a) => a.status !== "orphan").length > 0;
 
   return (
-    <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
+    <div className="dashboard-scrollbar h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
       <div className="flex items-center gap-2 py-2">
         <button
           className="text-xs rounded px-2 py-1 border border-border text-text hover:bg-surface-hover transition-colors"

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -154,7 +154,7 @@ export function EventsPanel() {
         <div
           ref={containerRef}
           onScroll={handleScroll}
-          className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
+          className="dashboard-scrollbar flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
         >
           {events.map((event, i) => (
             <EventCard key={`${event.timestamp}-${i}`} event={event} />

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -275,7 +275,7 @@ export function IssuesPanel() {
       )}
 
       {/* Issue list */}
-      <div className="flex-1 overflow-y-auto px-3 pb-3">
+      <div className="dashboard-scrollbar flex-1 overflow-y-auto px-3 pb-3">
         {filtered.length === 0 && !error ? (
           <p className="text-muted-foreground text-sm pt-3">No issues found.</p>
         ) : (

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -391,7 +391,7 @@ export function LogsPanel() {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-2"
+        className="dashboard-scrollbar flex-1 overflow-y-auto p-4 space-y-2"
       >
         {displayBlocks.length === 0 ? (
           <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
**@worker-03**

## Summary
- add a shared `dashboard-scrollbar` utility in `apps/web/src/app/globals.css`
- apply that shared scrollbar treatment to the main agent, logs, events, and issues scroll regions
- leave panel layout, filtering, polling, and card styling unchanged

## Validation
- `npm run lint` in `apps/web` (fails on pre-existing issues in `src/components/issues-panel.tsx`, `src/components/resizable-layout.tsx`, and one warning in `src/components/agent-panel.tsx`)
