### PR TITLE
Fix web agent diff optional-field normalization

### DIFF
--- a/apps/web/src/app/api/agents/diff/route.ts
+++ b/apps/web/src/app/api/agents/diff/route.ts
@@ -37,11 +37,6 @@ interface CronState {
 
 type DiffStatus = "new" | "modified" | "deleted";
 
-interface FieldChange {
-  from: unknown;
-  to: unknown;
-}
-
 interface AgentDiff {
   id: string;
   status: DiffStatus;

--- a/apps/web/src/lib/agent-config-diff.ts
+++ b/apps/web/src/lib/agent-config-diff.ts
@@ -25,6 +25,26 @@ export const COMPARE_FIELDS = [
   "model",
 ] as const;
 
+const OPTIONAL_FIELD_DEFAULTS = {
+  repo: "",
+  runtime: "claude",
+  model: "",
+} as const;
+
+function normalizeOptionalField(
+  field: keyof AgentConfigFields,
+  value: unknown
+): unknown {
+  if (
+    Object.prototype.hasOwnProperty.call(OPTIONAL_FIELD_DEFAULTS, field) &&
+    value === undefined
+  ) {
+    return OPTIONAL_FIELD_DEFAULTS[field as keyof typeof OPTIONAL_FIELD_DEFAULTS];
+  }
+
+  return value;
+}
+
 function fieldsEqual(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
@@ -36,8 +56,8 @@ export function diffAgentConfig(
   const changes: Record<string, FieldChange> = {};
 
   for (const field of COMPARE_FIELDS) {
-    const stagedVal = staged[field];
-    const appliedVal = applied[field];
+    const stagedVal = normalizeOptionalField(field, staged[field]);
+    const appliedVal = normalizeOptionalField(field, applied[field]);
     if (!fieldsEqual(stagedVal, appliedVal)) {
       changes[field] = { from: appliedVal, to: stagedVal };
     }


### PR DESCRIPTION
**@worker-05**

## Summary
Normalize optional `repo`, `runtime`, and `model` fields in the shared web agent diff helper so `/api/agents` and `/api/agents/diff` match the CLI/backend dirty-state semantics.

## Validation
- `npm run build` in `apps/web`
- `npm run lint` in `apps/web` still reports pre-existing errors in unrelated components (`issues-panel.tsx`, `resizable-layout.tsx`)
