### PR TITLE
Cron: enforce required repo in manage.py

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -77,6 +77,13 @@ def validate_model(model):
         sys.exit(1)
 
 
+def require_repo(repo, context):
+    if not isinstance(repo, str) or not repo.strip():
+        print(f"Error: {context} requires a non-empty repo", file=sys.stderr)
+        sys.exit(1)
+    return repo.strip()
+
+
 
 def build_cron_command(job_id, prompt, contexts=None, repo=None, runtime=None, model=None):
     runtime = runtime or "claude"
@@ -243,6 +250,7 @@ def cmd_apply(args):
     for job in config.get("jobs", []):
         if job.get("enabled", True):
             desired[job["id"]] = job
+            job["repo"] = require_repo(job.get("repo"), f"job '{job['id']}'")
 
     # Compute stagger offsets when enabled
     stagger_offsets = {}
@@ -286,12 +294,12 @@ def cmd_apply(args):
     for job_id in sorted(to_add | to_update):
         job = desired[job_id]
         contexts = job.get("contexts", [])
-        repo = job.get("repo", "")
+        repo = job["repo"]
         runtime = job.get("runtime", "claude")
         model = job.get("model", "")
         validate_runtime(runtime)
         validate_model(model)
-        command = build_cron_command(job_id, job["prompt"], contexts, repo or None, runtime, model or None)
+        command = build_cron_command(job_id, job["prompt"], contexts, repo, runtime, model or None)
 
         offset = stagger_offsets.get(job_id, 0)
         if stagger and offset > 0:
@@ -348,8 +356,8 @@ def cmd_add(args):
 
     cron_expr = parse_interval(args.interval)
     contexts = args.context or []
-    repo = args.repo or ""
-    command = build_cron_command(args.id, args.prompt, contexts, repo or None, runtime, model or None)
+    repo = require_repo(args.repo, f"job '{args.id}'")
+    command = build_cron_command(args.id, args.prompt, contexts, repo, runtime, model or None)
 
     crontab = read_crontab()
     crontab = add_job_to_crontab(crontab, args.id, cron_expr, command)
@@ -539,7 +547,7 @@ def main():
     p_add.add_argument("interval", help="Interval: Nm or Nh")
     p_add.add_argument("prompt", help="Prompt for run.sh")
     p_add.add_argument("--context", action="append", help="Context file path relative to repo root (repeatable)")
-    p_add.add_argument("--repo", help="Target repo (e.g. github.com/owner/repo or absolute path)")
+    p_add.add_argument("--repo", required=True, help="Target repo (e.g. github.com/owner/repo or absolute path)")
     p_add.add_argument("--runtime", default="claude", help="Agent runtime: claude or codex (default: claude)")
     p_add.add_argument("--model", default="", help="Explicit model override (e.g. gpt-5.4)")
 

--- a/agent-kernel/cron/test_manage.py
+++ b/agent-kernel/cron/test_manage.py
@@ -1,0 +1,69 @@
+import argparse
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).with_name("manage.py")
+SPEC = importlib.util.spec_from_file_location("agent_kernel_cron_manage", MODULE_PATH)
+manage = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(manage)
+
+
+class ManageRepoValidationTests(unittest.TestCase):
+    def test_add_requires_non_empty_repo(self):
+        args = argparse.Namespace(
+            id="worker-01",
+            interval="5m",
+            prompt="run",
+            context=[],
+            repo="   ",
+            runtime="claude",
+            model="",
+        )
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as exc:
+            manage.cmd_add(args)
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("job 'worker-01' requires a non-empty repo", stderr.getvalue())
+
+    def test_apply_rejects_job_without_repo(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jobs_file = Path(tmpdir) / "cron-jobs.json"
+            jobs_file.write_text(json.dumps({
+                "jobs": [
+                    {
+                        "id": "worker-01",
+                        "interval": "5m",
+                        "prompt": "run",
+                    }
+                ]
+            }))
+
+            stderr = io.StringIO()
+            with (
+                patch.object(manage, "JOBS_FILE", str(jobs_file)),
+                patch.object(manage, "load_state", return_value={"jobs": {}, "last_applied": None}),
+                patch.object(manage, "read_crontab", return_value=""),
+                patch.object(manage, "write_crontab") as write_crontab,
+                patch.object(manage, "save_state") as save_state,
+                redirect_stderr(stderr),
+                self.assertRaises(SystemExit) as exc,
+            ):
+                manage.cmd_apply(argparse.Namespace())
+
+            self.assertEqual(exc.exception.code, 1)
+            self.assertIn("job 'worker-01' requires a non-empty repo", stderr.getvalue())
+            write_crontab.assert_not_called()
+            save_state.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**@worker-01**

## Summary
Enforce the cron manager's required `repo` contract so it matches `run.sh`.

## What Changed
- require a non-empty `repo` for every enabled `cron-jobs.json` entry during `apply`
- require `--repo` for `manage.py add` and reject blank values consistently
- add regression tests covering both failure paths

## Verification
- `python3 -m unittest agent-kernel/cron/test_manage.py`
- `python3 agent-kernel/cron/manage.py add worker-01 5m "run"`
- `python3 /tmp/.../manage.py apply` against a temp `cron-jobs.json` without `repo` (manual check)
