### PR TITLE
Runtime/config: remove agentic/workspace fields from templates, cron, and run.sh

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -25,17 +25,14 @@ cp agent-kernel/.env.example agent-kernel/.env
 ## Usage
 
 ```bash
-# Text-only (default — --print, no tools)
-./agent-kernel/run.sh "Summarize recent commits"
+# Tool-enabled run against a repo
+./agent-kernel/run.sh --repo github.com/owner/repo "Summarize recent commits"
 
 # With context files (paths relative to repo root)
-./agent-kernel/run.sh --context contexts/IDENTITY.md "Summarize recent commits"
-
-# Agentic with context
-./agent-kernel/run.sh --agentic --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
+./agent-kernel/run.sh --repo github.com/owner/repo --context contexts/IDENTITY.md "Summarize recent commits"
 
 # Piped
-echo "List open issues" | ./agent-kernel/run.sh
+echo "List open issues" | ./agent-kernel/run.sh --repo github.com/owner/repo
 ```
 
 ## Context Library
@@ -104,6 +101,5 @@ This checks connectivity and confirms your token is valid.
 1. `--context <path>` flags assemble a system prompt from context files (paths relative to repo root)
 2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
-4. `--dangerously-skip-permissions` is on by default for unattended runs
-5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
-6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`
+4. Tool-enabled execution uses `--dangerously-skip-permissions` for unattended runs
+5. `--workspace <id>` runs inside an isolated git worktree at `.repos/<repo>/.worktrees/<id>`

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -23,9 +23,7 @@ Source of truth for desired cron state. Checked into git.
       "id": "worker",
       "interval": "5m",
       "prompt": "Check for stale PRs",
-      "agentic": true,
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md"],
-      "workspace": true,
       "repo": "github.com/owner/repo",
       "enabled": true
     }
@@ -38,10 +36,8 @@ Source of truth for desired cron state. Checked into git.
 | `id` | string | required | Unique job identifier. |
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
-| `agentic` | bool | `false` | Enable tool use (`--agentic`). |
 | `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
