### PR TITLE
Fix planner/super no-assignment fallback wording

### DIFF
--- a/contexts/ASSIGNED_ISSUE.md
+++ b/contexts/ASSIGNED_ISSUE.md
@@ -8,4 +8,5 @@ Work on this issue directly instead of searching for a new one.
 3. If the issue is valid, pick it up using your normal role-specific workflow.
 4. If the issue is not valid, do not pick up different work. Stop or continue with any role-specific non-claiming duties.
 
-If `ASSIGNED_ISSUE` is not present, defer to your role instructions for what to do without a pre-assigned issue.
+If `ASSIGNED_ISSUE` is not present, follow your role-specific instructions for runs without a pre-assigned issue.
+Workers may use their normal claim flow. Planners and supers may continue only with role-specific non-claiming duties.

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -4,7 +4,7 @@ You are a planner agent. You own the full scope of the instructions you've been 
 
 ## Role
 
-- If `ASSIGNED_ISSUE` is not present, do not search for or claim new issues on your own. Continue with non-claiming planner duties only: review existing handoffs, process `@ADMIN` feedback, monitor current epics, and maintain planning state.
+- If `ASSIGNED_ISSUE` is not present, do not search for or claim new issues on your own. For runs without a pre-assigned issue, continue with non-claiming planner duties only: review existing handoffs, process `@ADMIN` feedback, monitor current epics, and maintain planning state.
 - Assess current project state before planning (read code, check open issues/PRs, read existing comments for context).
 - Break scope into concrete, parallelizable GitHub issues with clear acceptance criteria.
 - Delegate tasks — never write code yourself.

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -4,7 +4,7 @@ You are a super agent. You are the final quality gate before epic PRs reach the 
 
 ## Role
 
-- If `ASSIGNED_ISSUE` is not present, do not claim new issues. Limit yourself to non-claiming super duties such as reviewing epic PRs that already need review and running monitoring sweeps when no reviews are pending.
+- If `ASSIGNED_ISSUE` is not present, do not claim new issues. For runs without a pre-assigned issue, limit yourself to non-claiming super duties such as reviewing epic PRs that already need review and running monitoring sweeps when no reviews are pending.
 - Review epic parent PRs that are labeled `status:needs-review` and `role:super`.
 - You do NOT review individual subtask PRs — planners handle those.
 - You do NOT merge anything. You either approve (hand off to admin) or reject (send back to planner).


### PR DESCRIPTION
**@worker-05**

## Summary
- align the shared assigned-issue guidance with the existing planner/super no-claim fallback
- make the planner and super role bullets explicitly describe runs without a pre-assigned issue

## Testing
- not run (context/docs-only change)
