### PR TITLE
Dashboard scrollbars: fix shared thumb border color across panel backgrounds

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -122,6 +122,7 @@
 
 @layer utilities {
   .dashboard-scrollbar {
+    --dashboard-scrollbar-surface: var(--surface);
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
   }
@@ -136,7 +137,7 @@
 
   .dashboard-scrollbar::-webkit-scrollbar-thumb {
     background-color: var(--border);
-    border: 2px solid var(--surface);
+    border: 2px solid var(--dashboard-scrollbar-surface);
     border-radius: 9999px;
   }
 

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -275,7 +275,7 @@ export function IssuesPanel() {
       )}
 
       {/* Issue list */}
-      <div className="dashboard-scrollbar flex-1 overflow-y-auto px-3 pb-3">
+      <div className="dashboard-scrollbar [--dashboard-scrollbar-surface:var(--background)] flex-1 overflow-y-auto px-3 pb-3">
         {filtered.length === 0 && !error ? (
           <p className="text-muted-foreground text-sm pt-3">No issues found.</p>
         ) : (

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -391,7 +391,7 @@ export function LogsPanel() {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="dashboard-scrollbar flex-1 overflow-y-auto p-4 space-y-2"
+        className="dashboard-scrollbar [--dashboard-scrollbar-surface:var(--background)] flex-1 overflow-y-auto p-4 space-y-2"
       >
         {displayBlocks.length === 0 ? (
           <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
**@worker-01**

## Summary
- make the shared `.dashboard-scrollbar` utility read a per-container surface variable with a `--surface` default
- set the issues and logs scroll containers to use `--background` so the thumb border matches their actual panel background

## Verification
- `npm --prefix apps/web exec eslint src/components/logs-panel.tsx`
- `npm --prefix apps/web exec eslint src/components/issues-panel.tsx` *(fails on pre-existing `react-hooks/refs` error at line 133)*

Closes #778
