### PR TITLE
Docs: reconcile runtime guidance after #764 and #767

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -25,11 +25,14 @@ cp agent-kernel/.env.example agent-kernel/.env
 ## Usage
 
 ```bash
-# Tool-enabled run against a repo
+# --repo is required
 ./agent-kernel/run.sh --repo github.com/owner/repo "Summarize recent commits"
 
 # With context files (paths relative to repo root)
 ./agent-kernel/run.sh --repo github.com/owner/repo --context contexts/IDENTITY.md "Summarize recent commits"
+
+# In an isolated worktree under the target repo
+./agent-kernel/run.sh --repo github.com/owner/repo --workspace worker-01 "Check for stale PRs"
 
 # Piped
 echo "List open issues" | ./agent-kernel/run.sh --repo github.com/owner/repo
@@ -55,10 +58,15 @@ Select which contexts to include per invocation with `--context <path>` (repeata
 Cron jobs can also specify contexts in `cron-jobs.json`:
 ```json
 {
-  "id": "daily-summary",
-  "interval": "1h",
-  "prompt": "Summarize recent activity",
-  "contexts": ["contexts/IDENTITY.md"]
+  "jobs": [
+    {
+      "id": "daily-summary",
+      "interval": "1h",
+      "prompt": "Summarize recent activity",
+      "repo": "github.com/owner/repo",
+      "contexts": ["contexts/IDENTITY.md"]
+    }
+  ]
 }
 ```
 
@@ -101,5 +109,6 @@ This checks connectivity and confirms your token is valid.
 1. `--context <path>` flags assemble a system prompt from context files (paths relative to repo root)
 2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
-4. Tool-enabled execution uses `--dangerously-skip-permissions` for unattended runs
-5. `--workspace <id>` runs inside an isolated git worktree at `.repos/<repo>/.worktrees/<id>`
+4. `--repo <path-or-url>` is required; GitHub repos like `github.com/owner/repo` are cloned under Forge at `.repos/github.com/owner/repo`
+5. Tool-enabled execution uses `--dangerously-skip-permissions` for unattended runs
+6. `--workspace <id>` runs inside an isolated git worktree at `<target-repo>/.worktrees/<id>`

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -12,6 +12,8 @@ Declarative cron management for agent-kernel. Python 3, no dependencies.
 ./agent-kernel/cron/manage.py apply
 ```
 
+Each job must declare a `repo`. When a job runs with workspace isolation, `run.sh` creates the worktree at `<target-repo>/.worktrees/<id>`.
+
 ## cron-jobs.json
 
 Source of truth for desired cron state. Checked into git.
@@ -36,7 +38,7 @@ Source of truth for desired cron state. Checked into git.
 | `id` | string | required | Unique job identifier. |
 | `interval` | string | required | `Nm` (minutes) or `Nh` (hours). |
 | `prompt` | string | required | Prompt passed to `run.sh`. |
-| `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
+| `repo` | string | required | Target repo (for example `"github.com/owner/repo"` or an absolute local path). This is passed to `run.sh --repo`. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
@@ -47,7 +49,7 @@ Source of truth for desired cron state. Checked into git.
 ./agent-kernel/cron/manage.py apply
 
 # Imperative — one-off add/remove
-./agent-kernel/cron/manage.py add <id> <interval> "<prompt>"
+./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" --repo github.com/owner/repo
 ./agent-kernel/cron/manage.py remove <id>
 
 # Inspect


### PR DESCRIPTION
**@worker-04**

## Summary
- reconcile `agent-kernel/README.md` with the current runtime by making `--repo` explicit, adding a worktree example, and correcting the worktree location
- reconcile `agent-kernel/cron/README.md` by documenting `repo` as required and removing stale public guidance for `agentic` / `workspace` job fields

## Testing
- not run (docs-only change)
