### PR TITLE
CLI/docs: rebase #757 onto epic/738 and preserve runtime guidance fixes

### DIFF
--- a/agent-kernel/README.md
+++ b/agent-kernel/README.md
@@ -32,7 +32,7 @@ cp agent-kernel/.env.example agent-kernel/.env
 ./agent-kernel/run.sh --repo github.com/owner/repo --context contexts/IDENTITY.md "Summarize recent commits"
 
 # In an isolated worktree under the target repo
-./agent-kernel/run.sh --repo github.com/owner/repo --workspace worker-01 "Check for stale PRs"
+./agent-kernel/run.sh --repo github.com/owner/repo --workspace worker-01 --context contexts/IDENTITY.md "Check for stale PRs and comment on them"
 
 # Piped
 echo "List open issues" | ./agent-kernel/run.sh --repo github.com/owner/repo
@@ -110,5 +110,6 @@ This checks connectivity and confirms your token is valid.
 2. System prompt is passed via `--append-system-prompt` (preserves Claude's built-in capabilities)
 3. Your prompt goes as the message argument
 4. `--repo <path-or-url>` is required; GitHub repos like `github.com/owner/repo` are cloned under Forge at `.repos/github.com/owner/repo`
-5. Tool-enabled execution uses `--dangerously-skip-permissions` for unattended runs
-6. `--workspace <id>` runs inside an isolated git worktree at `<target-repo>/.worktrees/<id>`
+5. `--dangerously-skip-permissions` is on by default for unattended runs
+6. One-shot runs default to text-only `--print`; pass `--agentic` when you want tool access directly
+7. Forge-managed cron and template runs enable tool access automatically and use `--workspace <id>` under `<target-repo>/.worktrees/<id>`

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -12,7 +12,7 @@ Declarative cron management for agent-kernel. Python 3, no dependencies.
 ./agent-kernel/cron/manage.py apply
 ```
 
-Each job must declare a `repo`. When a job runs with workspace isolation, `run.sh` creates the worktree at `<target-repo>/.worktrees/<id>`.
+Each job must declare a `repo`. Managed cron jobs always run with tool access in an isolated git worktree at `<target-repo>/.worktrees/<id>`.
 
 ## cron-jobs.json
 
@@ -41,6 +41,8 @@ Source of truth for desired cron state. Checked into git.
 | `repo` | string | required | Target repo (for example `"github.com/owner/repo"` or an absolute local path). This is passed to `run.sh --repo`. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
+
+Managed cron jobs always run with tool access in an isolated worktree named after the job ID under the target repo, so those runtime behaviors are no longer configured per job.
 
 ## Commands
 

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -124,7 +124,7 @@ forge cron apply
 Add a single cron job.
 
 ```
-forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]
+forge cron add ID INTERVAL PROMPT [--context TEXT] --repo REPO
 ```
 
 **Arguments:**
@@ -139,14 +139,14 @@ forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--
 
 | Flag | Description |
 |------|-------------|
-| `--agentic` | Enable tool use |
-| `--workspace` | Run in isolated git worktree |
 | `--context TEXT` | Context file path (repeatable) |
 | `--repo REPO` | Target repo |
 
 ```bash
-forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
+forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md --repo github.com/owner/repo
 ```
+
+Forge-managed cron jobs always run with tool access in an isolated worktree named after the job ID under the target repo, so those runtime behaviors are no longer exposed as flags.
 
 #### `forge cron remove`
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling and execution settings.
+JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling metadata and the target repo.
 
 ## Template format
 
@@ -31,3 +31,5 @@ JSON files that define the runtime configuration for each agent role. Each templ
 ## Usage
 
 Templates are loaded by the Forge CLI (`apps/forge-cli`) and web dashboard (`apps/web`) to launch agent runs via `agent-kernel/run.sh`.
+
+Forge-managed agents always run with tool access in isolated worktrees under the target repo. Templates no longer expose separate booleans for those runtime behaviors.


### PR DESCRIPTION
**@worker-05**

## Summary
- refresh the CLI and README wording for the current managed runtime contract on `epic/738-agentic-workspace-always-true`
- remove stale `forge cron add` flags and align examples with required `--repo` usage
- clarify that managed cron/template runs always use tool access plus isolated worktrees under the target repo

## Verification
- docs-only change; verified with `git diff` and targeted `rg` scans of the touched docs

Replaces the conflicted change set from #757.
