### PR TITLE
Docs: correct repo/worktree runtime guidance after #757

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -26,17 +26,19 @@ cp agent-kernel/.env.example agent-kernel/.env
 
 ```bash
 # Text-only (default — --print, no tools)
-./agent-kernel/run.sh "Summarize recent commits"
+./agent-kernel/run.sh --repo github.com/owner/repo "Summarize recent commits"
 
 # With context files (paths relative to repo root)
-./agent-kernel/run.sh --context contexts/IDENTITY.md "Summarize recent commits"
+./agent-kernel/run.sh --repo github.com/owner/repo --context contexts/IDENTITY.md "Summarize recent commits"
 
 # Agentic with context
-./agent-kernel/run.sh --agentic --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
+./agent-kernel/run.sh --repo github.com/owner/repo --agentic --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
 
 # Piped
-echo "List open issues" | ./agent-kernel/run.sh
+echo "List open issues" | ./agent-kernel/run.sh --repo github.com/owner/repo
 ```
+
+`--repo` is required. Pass an absolute local path or a `github.com/owner/repo` string.
 
 ## Context Library
 
@@ -106,4 +108,5 @@ This checks connectivity and confirms your token is valid.
 3. Your prompt goes as the message argument
 4. `--dangerously-skip-permissions` is on by default for unattended runs
 5. Default mode is `--print` (text only). Pass `--agentic` to enable tool use.
-6. `--workspace <id>` runs inside an isolated git worktree at `.repos/<id>`
+6. `--repo` selects the working repository. `github.com/owner/repo` targets a clone at `.repos/github.com/owner/repo`; an absolute path uses that local repo directly.
+7. `--workspace <id>` runs inside an isolated git worktree at `<target-repo>/.worktrees/<id>`

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -39,9 +39,9 @@ Source of truth for desired cron state. Checked into git.
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
 | `agentic` | bool | `false` | Enable tool use (`--agentic`). |
-| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
+| `repo` | string | required | Target repo (for example `"github.com/owner/repo"` or an absolute local path). `run.sh` exits with an error when this is omitted. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
-| `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
+| `workspace` | bool | `false` | Run the agent in an isolated git worktree at `<target-repo>/.worktrees/<id>`. For GitHub repo strings, the base clone lives at `.repos/github.com/owner/repo`. |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
 ## Commands


### PR DESCRIPTION
**@worker-02**

Review follow-up for PR #757.

## Summary
- fix `agent-kernel/run.sh` examples in `agent-kernel/README.md` so they include the required `--repo` argument
- correct the runtime docs to describe the current clone and worktree layout used by `run.sh`
- update `agent-kernel/cron/README.md` to document `repo` as required and point `workspace` at the target repo's `.worktrees/<id>` path
