### PR TITLE
Fix CLI diff/reset optional cron field normalization

### DIFF
--- a/apps/forge-cli/src/forge_cli/cron_normalization.py
+++ b/apps/forge-cli/src/forge_cli/cron_normalization.py
@@ -1,0 +1,14 @@
+"""Normalization helpers for staged/applied cron job comparisons."""
+
+OPTIONAL_CRON_FIELD_DEFAULTS = {
+    "repo": "",
+    "runtime": "claude",
+    "model": "",
+}
+
+
+def normalize_optional_cron_field(field, value):
+    """Match manage.py apply-state defaults for optional cron fields."""
+    if field in OPTIONAL_CRON_FIELD_DEFAULTS and value is None:
+        return OPTIONAL_CRON_FIELD_DEFAULTS[field]
+    return value

--- a/apps/forge-cli/src/forge_cli/diff_cmd.py
+++ b/apps/forge-cli/src/forge_cli/diff_cmd.py
@@ -5,6 +5,7 @@ import os
 
 import click
 
+from forge_cli.cron_normalization import normalize_optional_cron_field
 from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs
 
 DIFF_FIELDS = ["interval", "prompt", "contexts", "agentic", "workspace", "repo", "runtime", "model", "enabled"]
@@ -63,7 +64,10 @@ def diff_cmd():
         for field in DIFF_FIELDS:
             staged_val = _get_field(staged_jobs[agent_id], field)
             applied_val = _get_field(applied_jobs[agent_id], field)
-            if staged_val != applied_val:
+            if (
+                normalize_optional_cron_field(field, staged_val)
+                != normalize_optional_cron_field(field, applied_val)
+            ):
                 changes.append((field, applied_val, staged_val))
         if changes:
             modified[agent_id] = changes

--- a/apps/forge-cli/src/forge_cli/reset_cmd.py
+++ b/apps/forge-cli/src/forge_cli/reset_cmd.py
@@ -5,6 +5,7 @@ import os
 
 import click
 
+from forge_cli.cron_normalization import normalize_optional_cron_field
 from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, save_cron_jobs
 
 # Fields to copy from state entries back into config job entries.
@@ -138,11 +139,8 @@ def _reset_single(agent_id, applied_jobs, staged_jobs, config, jobs_path, yes):
 def _jobs_match(staged_job, applied_entry):
     """Check if a staged job matches the applied state entry."""
     for field in _CONFIG_FIELDS:
-        staged_val = staged_job.get(field)
-        applied_val = applied_entry.get(field)
-        # Normalize missing values
-        if staged_val is None and applied_val is None:
-            continue
+        staged_val = normalize_optional_cron_field(field, staged_job.get(field))
+        applied_val = normalize_optional_cron_field(field, applied_entry.get(field))
         if staged_val != applied_val:
             return False
     return True

--- a/apps/forge-cli/tests/test_cron_normalization.py
+++ b/apps/forge-cli/tests/test_cron_normalization.py
@@ -1,0 +1,126 @@
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from forge_cli.diff_cmd import diff_cmd
+from forge_cli.reset_cmd import _jobs_match, reset_cmd
+
+
+class CronNormalizationTests(unittest.TestCase):
+    def test_jobs_match_normalizes_optional_fields(self):
+        staged_job = {
+            "id": "agent-1",
+            "interval": "5m",
+            "prompt": "Test prompt",
+            "contexts": [],
+            "agentic": False,
+            "workspace": False,
+        }
+        applied_job = {
+            "interval": "5m",
+            "prompt": "Test prompt",
+            "contexts": [],
+            "agentic": False,
+            "workspace": False,
+            "repo": "",
+            "runtime": "claude",
+            "model": "",
+        }
+
+        self.assertTrue(_jobs_match(staged_job, applied_job))
+
+    def test_diff_ignores_normalized_optional_field_differences(self):
+        manage = type(
+            "Manage",
+            (),
+            {
+                "load_state": lambda self: {
+                    "jobs": {
+                        "agent-1": {
+                            "interval": "5m",
+                            "prompt": "Test prompt",
+                            "contexts": [],
+                            "agentic": False,
+                            "workspace": False,
+                            "repo": "",
+                            "runtime": "claude",
+                            "model": "",
+                            "enabled": True,
+                        }
+                    }
+                }
+            },
+        )()
+        staged_data = {
+            "jobs": [
+                {
+                    "id": "agent-1",
+                    "interval": "5m",
+                    "prompt": "Test prompt",
+                    "contexts": [],
+                    "agentic": False,
+                    "workspace": False,
+                    "enabled": True,
+                }
+            ]
+        }
+
+        runner = CliRunner()
+        with patch("forge_cli.diff_cmd._get_manage", return_value=manage), patch(
+            "forge_cli.diff_cmd.cron_jobs_path", return_value="/tmp/cron-jobs.json"
+        ), patch("forge_cli.diff_cmd.load_cron_jobs", return_value=staged_data):
+            result = runner.invoke(diff_cmd)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Config matches applied state. Nothing to diff.", result.output)
+
+    def test_reset_skips_write_for_normalized_optional_field_differences(self):
+        manage = type(
+            "Manage",
+            (),
+            {
+                "load_state": lambda self: {
+                    "jobs": {
+                        "agent-1": {
+                            "interval": "5m",
+                            "prompt": "Test prompt",
+                            "contexts": [],
+                            "agentic": False,
+                            "workspace": False,
+                            "repo": "",
+                            "runtime": "claude",
+                            "model": "",
+                        }
+                    }
+                }
+            },
+        )()
+        staged_config = {
+            "jobs": [
+                {
+                    "id": "agent-1",
+                    "interval": "5m",
+                    "prompt": "Test prompt",
+                    "contexts": [],
+                    "agentic": False,
+                    "workspace": False,
+                }
+            ]
+        }
+
+        runner = CliRunner()
+        with patch("forge_cli.reset_cmd._get_manage", return_value=manage), patch(
+            "forge_cli.reset_cmd.cron_jobs_path", return_value="/tmp/cron-jobs.json"
+        ), patch("forge_cli.reset_cmd.load_cron_jobs", return_value=staged_config), patch(
+            "forge_cli.reset_cmd.save_cron_jobs"
+        ) as save_cron_jobs:
+            result = runner.invoke(reset_cmd, ["--yes"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Config already matches applied state. Nothing to reset.", result.output)
+        save_cron_jobs.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**@worker-02**

## Summary
- normalize optional `repo`, `runtime`, and `model` fields before comparing staged jobs against applied state in `forge diff` and `forge reset`
- add focused CLI tests covering the normalized comparison behavior

## Verification
- `PYTHONPATH=apps/forge-cli/src python3 -m unittest discover -s apps/forge-cli/tests -v`
