### PR TITLE
Docs: update CLI and dashboard references for git-style workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Unified command-line interface for managing agents.
 | Command | Description |
 |---------|-------------|
 | `forge add <role>` | Add an agent from a template (worker, planner, super) |
-| `forge remove <id>` | Remove an agent |
+| `forge rm <id>` | Remove staged agents by ID |
 | `forge apply` | Sync staged agent config to live crontab |
+| `forge diff` | Show git-style staged vs applied config changes |
+| `forge reset [agent-id]` | Reset staged config to match applied state |
 | `forge run <id>` | Run an agent once immediately |
-| `forge clear` | Clear active crontab and state |
-| `forge clear --staged` | Clear only staged config |
-| `forge list` | Show all agents (staged, active, unstaged) |
-| `forge status` | Alias for `forge list` |
+| `forge clear` | Clear staged config (`cron-jobs.json`) |
+| `forge status` | Show staged changes and applied agents |
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge ui` | Start the web dashboard |
 | `forge wh` | Start webhook monitor with auto-tunnel |
@@ -66,3 +66,10 @@ If you prefer manual setup:
 3. `cd apps/web && npm install` — Install dashboard dependencies
 4. `cp agent-kernel/.env.example agent-kernel/.env` — Configure credentials
 5. `cp apps/webhook-monitor/config.example.toml apps/webhook-monitor/config.toml` — Configure webhooks
+
+Typical workflow after setup:
+1. `forge add worker` — Stage a new agent from the template
+2. `forge status` — Review staged changes and applied agents
+3. `forge diff` — Inspect field-level staged vs applied differences
+4. `forge apply` — Activate the staged config
+5. `forge reset` — Discard staged changes and restore the applied config

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,6 +28,8 @@ src/app/
     │   ├── route.ts          # GET (list) / POST (create) agents
     │   ├── apply/route.ts    # POST — run manage.py apply
     │   ├── clear/route.ts    # POST — reset staged config
+    │   ├── diff/route.ts     # GET — staged vs applied field-level diff
+    │   ├── reset/route.ts    # POST — restore staged config from applied state
     │   └── [id]/
     │       ├── route.ts      # DELETE agent
     │       └── force-run/route.ts  # POST — spawn agent run
@@ -46,7 +48,7 @@ src/app/
 | Component | File | Purpose |
 |-----------|------|---------|
 | **ResizableLayout** | `resizable-layout.tsx` | Three-panel layout: sidebar (agents), top-right (logs), bottom-right (events). Panels are resizable with drag handles and collapsible on double-click. Sizes persist to localStorage. |
-| **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (STAGED, ACTIVE, MODIFIED, ORPHAN), role badges, interval/countdown info. Supports add, delete, force-run, apply, and clear actions. Auto-refreshes every 5s. |
+| **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (NEW, ACTIVE, MODIFIED, DELETED), role badges, interval/countdown info, and branch context. Supports add, delete, force-run, apply, clear, diff, and reset actions. Auto-refreshes every 5s. |
 | **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
 | **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
 | **IssuesPanel** | `issues-panel.tsx` | Polls `/api/issues` every 10s. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert for new `role:admin` issues. |
@@ -71,18 +73,18 @@ All paths are resolved relative to the repo root via `src/lib/paths.ts`. The rep
 
 ### `GET /api/agents`
 
-Returns all agents with computed status and metadata. Reads staged config from `cron-jobs.json` and active state from `cron-state.json`. Status is derived by comparing both:
+Returns all agents with computed status and metadata. Reads staged config from `cron-jobs.json` and applied state from `cron-state.json`. Status is derived by comparing both:
 
-- **staged** — in jobs but not state
-- **active** — in both with matching interval
-- **modified** — in both but interval differs
-- **orphan** — in state but not jobs
+- **new** — in staged config but not applied state yet
+- **active** — in both with matching applied interval
+- **modified** — in both, but the staged interval differs from the running interval
+- **deleted** — in applied state but removed from staged config
 
 Running state is detected via `.agent.lock` PID files in agent worktrees.
 
 ### `POST /api/agents`
 
-Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`. Auto-generates ID as `{type}-{N}` if not provided.
+Creates a new agent. Body: `{ type: "<template-name>", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`, so any template in `templates/` is valid. Auto-generates ID as `{type}-{N}` if not provided.
 
 ### `DELETE /api/agents/[id]`
 
@@ -99,6 +101,14 @@ Runs `manage.py apply` to activate staged config changes. Returns stdout/stderr.
 ### `POST /api/agents/clear`
 
 Resets staged config to empty.
+
+### `GET /api/agents/diff`
+
+Returns a field-level staged vs applied diff for agent records. Response shape is `{ hasDiff, agents }`, where each entry is tagged as `new`, `modified`, or `deleted`.
+
+### `POST /api/agents/reset`
+
+Rebuilds staged config from the currently applied state while preserving the top-level `stagger` setting from `cron-jobs.json`.
 
 ### `GET /api/logs/[agentId]?offset={n}`
 


### PR DESCRIPTION
**@worker-03**

## Summary
- update the root README command reference to the current git-style CLI workflow
- document the staged-vs-applied diff/reset flow in the setup guidance
- update the dashboard README for the current agent statuses and diff/reset API routes

## Testing
- not run (documentation-only change)

Closes #781
