### PR TITLE
Extract shared assigned issue context

### DIFF
--- a/agent-kernel/cron/cron-jobs.json
+++ b/agent-kernel/cron/cron-jobs.json
@@ -5,7 +5,7 @@
       "id": "planner-01",
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -14,7 +14,7 @@
       "id": "worker-01",
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -23,7 +23,7 @@
       "id": "worker-02",
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -32,7 +32,7 @@
       "id": "planner-02",
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -41,7 +41,7 @@
       "id": "worker-03",
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -50,7 +50,7 @@
       "id": "planner-03",
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -59,7 +59,7 @@
       "id": "worker-04",
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
@@ -68,7 +68,7 @@
       "id": "planner-04",
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+      "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
       "agentic": true,
       "workspace": true,
       "repo": "github.com/alexjaniak/Forge"

--- a/contexts/ASSIGNED_ISSUE.md
+++ b/contexts/ASSIGNED_ISSUE.md
@@ -1,0 +1,11 @@
+# Assigned Issue
+
+If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
+Work on this issue directly instead of searching for a new one.
+
+1. Read the issue: `gh issue view <N> --comments`
+2. Verify the issue is valid: not closed, still labeled for your role, and not already claimed by another agent.
+3. If the issue is valid, pick it up using your normal role-specific workflow.
+4. If the issue is not valid, do not pick up different work. Stop or continue with any role-specific non-claiming duties.
+
+If `ASSIGNED_ISSUE` is not present, follow your normal role-specific intake behavior.

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -2,18 +2,6 @@
 
 You are a planner agent. You own the full scope of the instructions you've been given. Your job is to understand the current state of the project and create specific, targeted tasks that progress toward the goal.
 
-## Pre-assigned issues
-
-If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
-Work on this issue directly — do not search for other issues to pick up.
-
-1. Read the issue: `gh issue view <N> --comments`
-2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:planner`.
-3. Announce pickup and relabel as normal.
-4. Proceed with planning/review.
-
-If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Proceed with reviews, sweeps, and @ADMIN processing only.
-
 ## Role
 
 - Assess current project state before planning (read code, check open issues/PRs, read existing comments for context).

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -2,18 +2,6 @@
 
 You are a super agent. You are the final quality gate before epic PRs reach the human admin for merge to `main`. You see the entire project — not just one epic, but all of them simultaneously.
 
-## Pre-assigned issues
-
-If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
-Work on this issue directly — do not search for other issues to pick up.
-
-1. Read the issue: `gh issue view <N> --comments`
-2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:super`.
-3. Announce pickup and relabel as normal.
-4. Proceed with review.
-
-If `ASSIGNED_ISSUE` is not present, do **not** search for or claim new issues. Proceed with sweeps and @ADMIN processing only.
-
 ## Role
 
 - Review epic parent PRs that are labeled `status:needs-review` and `role:super`.

--- a/contexts/WORKER.md
+++ b/contexts/WORKER.md
@@ -2,18 +2,6 @@
 
 You are a worker agent. You pick up a single task, implement it completely, and hand off your results. You are unaware of the larger system — focus entirely on your assigned issue.
 
-## Pre-assigned issues
-
-If your system prompt includes `ASSIGNED_ISSUE: <N>`, you have been pre-assigned issue #N.
-Work on this issue directly — do not search for other issues.
-
-1. Read the issue: `gh issue view <N> --comments`
-2. Verify the issue is valid: not already claimed by another agent, not closed, and still labeled `role:worker`.
-3. Claim it immediately: relabel to `status:in-progress` and comment your claim.
-4. Proceed with implementation.
-
-If `ASSIGNED_ISSUE` is not present, use the standard claim flow below.
-
 ## Role
 
 - Search for one issue labeled `status:ready-for-work` and `role:worker`.

--- a/templates/planner.json
+++ b/templates/planner.json
@@ -1,7 +1,7 @@
 {
   "interval": "2m",
   "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-  "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+  "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
   "repo": "github.com/alexjaniak/Forge"

--- a/templates/super.json
+++ b/templates/super.json
@@ -1,7 +1,7 @@
 {
   "interval": "5m",
   "prompt": "Review epic PRs labeled status:needs-review and role:super. Check for cohesion, DRY code, and cross-cutting conflicts with other open PRs and issues. Approve to admin or send back to planner. Sweep for stale, stuck, or orphaned issues and PRs.",
-  "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
+  "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
   "repo": "github.com/alexjaniak/Forge"

--- a/templates/worker.json
+++ b/templates/worker.json
@@ -1,7 +1,7 @@
 {
   "interval": "2m",
   "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
-  "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+  "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
   "repo": "github.com/alexjaniak/Forge"


### PR DESCRIPTION
**@worker-02**

## Summary
- extract the shared pre-assigned issue guidance into `contexts/ASSIGNED_ISSUE.md`
- wire the shared context into worker, planner, and super template/context arrays
- remove the duplicated pre-assigned issue blocks from the three role files

## Context
- Addresses #744 for epic #517.
- Follows up on PR #546 to satisfy the latest `@ADMIN` refactor request.
