### PR TITLE
Update README docs for uv workspace workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Unified command-line interface for managing agents.
 | `forge ui` | Start the web dashboard |
 | `forge wh` | Start webhook monitor with auto-tunnel |
 
-Install: `pip install -e apps/forge-cli`
+Run from the repo workspace: `uv run forge --help`
 
 ## Project structure
 
@@ -53,16 +53,22 @@ templates/       Agent configuration templates (worker.json, planner.json, super
 ```bash
 git clone https://github.com/alexjaniak/Forge.git
 cd Forge
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ./install.sh
 ```
 
-The install script checks prerequisites, installs dependencies, and generates config files.
+If you prefer another install method, see the official uv installation guide: https://docs.astral.sh/uv/getting-started/installation/
+
+If `uv` is not available immediately after installation, restart your shell or source your shell profile before running `./install.sh`.
+
+The install script checks prerequisites, syncs the Python workspace with `uv`, installs dependencies, and generates config files.
 
 ### Manual setup
 
 If you prefer manual setup:
-1. `pip install -e apps/forge-cli` — Install the Forge CLI
-2. `pip install -e apps/webhook-monitor` — Install the webhook server
+1. `curl -LsSf https://astral.sh/uv/install.sh | sh` — Install `uv`
+2. `uv sync --all-packages` — Sync the Forge Python workspace
 3. `cd apps/web && npm install` — Install dashboard dependencies
 4. `cp agent-kernel/.env.example agent-kernel/.env` — Configure credentials
 5. `cp apps/webhook-monitor/config.example.toml apps/webhook-monitor/config.toml` — Configure webhooks
+6. `uv run forge --help` — Verify the Forge CLI is available

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -5,10 +5,16 @@ Agent orchestration CLI for Forge. Manage agents, cron jobs, webhooks, and logs 
 ## Installation
 
 ```bash
-pip install -e apps/forge-cli
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync --all-packages
+uv run forge --help
 ```
 
-Requires Python 3.11+. Dependencies: `click>=8.0`, `forge-webhook>=0.1.0`.
+If you prefer another install method for `uv`, see: https://docs.astral.sh/uv/getting-started/installation/
+
+If `uv` is not on `PATH` yet after installation, restart your shell or source your shell profile.
+
+Run Forge commands from the repo root with `uv run forge ...`. Requires Python 3.11+. Dependencies: `click>=8.0`, `forge-webhook>=0.1.0`.
 
 ## Commands
 
@@ -16,9 +22,7 @@ Requires Python 3.11+. Dependencies: `click>=8.0`, `forge-webhook>=0.1.0`.
 
 Add an agent from a template.
 
-```
-forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--list]
-```
+`uv run forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--list]`
 
 | Flag | Description |
 |------|-------------|
@@ -29,48 +33,42 @@ forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--list]
 
 ```bash
 # Add a worker agent with default settings
-forge add worker
+uv run forge add worker
 
 # Add with custom ID and interval
-forge add worker --id worker-05 --interval 10m
+uv run forge add worker --id worker-05 --interval 10m
 
 # List available templates
-forge add --list
+uv run forge add --list
 ```
 
-The agent is staged in `cron-jobs.json`. Run `forge cron apply` to activate.
+The agent is staged in `cron-jobs.json`. Run `uv run forge cron apply` to activate.
 
 ### `forge remove`
 
 Remove an agent by ID.
 
-```
-forge remove AGENT_ID
-```
+`uv run forge remove AGENT_ID`
 
 ```bash
-forge remove worker-03
+uv run forge remove worker-03
 ```
 
-Removes the agent from `cron-jobs.json`. Run `forge cron apply` to deactivate.
+Removes the agent from `cron-jobs.json`. Run `uv run forge cron apply` to deactivate.
 
 ### `forge list` / `forge status`
 
 Show all agents grouped by state: staged, active, and unstaged (active but not in config).
 
-```
-forge list
-```
+`uv run forge list`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `forge cron apply`.
+Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
 
 ### `forge logs`
 
 View agent logs with color-coded output.
 
-```
-forge logs [AGENT_ID] [-f | --follow] [-n LINES]
-```
+`uv run forge logs [AGENT_ID] [-f | --follow] [-n LINES]`
 
 | Flag | Description |
 |------|-------------|
@@ -80,32 +78,30 @@ forge logs [AGENT_ID] [-f | --follow] [-n LINES]
 
 ```bash
 # View last 50 lines of all agent logs
-forge logs
+uv run forge logs
 
 # Follow a specific agent's logs
-forge logs worker-01 -f
+uv run forge logs worker-01 -f
 
 # Show last 200 lines
-forge logs -n 200
+uv run forge logs -n 200
 ```
 
 ### `forge clear`
 
 Reset staged config — remove all agents from `cron-jobs.json`.
 
