### PR TITLE
Fix dashboard modified-state detection for agent diffs

### DIFF
--- a/apps/web/src/app/api/agents/diff/route.ts
+++ b/apps/web/src/app/api/agents/diff/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
 import { cronJobsPath, cronStatePath } from "@/lib/paths";
+import { diffAgentConfig } from "@/lib/agent-config-diff";
 
 interface CronJob {
   id: string;
@@ -44,21 +45,6 @@ interface AgentDiff {
   changes?: Record<string, FieldChange>;
 }
 
-const COMPARE_FIELDS = [
-  "interval",
-  "prompt",
-  "contexts",
-  "agentic",
-  "workspace",
-  "repo",
-  "runtime",
-  "model",
-] as const;
-
-function fieldsEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
-}
-
 export async function GET() {
   try {
     let jobs: CronJob[] = [];
@@ -96,14 +82,7 @@ export async function GET() {
 
       // Modified agents: in both but with different fields
       const applied = state.jobs[job.id];
-      const changes: Record<string, FieldChange> = {};
-      for (const field of COMPARE_FIELDS) {
-        const stagedVal = job[field];
-        const appliedVal = applied[field];
-        if (!fieldsEqual(stagedVal, appliedVal)) {
-          changes[field] = { from: appliedVal, to: stagedVal };
-        }
-      }
+      const changes = diffAgentConfig(job, applied);
       if (Object.keys(changes).length > 0) {
         agents.push({ id: job.id, status: "modified", changes });
       }

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -10,6 +10,7 @@ import {
   templatePath,
   worktreePath,
 } from "@/lib/paths";
+import { diffAgentConfig } from "@/lib/agent-config-diff";
 
 interface CronJob {
   id: string;
@@ -20,6 +21,8 @@ interface CronJob {
   workspace: boolean;
   enabled?: boolean;
   repo?: string;
+  runtime?: string;
+  model?: string;
 }
 
 interface CronState {
@@ -31,6 +34,12 @@ interface CronState {
       stagger_offset?: number;
       installed_at?: string;
       contexts?: string[];
+      prompt?: string;
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
     }
   >;
 }
@@ -167,12 +176,17 @@ export async function GET() {
       return buildAgentFromJob(job, undefined, "new");
     }
 
-    const activeInterval = jobState?.interval;
-    if (activeInterval && activeInterval !== job.interval) {
+    const changes = diffAgentConfig(job, jobState ?? {});
+    if (Object.keys(changes).length > 0) {
+      const activeInterval = jobState?.interval;
+
       // interval field shows the active (running) interval
       // stagedInterval shows what it will change to on next apply
-      const modifiedJob = { ...job, interval: activeInterval };
-      return buildAgentFromJob(modifiedJob, jobState, "modified", job.interval);
+      const modifiedJob = activeInterval ? { ...job, interval: activeInterval } : job;
+      const stagedInterval =
+        changes.interval && typeof job.interval === "string" ? job.interval : undefined;
+
+      return buildAgentFromJob(modifiedJob, jobState, "modified", stagedInterval);
     }
 
     return buildAgentFromJob(job, jobState, "active");

--- a/apps/web/src/lib/agent-config-diff.ts
+++ b/apps/web/src/lib/agent-config-diff.ts
@@ -1,0 +1,47 @@
+export interface AgentConfigFields {
+  interval?: string;
+  prompt?: string;
+  contexts?: string[];
+  agentic?: boolean;
+  workspace?: boolean;
+  repo?: string;
+  runtime?: string;
+  model?: string;
+}
+
+export interface FieldChange {
+  from: unknown;
+  to: unknown;
+}
+
+export const COMPARE_FIELDS = [
+  "interval",
+  "prompt",
+  "contexts",
+  "agentic",
+  "workspace",
+  "repo",
+  "runtime",
+  "model",
+] as const;
+
+function fieldsEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffAgentConfig(
+  staged: AgentConfigFields,
+  applied: AgentConfigFields
+): Record<string, FieldChange> {
+  const changes: Record<string, FieldChange> = {};
+
+  for (const field of COMPARE_FIELDS) {
+    const stagedVal = staged[field];
+    const appliedVal = applied[field];
+    if (!fieldsEqual(stagedVal, appliedVal)) {
+      changes[field] = { from: appliedVal, to: stagedVal };
+    }
+  }
+
+  return changes;
+}


### PR DESCRIPTION
**@worker-04**

## Summary
- align `/api/agents` modified-state detection with the existing staged-vs-applied diff field set
- reuse one shared comparison helper between the agents list and diff endpoints

## Verification
- `pnpm lint` (fails: `eslint: command not found`, `node_modules` missing in `apps/web`)
- `npm run build` (fails: `next: command not found`, `node_modules` missing in `apps/web`)

Closes #780
