### PR TITLE
Restore planner/super no-assignment semantics

### DIFF
--- a/contexts/ASSIGNED_ISSUE.md
+++ b/contexts/ASSIGNED_ISSUE.md
@@ -8,4 +8,4 @@ Work on this issue directly instead of searching for a new one.
 3. If the issue is valid, pick it up using your normal role-specific workflow.
 4. If the issue is not valid, do not pick up different work. Stop or continue with any role-specific non-claiming duties.
 
-If `ASSIGNED_ISSUE` is not present, follow your normal role-specific intake behavior.
+If `ASSIGNED_ISSUE` is not present, defer to your role instructions for what to do without a pre-assigned issue.

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -4,6 +4,7 @@ You are a planner agent. You own the full scope of the instructions you've been 
 
 ## Role
 
+- If `ASSIGNED_ISSUE` is not present, do not search for or claim new issues on your own. Continue with non-claiming planner duties only: review existing handoffs, process `@ADMIN` feedback, monitor current epics, and maintain planning state.
 - Assess current project state before planning (read code, check open issues/PRs, read existing comments for context).
 - Break scope into concrete, parallelizable GitHub issues with clear acceptance criteria.
 - Delegate tasks — never write code yourself.

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -4,6 +4,7 @@ You are a super agent. You are the final quality gate before epic PRs reach the 
 
 ## Role
 
+- If `ASSIGNED_ISSUE` is not present, do not claim new issues. Limit yourself to non-claiming super duties such as reviewing epic PRs that already need review and running monitoring sweeps when no reviews are pending.
 - Review epic parent PRs that are labeled `status:needs-review` and `role:super`.
 - You do NOT review individual subtask PRs — planners handle those.
 - You do NOT merge anything. You either approve (hand off to admin) or reject (send back to planner).

--- a/contexts/WORKER.md
+++ b/contexts/WORKER.md
@@ -4,6 +4,7 @@ You are a worker agent. You pick up a single task, implement it completely, and 
 
 ## Role
 
+- If `ASSIGNED_ISSUE` is not present, follow the normal worker intake flow below and claim one `status:ready-for-work` + `role:worker` issue.
 - Search for one issue labeled `status:ready-for-work` and `role:worker`.
 - **Before claiming**, check the issue's comments and labels. If another agent has already commented a claim or the label is already `status:in-progress`, skip it and find another issue.
 - On claim, **immediately** relabel and comment in a single step — do this before reading the issue in detail or starting any work:

--- a/templates/planner.json
+++ b/templates/planner.json
@@ -1,7 +1,7 @@
 {
   "interval": "2m",
   "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
-  "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+  "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
   "repo": "github.com/alexjaniak/Forge"


### PR DESCRIPTION
**@worker-03**

## Summary
- restore shared assigned-issue fallback so unassigned agents defer to role-specific docs instead of always resuming intake
- add explicit no-assignment behavior for planner and super roles while keeping worker claim flow intact
- align `templates/planner.json` with planner cron context assembly by including `contexts/REVIEWER.md`

## Verification
- compared the edited docs and template diff
- verified `templates/planner.json` now matches every planner job in `agent-kernel/cron/cron-jobs.json`
