### PR TITLE
Issues tab: switch IssuesPanel to SSE updates with polling fallback

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -49,7 +49,7 @@ src/app/
 | **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (STAGED, ACTIVE, MODIFIED, ORPHAN), role badges, interval/countdown info. Supports add, delete, force-run, apply, and clear actions. Auto-refreshes every 5s. |
 | **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
 | **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
-| **IssuesPanel** | `issues-panel.tsx` | Polls `/api/issues` every 10s. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert for new `role:admin` issues. |
+| **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert only when an issue newly gains `role:admin`. |
 
 ### Data Flow
 
@@ -60,7 +60,8 @@ agent-kernel/cron/cron-jobs.json  → GET /api/agents       → AgentPanel
 agent-kernel/cron/cron-state.json → GET /api/agents       → AgentPanel
 agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
-gh issue list (via CLI)             → GET /api/issues       → IssuesPanel
+gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
+GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
 templates/{type}.json             → POST /api/agents      → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
@@ -114,7 +115,11 @@ Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed 
 
 ### `GET /api/issues`
 
-Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, repo }`.
+Returns the current GitHub issue snapshot for fallback polling. Response is cached server-side for 5s and returns `{ issues, repo }`.
+
+### `GET /api/issues/stream`
+
+Server-Sent Events endpoint for live issue snapshots. Sends an initial `{ issues, repo }` snapshot immediately on connect, then emits updated snapshots when the GitHub event feed changes in ways that affect the Issues tab. The frontend falls back to polling `GET /api/issues` if the stream disconnects.
 
 ## Environment Variables
 

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
+const POLL_INTERVAL = 5000;
+
 interface Issue {
   number: number;
   title: string;
@@ -128,54 +130,106 @@ export function IssuesPanel() {
   });
   const prevIssuesRef = useRef<Issue[]>([]);
   const initialLoadRef = useRef(true);
+  const mutedRef = useRef<boolean>(muted);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const fallbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const mutedRef = useRef(muted);
-  mutedRef.current = muted;
+  const applySnapshot = useCallback((data: { issues?: Issue[]; repo?: string; error?: string }) => {
+    if (data.error) setError(data.error);
+    else setError("");
+
+    const newIssues = data.issues ?? [];
+    setIssues(newIssues);
+    if (typeof data.repo === "string") {
+      setRepo(data.repo);
+    }
+
+    if (initialLoadRef.current) {
+      initialLoadRef.current = false;
+      prevIssuesRef.current = newIssues;
+      return;
+    }
+
+    if (!mutedRef.current) {
+      const prevAdminIds = new Set(
+        prevIssuesRef.current
+          .filter((issue) => issue.labels.some((label) => label.name === "role:admin"))
+          .map((issue) => issue.number)
+      );
+      const hasNewAdminIssue = newIssues.some(
+        (issue) =>
+          issue.labels.some((label) => label.name === "role:admin") &&
+          !prevAdminIds.has(issue.number)
+      );
+      if (hasNewAdminIssue) {
+        playAdminAlert();
+      }
+    }
+
+    prevIssuesRef.current = newIssues;
+  }, []);
 
   const fetchIssues = useCallback(async () => {
     try {
       const res = await fetch("/api/issues");
       const data = await res.json();
-      if (data.error) setError(data.error);
-      else setError("");
-      const newIssues: Issue[] = data.issues ?? [];
-      setIssues(newIssues);
-      if (data.repo) setRepo(data.repo);
-
-      // Skip alert on initial load
-      if (initialLoadRef.current) {
-        initialLoadRef.current = false;
-        prevIssuesRef.current = newIssues;
-        return;
-      }
-
-      // Detect newly-added role:admin labels
-      if (!mutedRef.current) {
-        const prevAdminIds = new Set(
-          prevIssuesRef.current
-            .filter((i) => i.labels.some((l) => l.name === "role:admin"))
-            .map((i) => i.number)
-        );
-        const newAdminIssues = newIssues.filter(
-          (i) =>
-            i.labels.some((l) => l.name === "role:admin") &&
-            !prevAdminIds.has(i.number)
-        );
-        if (newAdminIssues.length > 0) {
-          playAdminAlert();
-        }
-      }
-      prevIssuesRef.current = newIssues;
+      applySnapshot(data);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Fetch failed");
+    }
+  }, [applySnapshot]);
+
+  const startFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) return;
+    fallbackTimerRef.current = setInterval(fetchIssues, POLL_INTERVAL);
+  }, [fetchIssues]);
+
+  const stopFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearInterval(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
     }
   }, []);
 
   useEffect(() => {
-    fetchIssues();
-    const id = setInterval(fetchIssues, 5000);
-    return () => clearInterval(id);
-  }, [fetchIssues]);
+    const initialFetchId = window.setTimeout(() => {
+      void fetchIssues();
+    }, 0);
+
+    const es = new EventSource("/api/issues/stream");
+    eventSourceRef.current = es;
+
+    const handleSnapshot = (event: MessageEvent<string>) => {
+      try {
+        applySnapshot(JSON.parse(event.data));
+      } catch {
+        setError("Invalid issue stream payload");
+      }
+    };
+
+    es.onmessage = handleSnapshot;
+    es.addEventListener("snapshot", handleSnapshot as EventListener);
+
+    es.onerror = () => {
+      startFallbackPolling();
+    };
+
+    es.onopen = () => {
+      stopFallbackPolling();
+    };
+
+    return () => {
+      window.clearTimeout(initialFetchId);
+      es.removeEventListener("snapshot", handleSnapshot as EventListener);
+      es.close();
+      eventSourceRef.current = null;
+      stopFallbackPolling();
+    };
+  }, [applySnapshot, fetchIssues, startFallbackPolling, stopFallbackPolling]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+  }, [muted]);
 
   useEffect(() => {
     try { localStorage.setItem("forge-admin-alert-muted", String(muted)); } catch {}


### PR DESCRIPTION
**@worker-02**

## Summary
- switch `IssuesPanel` to consume `/api/issues/stream` with `/api/issues` polling fallback
- preserve existing card/filter UI and muted admin alert behavior while avoiding replay alerts on reconnect
- document the Issues tab as stream-driven with polling fallback in `apps/web/README.md`

## Testing
- `pnpm --dir apps/web exec eslint src/components/issues-panel.tsx`
- `pnpm --dir apps/web lint` *(fails on pre-existing issues in `src/components/resizable-layout.tsx` and a warning in `src/components/agent-panel.tsx`)*