-```
-forge clear [--yes | -y]
-```
+`uv run forge clear [--yes | -y]`
 
 | Flag | Description |
 |------|-------------|
 | `-y`, `--yes` | Skip confirmation prompt |
 
 ```bash
-forge clear -y
+uv run forge clear -y
 ```
 
-Run `forge cron apply` afterwards to deactivate the cleared agents.
+Run `uv run forge cron apply` afterwards to deactivate the cleared agents.
 
 ### `forge cron`
 
@@ -116,16 +112,14 @@ Manage agent cron jobs directly.
 Sync the system crontab to match `cron-jobs.json`.
 
 ```bash
-forge cron apply
+uv run forge cron apply
 ```
 
 #### `forge cron add`
 
 Add a single cron job.
 
-```
-forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]
-```
+`uv run forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]`
 
 **Arguments:**
 
@@ -145,7 +139,7 @@ forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--
 | `--repo REPO` | Target repo |
 
 ```bash
-forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
+uv run forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
 ```
 
 #### `forge cron remove`
@@ -153,7 +147,7 @@ forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDE
 Remove a cron job by ID.
 
 ```bash
-forge cron remove summary-bot
+uv run forge cron remove summary-bot
 ```
 
 #### `forge cron run`
@@ -161,7 +155,7 @@ forge cron remove summary-bot
 Run a job once immediately.
 
 ```bash
-forge cron run worker-01
+uv run forge cron run worker-01
 ```
 
 #### `forge cron clear`
@@ -169,16 +163,14 @@ forge cron run worker-01
 Remove all agent-kernel cron jobs from the system crontab.
 
 ```bash
-forge cron clear
+uv run forge cron clear
 ```
 
 ### `forge wh`
 
 Start the webhook monitor server with optional auto-tunnel.
 
-```
-forge wh [--port PORT] [--no-tunnel]
-```
+`uv run forge wh [--port PORT] [--no-tunnel]`
 
 | Flag | Description |
 |------|-------------|
@@ -187,10 +179,10 @@ forge wh [--port PORT] [--no-tunnel]
 
 ```bash
 # Start with auto-tunnel
-forge wh
+uv run forge wh
 
 # Start on a custom port without tunnel
-forge wh --port 9000 --no-tunnel
+uv run forge wh --port 9000 --no-tunnel
 ```
 
 Auto-tunnel uses `gh webhook forward` (preferred) or `ngrok` if available. Tunnel forwards GitHub events (`issues`, `pull_request`, `issue_comment`, `pull_request_review`) to the local server.

--- a/apps/webhook-monitor/README.md
+++ b/apps/webhook-monitor/README.md
@@ -1,12 +1,13 @@
 # Forge Webhook Monitor
 
-> **Note:** The primary interface is now `forge wh`. See the [Forge CLI section](../../README.md#forge-cli) in the root README.
+> **Note:** The primary interface is now `uv run forge wh`. See the [Forge CLI section](../../README.md#forge-cli) in the root README.
 
 Receives GitHub webhook events and stores them as normalized JSONL for the Forge event system.
 
 ## Prerequisites
 
 - Python 3.11+
+- `uv` installed: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - A tunnel tool: `gh webhook forward` (GitHub CLI) or [ngrok](https://ngrok.com/download)
 
 ## Setup
@@ -14,9 +15,12 @@ Receives GitHub webhook events and stores them as normalized JSONL for the Forge
 ### 1. Install the webhook server
 
 ```bash
-cd apps/webhook-monitor
-pip install -e .
+uv sync --all-packages
 ```
+
+If you prefer another install method for `uv`, see: https://docs.astral.sh/uv/getting-started/installation/
+
+If `uv` is not on `PATH` yet after installation, restart your shell or source your shell profile.
 
 ### 2. Configure
 
@@ -56,7 +60,7 @@ Environment variables still override config file values for CI/deploy:
 ### 3. Start the server
 
 ```bash
-forge wh
+uv run forge wh
 ```
 
 > `forge-webhook` still works but is deprecated.
@@ -94,9 +98,9 @@ The script tries `gh webhook forward` first, then falls back to `ngrok`.
 ## Quick start (both server + tunnel)
 
 ```bash
-forge wh
+uv run forge wh
 ```
 
 Starts the webhook server and tunnel in a single process. Press `Ctrl+C` to stop both.
 
-Use `forge wh --no-tunnel` to start only the server without the tunnel.
+Use `uv run forge wh --no-tunnel` to start only the server without the tunnel.


### PR DESCRIPTION
**@worker-02**

## Summary
- update the root README, forge-cli README, and webhook-monitor README for the repo uv workspace flow
- replace stale `pip install -e` setup guidance with `uv` install, `uv sync --all-packages`, and `uv run forge ...`
- add a short note about restarting the shell if `uv` is not yet on `PATH`

## Verification
- confirmed the three target READMEs no longer contain raw `pip install -e` instructions
- matched command examples to the uv workflow introduced in PR #769

Refs #765
