### PR TITLE
Issues tab: source canonical filter labels from LABELS.md and render them in-panel

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -114,7 +114,7 @@ Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed 
 
 ### `GET /api/issues`
 
-Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, repo }`.
+Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, labels, repo }`, where `labels` is the canonical `status`, `role`, and `type` label set parsed from `contexts/LABELS.md` so the Issues tab can render filter chips even when a label has zero open matches.
 
 ## Environment Variables
 

--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,17 +1,30 @@
 import { execSync } from "child_process";
 import { NextResponse } from "next/server";
+import { readCanonicalIssueLabels } from "@/lib/github-labels";
 import { getForgeRoot } from "@/lib/paths";
 
-let cache: { issues: unknown[]; repo: string; ts: number } | null = null;
+let cache:
+  | {
+      issues: unknown[];
+      labels: ReturnType<typeof readCanonicalIssueLabels>;
+      repo: string;
+      ts: number;
+    }
+  | null = null;
 const TTL = 5000;
 
 export async function GET() {
   const now = Date.now();
   if (cache && now - cache.ts < TTL) {
-    return NextResponse.json({ issues: cache.issues, repo: cache.repo });
+    return NextResponse.json({
+      issues: cache.issues,
+      labels: cache.labels,
+      repo: cache.repo,
+    });
   }
 
   const cwd = getForgeRoot();
+  const labels = readCanonicalIssueLabels();
 
   let issues: unknown[] = [];
   let repo = "";
@@ -24,7 +37,7 @@ export async function GET() {
     issues = JSON.parse(raw);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return NextResponse.json({ issues: [], repo: "", error: msg });
+    return NextResponse.json({ issues: [], labels, repo: "", error: msg });
   }
 
   try {
@@ -36,6 +49,6 @@ export async function GET() {
     // non-fatal — links just won't work
   }
 
-  cache = { issues, repo, ts: now };
-  return NextResponse.json({ issues, repo });
+  cache = { issues, labels, repo, ts: now };
+  return NextResponse.json({ issues, labels, repo });
 }

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import type { CanonicalIssueLabels } from "@/lib/github-labels";
 
 interface Issue {
   number: number;
@@ -39,6 +40,43 @@ function labelColor(name: string): string {
     TYPE_COLORS[name] ??
     "bg-surface-hover text-text"
   );
+}
+
+function chipBorderColor(name: string): string {
+  if (name.startsWith("status:")) {
+    return STATUS_COLORS[name]?.includes("accent-green")
+      ? "border-accent-green/50"
+      : STATUS_COLORS[name]?.includes("accent-blue")
+        ? "border-accent-blue/50"
+        : STATUS_COLORS[name]?.includes("accent-magenta")
+          ? "border-accent-magenta/50"
+          : STATUS_COLORS[name]?.includes("accent-red")
+            ? "border-accent-red/50"
+            : "border-accent-yellow/50";
+  }
+
+  if (name.startsWith("role:")) {
+    return ROLE_COLORS[name]?.includes("accent-green")
+      ? "border-accent-green/50"
+      : ROLE_COLORS[name]?.includes("accent-magenta")
+        ? "border-accent-magenta/50"
+        : ROLE_COLORS[name]?.includes("accent-yellow")
+          ? "border-accent-yellow/50"
+          : "border-accent-orange/50";
+  }
+
+  if (name === "type:epic") return "border-accent-cyan/50";
+  if (name === "type:fix") return "border-accent-red/50";
+
+  return "border-border";
+}
+
+function filterChipClass(name: string, active: boolean): string {
+  if (!active) {
+    return "text-muted-foreground border border-border";
+  }
+
+  return `${labelColor(name)} border ${chipBorderColor(name)}`;
 }
 
 function playAdminAlert() {
@@ -119,18 +157,26 @@ function IssueCard({ issue, repo }: { issue: Issue; repo: string }) {
 
 export function IssuesPanel() {
   const [issues, setIssues] = useState<Issue[]>([]);
+  const [labels, setLabels] = useState<CanonicalIssueLabels>({
+    status: [],
+    role: [],
+    type: [],
+  });
   const [repo, setRepo] = useState("");
   const [error, setError] = useState("");
   const [statusFilter, setStatusFilter] = useState<Set<string>>(new Set());
   const [roleFilter, setRoleFilter] = useState<Set<string>>(new Set());
+  const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
   const [muted, setMuted] = useState(() => {
     try { return localStorage.getItem("forge-admin-alert-muted") === "true"; } catch { return false; }
   });
   const prevIssuesRef = useRef<Issue[]>([]);
   const initialLoadRef = useRef(true);
-
   const mutedRef = useRef(muted);
-  mutedRef.current = muted;
+
+  useEffect(() => {
+    mutedRef.current = muted;
+  }, [muted]);
 
   const fetchIssues = useCallback(async () => {
     try {
@@ -140,6 +186,7 @@ export function IssuesPanel() {
       else setError("");
       const newIssues: Issue[] = data.issues ?? [];
       setIssues(newIssues);
+      if (data.labels) setLabels(data.labels);
       if (data.repo) setRepo(data.repo);
 
       // Skip alert on initial load
@@ -172,30 +219,19 @@ export function IssuesPanel() {
   }, []);
 
   useEffect(() => {
-    fetchIssues();
+    const initialFetchId = window.setTimeout(() => {
+      void fetchIssues();
+    }, 0);
     const id = setInterval(fetchIssues, 5000);
-    return () => clearInterval(id);
+    return () => {
+      window.clearTimeout(initialFetchId);
+      clearInterval(id);
+    };
   }, [fetchIssues]);
 
   useEffect(() => {
     try { localStorage.setItem("forge-admin-alert-muted", String(muted)); } catch {}
   }, [muted]);
-
-  // Collect unique status and role labels present in data
-  const statusLabels = [
-    ...new Set(
-      issues.flatMap((i) =>
-        i.labels.filter((l) => l.name.startsWith("status:")).map((l) => l.name)
-      )
-    ),
-  ].sort();
-  const roleLabels = [
-    ...new Set(
-      issues.flatMap((i) =>
-        i.labels.filter((l) => l.name.startsWith("role:")).map((l) => l.name)
-      )
-    ),
-  ].sort();
 
   const toggleFilter = (
     set: Set<string>,
@@ -221,6 +257,12 @@ export function IssuesPanel() {
       );
       if (!has) return false;
     }
+    if (typeFilter.size > 0) {
+      const has = issue.labels.some(
+        (l) => l.name.startsWith("type:") && typeFilter.has(l.name)
+      );
+      if (!has) return false;
+    }
     return true;
   });
 
@@ -239,30 +281,31 @@ export function IssuesPanel() {
         >
           <BellIcon muted={muted} />
         </button>
-        {statusLabels.map((s) => (
+        {labels.status.map((s) => (
           <button
             key={s}
             onClick={() => toggleFilter(statusFilter, setStatusFilter, s)}
-            className={`text-xs px-2 py-0.5 rounded-full cursor-pointer ${
-              statusFilter.has(s)
-                ? "bg-accent-blue/20 text-accent-blue border border-accent-blue/50"
-                : "text-muted-foreground border border-border"
-            }`}
+            className={`text-xs px-2 py-0.5 rounded-full cursor-pointer ${filterChipClass(s, statusFilter.has(s))}`}
           >
             {s}
           </button>
         ))}
-        {roleLabels.map((r) => (
+        {labels.role.map((r) => (
           <button
             key={r}
             onClick={() => toggleFilter(roleFilter, setRoleFilter, r)}
-            className={`text-xs px-2 py-0.5 rounded-full cursor-pointer ${
-              roleFilter.has(r)
-                ? "bg-accent-blue/20 text-accent-blue border border-accent-blue/50"
-                : "text-muted-foreground border border-border"
-            }`}
+            className={`text-xs px-2 py-0.5 rounded-full cursor-pointer ${filterChipClass(r, roleFilter.has(r))}`}
           >
             {r}
+          </button>
+        ))}
+        {labels.type.map((t) => (
+          <button
+            key={t}
+            onClick={() => toggleFilter(typeFilter, setTypeFilter, t)}
+            className={`text-xs px-2 py-0.5 rounded-full cursor-pointer ${filterChipClass(t, typeFilter.has(t))}`}
+          >
+            {t}
           </button>
         ))}
       </div>

--- a/apps/web/src/lib/github-labels.ts
+++ b/apps/web/src/lib/github-labels.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import path from "path";
+import { getForgeRoot } from "@/lib/paths";
+
+export interface CanonicalIssueLabels {
+  status: string[];
+  role: string[];
+  type: string[];
+}
+
+const EMPTY_LABELS: CanonicalIssueLabels = {
+  status: [],
+  role: [],
+  type: [],
+};
+
+function parseSection(
+  markdown: string,
+  heading: string,
+  prefix: "status" | "role" | "type"
+): string[] {
+  const start = markdown.indexOf(heading);
+  if (start === -1) {
+    return [];
+  }
+
+  const rest = markdown.slice(start + heading.length);
+  const end = rest.search(/\n##\s+/);
+  const section = end === -1 ? rest : rest.slice(0, end);
+  const matches = section.matchAll(new RegExp("`(" + prefix + ":[^`]+)`", "g"));
+
+  return [...new Set(Array.from(matches, (match) => match[1]))];
+}
+
+export function readCanonicalIssueLabels(): CanonicalIssueLabels {
+  try {
+    const labelsPath = path.join(getForgeRoot(), "contexts/LABELS.md");
+    const markdown = fs.readFileSync(labelsPath, "utf-8");
+
+    return {
+      status: parseSection(markdown, "## Status (lifecycle)", "status"),
+      role: parseSection(markdown, "## Role (who acts on it)", "role"),
+      type: parseSection(markdown, "## Type", "type"),
+    };
+  } catch {
+    return EMPTY_LABELS;
+  }
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- parse canonical `status`, `role`, and `type` labels from `contexts/LABELS.md` in the issues API
- render those canonical labels as Issues tab filter chips, including `type:` filters, even when there are zero matching open issues
- document the `/api/issues` response shape update in the web README

## Testing
- `npm run build`
- `npm run lint` *(still fails on pre-existing `apps/web/src/components/resizable-layout.tsx` and an existing warning in `agent-panel.tsx`)*

Closes #762
