### PR TITLE
Docs: reconcile runtime guidance after #764 and #767

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -25,7 +25,7 @@ cp agent-kernel/.env.example agent-kernel/.env
 ## Usage
 
 ```bash
-# Tool-enabled run against a repo
+# Tool-enabled run against a repo (--repo is required)
 ./agent-kernel/run.sh --repo github.com/owner/repo "Summarize recent commits"
 
 # With context files (paths relative to repo root)
@@ -101,5 +101,6 @@ This checks connectivity and confirms your token is valid.
 1. `--context <path>` flags assemble a system prompt from context files (paths relative to repo root)
 2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
-4. Tool-enabled execution uses `--dangerously-skip-permissions` for unattended runs
-5. `--workspace <id>` runs inside an isolated git worktree at `.repos/<repo>/.worktrees/<id>`
+4. Runs are always tool-enabled; `run.sh` does not have a separate text-only or `--agentic` mode
+5. `--workspace <id>` runs inside an isolated git worktree at `<target-repo>/.worktrees/<id>`
+6. `--repo <path-or-url>` is required; GitHub repos are cloned under Forge at `.repos/<repo>`, then worktrees are created inside that target repo

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -8,6 +8,7 @@ Declarative cron management for agent-kernel. Python 3, no dependencies.
 
 ```bash
 # 1. Define jobs in cron-jobs.json
+#    Each job must set "repo"
 # 2. Sync crontab
 ./agent-kernel/cron/manage.py apply
 ```
@@ -36,7 +37,7 @@ Source of truth for desired cron state. Checked into git.
 | `id` | string | required | Unique job identifier. |
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
-| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
+| `repo` | string | required | Target repo passed through as `--repo` to `run.sh` (for example `"github.com/owner/repo"` or an absolute local path). |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
@@ -47,7 +48,7 @@ Source of truth for desired cron state. Checked into git.
 ./agent-kernel/cron/manage.py apply
 
 # Imperative — one-off add/remove
-./agent-kernel/cron/manage.py add <id> <interval> "<prompt>"
+./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" --repo github.com/owner/repo
 ./agent-kernel/cron/manage.py remove <id>
 
 # Inspect
@@ -62,6 +63,8 @@ Source of truth for desired cron state. Checked into git.
 `cron-state.json` is auto-generated and gitignored. It tracks what's actually installed in crontab so `list` works without parsing `crontab -l`.
 
 If the state file gets deleted or out of sync, just run `apply` — it reconverges.
+
+When a job includes `repo`, `run.sh` creates that job's worktree at `<target-repo>/.worktrees/<id>`.
 
 ## Logs
 


### PR DESCRIPTION
**@worker-03**

## Summary
- update agent-kernel runtime docs to match current `run.sh` and `cron/manage.py` behavior
- keep the `--repo` guidance from #767 while removing stale pre-#764 runtime wording

## Testing
- docs-only change; no automated tests run
