### PR TITLE
Add issues snapshot SSE stream

### DIFF
--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,41 +1,11 @@
-import { execSync } from "child_process";
 import { NextResponse } from "next/server";
-import { getForgeRoot } from "@/lib/paths";
-
-let cache: { issues: unknown[]; repo: string; ts: number } | null = null;
-const TTL = 5000;
+import { getIssueSnapshot } from "@/lib/issues";
 
 export async function GET() {
-  const now = Date.now();
-  if (cache && now - cache.ts < TTL) {
-    return NextResponse.json({ issues: cache.issues, repo: cache.repo });
-  }
-
-  const cwd = getForgeRoot();
-
-  let issues: unknown[] = [];
-  let repo = "";
-
   try {
-    const raw = execSync(
-      "gh issue list --state open --json number,title,labels,assignees --limit 100",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    );
-    issues = JSON.parse(raw);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json(await getIssueSnapshot());
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ issues: [], repo: "", error: msg });
   }
-
-  try {
-    repo = execSync(
-      "gh repo view --json nameWithOwner -q '.nameWithOwner'",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    ).trim();
-  } catch {
-    // non-fatal — links just won't work
-  }
-
-  cache = { issues, repo, ts: now };
-  return NextResponse.json({ issues, repo });
 }

--- a/apps/web/src/app/api/issues/stream/route.ts
+++ b/apps/web/src/app/api/issues/stream/route.ts
@@ -1,0 +1,221 @@
+import fs from "fs";
+import path from "path";
+import { eventsPath } from "@/lib/paths";
+import { getIssueSnapshot, invalidateIssueSnapshot } from "@/lib/issues";
+
+const KEEPALIVE_MS = 15000;
+const ISSUE_EVENT_PREFIX = "issue.";
+
+export const dynamic = "force-dynamic";
+
+function encodeSse(event: string, payload: unknown): Uint8Array {
+  const encoder = new TextEncoder();
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+function isRelevantIssueEvent(line: string): boolean {
+  try {
+    const parsed = JSON.parse(line) as { event_type?: unknown };
+    return (
+      typeof parsed.event_type === "string" &&
+      parsed.event_type.startsWith(ISSUE_EVENT_PREFIX)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request: Request) {
+  const filePath = eventsPath();
+  const dirPath = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+
+  let fileWatcher: fs.FSWatcher | null = null;
+  let dirWatcher: fs.FSWatcher | null = null;
+  let keepalive: NodeJS.Timeout | null = null;
+  let closed = false;
+  let offset = 0;
+  let pendingLine = "";
+  let snapshotInFlight = false;
+  let snapshotQueued = false;
+
+  function cleanup() {
+    if (closed) return;
+    closed = true;
+
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      fileWatcher = null;
+    }
+
+    if (dirWatcher) {
+      try {
+        dirWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      dirWatcher = null;
+    }
+  }
+
+  async function sendSnapshot(
+    controller: ReadableStreamDefaultController,
+    forceRefresh: boolean
+  ) {
+    if (closed) return;
+    if (snapshotInFlight) {
+      snapshotQueued = snapshotQueued || forceRefresh;
+      return;
+    }
+
+    snapshotInFlight = true;
+    let nextForceRefresh = forceRefresh;
+
+    try {
+      do {
+        const shouldForceRefresh = nextForceRefresh || snapshotQueued;
+        snapshotQueued = false;
+        nextForceRefresh = false;
+
+        try {
+          const snapshot = await getIssueSnapshot({
+            forceRefresh: shouldForceRefresh,
+          });
+          if (closed) return;
+          controller.enqueue(encodeSse("snapshot", snapshot));
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (closed) return;
+          controller.enqueue(
+            encodeSse("snapshot", { issues: [], repo: "", error: message })
+          );
+        }
+      } while (snapshotQueued);
+    } finally {
+      snapshotInFlight = false;
+    }
+  }
+
+  function watchFile(onChange: () => void) {
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+
+    try {
+      fileWatcher = fs.watch(filePath, () => {
+        onChange();
+      });
+    } catch {
+      fileWatcher = null;
+    }
+  }
+
+  function readRelevantChanges(): boolean {
+    let fileSize = 0;
+    try {
+      fileSize = fs.statSync(filePath).size;
+    } catch {
+      offset = 0;
+      pendingLine = "";
+      return false;
+    }
+
+    if (offset > fileSize) {
+      offset = 0;
+      pendingLine = "";
+    }
+
+    if (offset === fileSize) {
+      return false;
+    }
+
+    const bytesToRead = fileSize - offset;
+    const fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(bytesToRead);
+
+    try {
+      fs.readSync(fd, buffer, 0, bytesToRead, offset);
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    offset = fileSize;
+    const chunk = pendingLine + buffer.toString("utf-8");
+    const lines = chunk.split("\n");
+    pendingLine = lines.pop() ?? "";
+
+    return lines.some((line) => line.trim() !== "" && isRelevantIssueEvent(line));
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      try {
+        fs.mkdirSync(dirPath, { recursive: true });
+      } catch {
+        // ignore setup errors
+      }
+
+      try {
+        offset = fs.statSync(filePath).size;
+      } catch {
+        offset = 0;
+      }
+
+      const handleChange = () => {
+        if (!readRelevantChanges()) {
+          return;
+        }
+        invalidateIssueSnapshot();
+        void sendSnapshot(controller, true);
+      };
+
+      watchFile(handleChange);
+
+      try {
+        dirWatcher = fs.watch(dirPath, (_eventType, filename) => {
+          if (filename && filename !== fileName) {
+            return;
+          }
+          watchFile(handleChange);
+          handleChange();
+        });
+      } catch {
+        dirWatcher = null;
+      }
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+      }, KEEPALIVE_MS);
+
+      void sendSnapshot(controller, false);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  request.signal.addEventListener("abort", cleanup, { once: true });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -1,0 +1,45 @@
+import { execSync } from "child_process";
+import { getForgeRoot } from "@/lib/paths";
+
+export interface IssueSnapshot {
+  issues: unknown[];
+  repo: string;
+}
+
+let cache: (IssueSnapshot & { ts: number }) | null = null;
+const TTL_MS = 5000;
+
+export function invalidateIssueSnapshot(): void {
+  cache = null;
+}
+
+export async function getIssueSnapshot(options?: {
+  forceRefresh?: boolean;
+}): Promise<IssueSnapshot> {
+  const now = Date.now();
+  if (!options?.forceRefresh && cache && now - cache.ts < TTL_MS) {
+    return { issues: cache.issues, repo: cache.repo };
+  }
+
+  const cwd = getForgeRoot();
+  const raw = execSync(
+    "gh issue list --state open --json number,title,labels,assignees --limit 100",
+    { cwd, encoding: "utf-8", timeout: 10000 }
+  );
+
+  const issues = JSON.parse(raw) as unknown[];
+  let repo = "";
+
+  try {
+    repo = execSync("gh repo view --json nameWithOwner -q '.nameWithOwner'", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10000,
+    }).trim();
+  } catch {
+    // Non-fatal. Issue links fall back to plain cards.
+  }
+
+  cache = { issues, repo, ts: now };
+  return { issues, repo };
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- extract GitHub issue snapshot loading and caching into a shared server helper reused by both issue routes
- add `/api/issues/stream` as an SSE endpoint that emits an initial snapshot immediately and refreshes on appended `issue.*` webhook events from `events.jsonl`
- keep `/api/issues` working as the fallback JSON snapshot route with the same response shape and error contract

## Verification
- `cd apps/web && npm run build`
- `cd apps/web && npx eslint src/app/api/issues/route.ts src/app/api/issues/stream/route.ts src/lib/issues.ts`
- `cd apps/web && npm run lint` still fails on pre-existing issues in `src/components/agent-panel.tsx`, `src/components/issues-panel.tsx`, and `src/components/resizable-layout.tsx`

## Notes
- the stream watches the shared webhook event feed instead of polling GitHub directly, and cleans up file watchers plus keepalive timers on disconnect