-| `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
 ## Commands
@@ -51,7 +47,7 @@ Source of truth for desired cron state. Checked into git.
 ./agent-kernel/cron/manage.py apply
 
 # Imperative — one-off add/remove
-./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" [--agentic]
+./agent-kernel/cron/manage.py add <id> <interval> "<prompt>"
 ./agent-kernel/cron/manage.py remove <id>
 
 # Inspect

--- a/agent-kernel/cron/cron-jobs.json
+++ b/agent-kernel/cron/cron-jobs.json
@@ -6,8 +6,6 @@
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -15,8 +13,6 @@
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -24,8 +20,6 @@
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -33,8 +27,6 @@
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -42,8 +34,6 @@
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -51,8 +41,6 @@
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -60,8 +48,6 @@
       "interval": "3m",
       "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     },
     {
@@ -69,8 +55,6 @@
       "interval": "5m",
       "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
       "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-      "agentic": true,
-      "workspace": true,
       "repo": "github.com/alexjaniak/Forge"
     }
   ]

--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -35,8 +35,6 @@ JOBS_FILE = os.path.join(SCRIPT_DIR, "cron-jobs.json")
 #       "interval": "5m",          # scheduling interval (Nm or Nh)
 #       "cron_expr": "*/5 * * * *",# resolved cron expression
 #       "prompt": "...",           # agent prompt
-#       "agentic": true,           # tool use enabled
-#       "workspace": true,         # git worktree isolation
 #       "contexts": [...],         # context file paths
 #       "repo": "",                # target repo (empty = self)
 #       "installed_at": "ISO8601", # when job was added/updated
@@ -80,14 +78,11 @@ def validate_model(model):
 
 
 
-def build_cron_command(job_id, prompt, agentic, contexts=None, workspace=False, repo=None, runtime=None, model=None):
+def build_cron_command(job_id, prompt, contexts=None, repo=None, runtime=None, model=None):
     runtime = runtime or "claude"
     env_prefix = f"AGENT_RUNTIME={runtime} " if runtime != "claude" else ""
     cmd = f"mkdir -p {LOGS_DIR} && cd {REPO_DIR} && {env_prefix}./agent-kernel/run.sh"
-    if agentic:
-        cmd += " --agentic"
-    if workspace:
-        cmd += f" --workspace {job_id}"
+    cmd += f" --workspace {job_id}"
     if repo:
         cmd += f" --repo {repo}"
     if model:
@@ -270,8 +265,6 @@ def cmd_apply(args):
         if (stagger_changed or
                 d["interval"] != a.get("interval") or
                 d["prompt"] != a.get("prompt") or
-                d.get("agentic", False) != a.get("agentic", False) or
-                d.get("workspace", False) != a.get("workspace", False) or
                 d.get("contexts", []) != a.get("contexts", []) or
                 d.get("repo", "") != a.get("repo", "") or
                 d.get("runtime", "claude") != a.get("runtime", "claude") or
@@ -298,7 +291,7 @@ def cmd_apply(args):
         model = job.get("model", "")
         validate_runtime(runtime)
         validate_model(model)
-        command = build_cron_command(job_id, job["prompt"], job.get("agentic", False), contexts, job.get("workspace", False), repo or None, runtime, model or None)
+        command = build_cron_command(job_id, job["prompt"], contexts, repo or None, runtime, model or None)
 
         offset = stagger_offsets.get(job_id, 0)
         if stagger and offset > 0:
@@ -314,8 +307,6 @@ def cmd_apply(args):
             "interval": job["interval"],
             "cron_expr": cron_expr,
             "prompt": job["prompt"],
-            "agentic": job.get("agentic", False),
-            "workspace": job.get("workspace", False),
             "contexts": contexts,
             "repo": repo,
             "runtime": runtime,
@@ -358,7 +349,7 @@ def cmd_add(args):
     cron_expr = parse_interval(args.interval)
     contexts = args.context or []
     repo = args.repo or ""
-    command = build_cron_command(args.id, args.prompt, args.agentic, contexts, args.workspace, repo or None, runtime, model or None)
+    command = build_cron_command(args.id, args.prompt, contexts, repo or None, runtime, model or None)
 
     crontab = read_crontab()
     crontab = add_job_to_crontab(crontab, args.id, cron_expr, command)
@@ -369,8 +360,6 @@ def cmd_add(args):
         "interval": args.interval,
         "cron_expr": cron_expr,
         "prompt": args.prompt,
-        "agentic": args.agentic,
-        "workspace": args.workspace,
         "contexts": contexts,
         "repo": repo,
         "runtime": runtime,
@@ -410,7 +399,6 @@ def cmd_list(args):
     stagger_enabled = state.get("stagger", False)
 
     for job_id, info in jobs.items():
-        mode = "agentic" if info.get("agentic") else "text"
         offset = info.get("stagger_offset", 0)
         if stagger_enabled and offset > 0:
             cron_expr, sleep_secs = apply_offset_to_interval(info["interval"], offset)
@@ -424,7 +412,7 @@ def cmd_list(args):
             cron_col = f"{info['cron_expr']} (stagger: base)"
         else:
             cron_col = info["cron_expr"]
-        print(f"  {job_id:<20} {cron_col:<30} {mode:<10} \"{info['prompt']}\"")
+        print(f"  {job_id:<20} {cron_col:<30} \"{info['prompt']}\"")
 
 
 def print_status_table():
@@ -507,10 +495,7 @@ def cmd_run(args):
         os.environ["AGENT_RUNTIME"] = runtime
 
     cmd = [os.path.join(REPO_DIR, "agent-kernel", "run.sh")]
-    if job.get("agentic"):
-        cmd.append("--agentic")
-    if job.get("workspace"):
-        cmd += ["--workspace", job["id"]]
+    cmd += ["--workspace", job["id"]]
     if job.get("repo"):
         cmd += ["--repo", job["repo"]]
     if job.get("model"):
@@ -553,8 +538,6 @@ def main():
     p_add.add_argument("id", help="Job identifier")
     p_add.add_argument("interval", help="Interval: Nm or Nh")
     p_add.add_argument("prompt", help="Prompt for run.sh")
-    p_add.add_argument("--agentic", action="store_true", help="Enable tool use")
-    p_add.add_argument("--workspace", action="store_true", help="Run in isolated git worktree")
     p_add.add_argument("--context", action="append", help="Context file path relative to repo root (repeatable)")
     p_add.add_argument("--repo", help="Target repo (e.g. github.com/owner/repo or absolute path)")
     p_add.add_argument("--runtime", default="claude", help="Agent runtime: claude or codex (default: claude)")

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -17,7 +17,6 @@ fi
 CLAUDE="${CLAUDE_BIN:-claude}"
 
 # ── parse flags ────────────────────────────────────────────────
-AGENTIC=false
 PROMPT=""
 CONTEXTS=()
 WORKSPACE_ID=""
@@ -50,7 +49,6 @@ for arg in "$@"; do
     continue
   fi
   case "$arg" in
-    --agentic)    AGENTIC=true ;;
     --context)    NEXT_IS_CONTEXT=true ;;
     --workspace)  NEXT_IS_WORKSPACE=true ;;
     --repo)       NEXT_IS_REPO=true ;;
@@ -65,7 +63,7 @@ if [[ -z "$PROMPT" ]] && [[ ! -t 0 ]]; then
 fi
 
 if [[ -z "$PROMPT" ]]; then
-  echo "Usage: $0 [--agentic] [--workspace <id>] [--repo <path-or-url>] [--model <model>] [--context <path> ...] \"<prompt>\"" >&2
+  echo "Usage: $0 [--workspace <id>] --repo <path-or-url> [--model <model>] [--context <path> ...] \"<prompt>\"" >&2
   exit 1
 fi
 
@@ -249,9 +247,6 @@ if [[ "$AGENT_RUNTIME" == "codex" ]]; then
     PROMPT="${SYSTEM_PROMPT}"$'\n\n'"${PROMPT}"
   fi
 else
-  if [[ "$AGENTIC" == false ]]; then
-    RUNTIME_ARGS+=(--print)          # text-only, no tools
-  fi
   RUNTIME_ARGS+=(--dangerously-skip-permissions)
   if [[ -n "$SYSTEM_PROMPT" ]]; then
     RUNTIME_ARGS+=(--append-system-prompt "$SYSTEM_PROMPT")

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -90,8 +90,6 @@ def add(agent_type, agent_id, interval, list_templates):
     job["interval"] = interval if interval else template["interval"]
     job["prompt"] = template["prompt"]
     job["contexts"] = template.get("contexts", [])
-    job["agentic"] = template.get("agentic", False)
-    job["workspace"] = template.get("workspace", False)
     if "repo" in template:
         job["repo"] = template["repo"]
 
@@ -108,8 +106,6 @@ def add(agent_type, agent_id, interval, list_templates):
     click.echo(f"  prompt:    \"{prompt_display}\"")
     if job["contexts"]:
         click.echo(f"  contexts:  {', '.join(job['contexts'])}")
-    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
-    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
     click.echo()
     click.echo("Run `forge apply` to activate.")
 

--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -88,8 +88,8 @@ def _invoke_agent(repo_dir: str, rule: dict, event: dict) -> None:
 
     cmd = [
         str(Path(repo_dir) / "agent-kernel" / "run.sh"),
-        "--agentic",
         "--workspace", workspace,
+        "--repo", repo_dir,
     ]
     if context:
         cmd.extend(["--context", context])

--- a/templates/README.md
+++ b/templates/README.md
@@ -9,8 +9,7 @@ JSON files that define the runtime configuration for each agent role. Each templ
   "interval": "2m",
   "prompt": "The instruction given to the agent each run.",
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "..."],
-  "agentic": true,
-  "workspace": true
+  "repo": "github.com/owner/repo"
 }
 ```
 
