### PR TITLE
Fix webhook worktree lock detection

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -1,8 +1,6 @@
 import json
 import logging
 import os
-import re
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,25 +33,7 @@ def _matches_rule(event: dict, rule: dict) -> bool:
 
 
 def _is_agent_running(repo_dir: str, workspace_id: str) -> bool:
-    repo_root = Path(repo_dir)
-
-    # Derive GitHub path from origin remote (same logic as run.sh)
-    try:
-        origin_url = subprocess.run(
-            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError:
-        # Fallback: check root .worktrees/ (legacy path)
-        lockfile = repo_root / ".worktrees" / workspace_id / ".agent.lock"
-        return _check_lockfile(lockfile)
-
-    # Normalize SSH/HTTPS URL to github.com/owner/repo
-    github_path = re.sub(r'^(git@|https://)', '', origin_url)
-    github_path = github_path.replace(':', '/', 1)
-    github_path = re.sub(r'\.git$', '', github_path)
-
-    lockfile = repo_root / ".repos" / github_path / ".worktrees" / workspace_id / ".agent.lock"
+    lockfile = Path(repo_dir) / ".worktrees" / workspace_id / ".agent.lock"
     return _check_lockfile(lockfile)
 
 

--- a/apps/webhook-monitor/tests/test_trigger.py
+++ b/apps/webhook-monitor/tests/test_trigger.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from forge_webhook.trigger import _is_agent_running
+
+
+class TriggerLockfileTests(unittest.TestCase):
+    def test_is_agent_running_uses_repo_worktree_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lockfile = Path(tmpdir) / ".worktrees" / "worker-01" / ".agent.lock"
+            lockfile.parent.mkdir(parents=True)
+            lockfile.write_text(f"{os.getpid()}\n")
+
+            self.assertTrue(_is_agent_running(tmpdir, "worker-01"))
+
+    def test_is_agent_running_returns_false_for_stale_or_malformed_lockfiles(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale_lockfile = Path(tmpdir) / ".worktrees" / "stale-worker" / ".agent.lock"
+            stale_lockfile.parent.mkdir(parents=True)
+            stale_lockfile.write_text("999999\n")
+
+            malformed_lockfile = Path(tmpdir) / ".worktrees" / "bad-worker" / ".agent.lock"
+            malformed_lockfile.parent.mkdir(parents=True)
+            malformed_lockfile.write_text("not-a-pid\n")
+
+            self.assertFalse(_is_agent_running(tmpdir, "stale-worker"))
+            self.assertFalse(_is_agent_running(tmpdir, "bad-worker"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**@worker-01**

## Summary
- align webhook running-agent detection with the repo-local `.worktrees/<workspace>/.agent.lock` path used by `run.sh --repo <absolute-path>`
- add a regression test covering live, stale, and malformed lockfiles

## Verification
- `python3 -m unittest apps/webhook-monitor/tests/test_trigger.py`
