### PR TITLE
CLI/docs: remove agentic/workspace from staged output and documentation

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -25,14 +25,11 @@ cp agent-kernel/.env.example agent-kernel/.env
 ## Usage
 
 ```bash
-# Text-only (default — --print, no tools)
-./agent-kernel/run.sh "Summarize recent commits"
-
 # With context files (paths relative to repo root)
 ./agent-kernel/run.sh --context contexts/IDENTITY.md "Summarize recent commits"
 
-# Agentic with context
-./agent-kernel/run.sh --agentic --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
+# With an isolated worktree
+./agent-kernel/run.sh --workspace worker-01 --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
 
 # Piped
 echo "List open issues" | ./agent-kernel/run.sh
@@ -105,5 +102,5 @@ This checks connectivity and confirms your token is valid.
 2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
 4. `--dangerously-skip-permissions` is on by default for unattended runs
-5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
-6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`
+5. Tool access is enabled for Forge-managed runs without an extra mode flag
+6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`; Forge-managed agents use this automatically

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -23,9 +23,7 @@ Source of truth for desired cron state. Checked into git.
       "id": "worker",
       "interval": "5m",
       "prompt": "Check for stale PRs",
-      "agentic": true,
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md"],
-      "workspace": true,
       "repo": "github.com/owner/repo",
       "enabled": true
     }
@@ -38,11 +36,11 @@ Source of truth for desired cron state. Checked into git.
 | `id` | string | required | Unique job identifier. |
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
-| `agentic` | bool | `false` | Enable tool use (`--agentic`). |
 | `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
-| `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
+
+Managed cron jobs always run with tool access in an isolated worktree named after the job ID.
 
 ## Commands
 
@@ -51,7 +49,7 @@ Source of truth for desired cron state. Checked into git.
 ./agent-kernel/cron/manage.py apply
 
 # Imperative — one-off add/remove
-./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" [--agentic]
+./agent-kernel/cron/manage.py add <id> <interval> "<prompt>"
 ./agent-kernel/cron/manage.py remove <id>
 
 # Inspect

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -124,7 +124,7 @@ forge cron apply
 Add a single cron job.
 
 ```
-forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]
+forge cron add ID INTERVAL PROMPT [--context TEXT] [--repo REPO]
 ```
 
 **Arguments:**
@@ -139,14 +139,14 @@ forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--
 
 | Flag | Description |
 |------|-------------|
-| `--agentic` | Enable tool use |
-| `--workspace` | Run in isolated git worktree |
 | `--context TEXT` | Context file path (repeatable) |
 | `--repo REPO` | Target repo |
 
 ```bash
 forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
 ```
+
+Forge-managed cron jobs always run with tool access in an isolated worktree named after the job ID, so those runtime behaviors are no longer configured per command or template.
 
 #### `forge cron remove`
 

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -90,8 +90,6 @@ def add(agent_type, agent_id, interval, list_templates):
     job["interval"] = interval if interval else template["interval"]
     job["prompt"] = template["prompt"]
     job["contexts"] = template.get("contexts", [])
-    job["agentic"] = template.get("agentic", False)
-    job["workspace"] = template.get("workspace", False)
     if "repo" in template:
         job["repo"] = template["repo"]
 
@@ -108,8 +106,6 @@ def add(agent_type, agent_id, interval, list_templates):
     click.echo(f"  prompt:    \"{prompt_display}\"")
     if job["contexts"]:
         click.echo(f"  contexts:  {', '.join(job['contexts'])}")
-    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
-    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
     click.echo()
     click.echo("Run `forge apply` to activate.")
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling and execution settings.
+JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling metadata.
 
 ## Template format
 
@@ -8,9 +8,7 @@ JSON files that define the runtime configuration for each agent role. Each templ
 {
   "interval": "2m",
   "prompt": "The instruction given to the agent each run.",
-  "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "..."],
-  "agentic": true,
-  "workspace": true
+  "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "..."]
 }
 ```
 
@@ -19,8 +17,6 @@ JSON files that define the runtime configuration for each agent role. Each templ
 | `interval` | Cron scheduling interval between runs |
 | `prompt` | The task prompt passed to the agent |
 | `contexts` | Ordered list of context files composed into the system prompt |
-| `agentic` | Whether the agent runs in agentic mode with tool access |
-| `workspace` | Whether the agent gets an isolated git worktree |
 
 ## Available templates
 
@@ -33,3 +29,5 @@ JSON files that define the runtime configuration for each agent role. Each templ
 ## Usage
 
 Templates are loaded by the Forge CLI (`apps/forge-cli`) and web dashboard (`apps/web`) to launch agent runs via `agent-kernel/run.sh`.
+
+Forge-managed agents always run with tool access in isolated worktrees. Templates no longer expose separate booleans for those runtime behaviors.


### PR DESCRIPTION
**@worker-03**

## Summary
- remove `agentic` and boolean `workspace` from `forge add` staging/output
- update Forge CLI and agent-kernel docs to describe tool access and isolated worktrees as the default managed behavior
- remove obsolete template and cron schema examples from the affected READMEs

## Verification
- `python3 -m compileall apps/forge-cli/src/forge_cli/agents.py`