@@ -19,8 +18,7 @@ JSON files that define the runtime configuration for each agent role. Each templ
 | `interval` | Cron scheduling interval between runs |
 | `prompt` | The task prompt passed to the agent |
 | `contexts` | Ordered list of context files composed into the system prompt |
-| `agentic` | Whether the agent runs in agentic mode with tool access |
-| `workspace` | Whether the agent gets an isolated git worktree |
+| `repo` | Target repository for isolated worktree creation and agent execution |
 
 ## Available templates
 

--- a/templates/planner.json
+++ b/templates/planner.json
@@ -2,7 +2,5 @@
   "interval": "2m",
   "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
   "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-  "agentic": true,
-  "workspace": true,
   "repo": "github.com/alexjaniak/Forge"
 }

--- a/templates/super.json
+++ b/templates/super.json
@@ -2,7 +2,5 @@
   "interval": "5m",
   "prompt": "Review epic PRs labeled status:needs-review and role:super. Check for cohesion, DRY code, and cross-cutting conflicts with other open PRs and issues. Approve to admin or send back to planner. Sweep for stale, stuck, or orphaned issues and PRs.",
   "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
-  "agentic": true,
-  "workspace": true,
   "repo": "github.com/alexjaniak/Forge"
 }

--- a/templates/worker.json
+++ b/templates/worker.json
@@ -2,7 +2,5 @@
   "interval": "2m",
   "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
-  "agentic": true,
-  "workspace": true,
   "repo": "github.com/alexjaniak/Forge"
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- remove `agentic` and `workspace` from templates, staged cron jobs, and Forge CLI staging
- make cron command generation and `run.sh` always use tool-enabled execution plus `--workspace <id>`
- update webhook-triggered runs and docs to match the simplified `run.sh` contract

## Validation
- `bash -n agent-kernel/run.sh`
- `python3 -m py_compile agent-kernel/cron/manage.py apps/webhook-monitor/src/forge_webhook/trigger.py apps/forge-cli/src/forge_cli/agents.py`
- inspected generated cron command and webhook invocation shape via Python snippets

Closes #749
