### PR TITLE
Add cron manager kill backend for managed runs

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -232,19 +232,38 @@ def add_job_to_crontab(crontab, job_id, cron_expr, command):
     return entry
 
 
-def _workspace_lock_path(job_id):
-    return os.path.join(REPO_DIR, ".worktrees", job_id, ".agent.lock")
+def _resolve_work_repo_dir(repo):
+    if not repo:
+        return REPO_DIR
+    if os.path.isabs(repo):
+        return repo
+    if repo.startswith("github.com/"):
+        return os.path.join(REPO_DIR, ".repos", repo)
+    return repo
 
 
-def _list_workspace_ids():
-    worktrees_dir = os.path.join(REPO_DIR, ".worktrees")
+def _workspace_lock_path(job_id, repo=""):
+    return os.path.join(_resolve_work_repo_dir(repo), ".worktrees", job_id, ".agent.lock")
+
+
+def _list_workspace_ids(repo=""):
+    worktrees_dir = os.path.join(_resolve_work_repo_dir(repo), ".worktrees")
     if not os.path.isdir(worktrees_dir):
         return []
     job_ids = []
     for entry in os.listdir(worktrees_dir):
-        if os.path.isfile(_workspace_lock_path(entry)):
+        if os.path.isfile(_workspace_lock_path(entry, repo)):
             job_ids.append(entry)
     return sorted(job_ids)
+
+
+def _configured_workspace_jobs():
+    state = load_state()
+    jobs = []
+    for job_id, info in state.get("jobs", {}).items():
+        if info.get("workspace"):
+            jobs.append((job_id, info.get("repo", "")))
+    return jobs
 
 
 def _read_lock_pid(lock_path):
@@ -355,10 +374,17 @@ def _matches_managed_run(job_id, pid, command):
 
 
 def find_managed_runs(agent_id=None):
-    job_ids = [agent_id] if agent_id else _list_workspace_ids()
+    if agent_id:
+        configured_jobs = dict(_configured_workspace_jobs())
+        job_refs = [(agent_id, configured_jobs.get(agent_id, ""))]
+    else:
+        job_refs = _configured_workspace_jobs()
+        if not job_refs:
+            job_refs = [(job_id, "") for job_id in _list_workspace_ids()]
+
     runs = []
-    for job_id in job_ids:
-        lock_path = _workspace_lock_path(job_id)
+    for job_id, repo in job_refs:
+        lock_path = _workspace_lock_path(job_id, repo)
         pid = _read_lock_pid(lock_path)
         if pid is None:
             continue

--- a/tests/test_manage_kill.py
+++ b/tests/test_manage_kill.py
@@ -15,6 +15,17 @@ spec.loader.exec_module(manage)
 
 
 class ManageKillTests(unittest.TestCase):
+    def test_workspace_lock_path_uses_target_repo_root(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"):
+            lock_path = manage._workspace_lock_path(
+                "worker-02", "github.com/alexjaniak/Forge"
+            )
+
+        self.assertEqual(
+            lock_path,
+            "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock",
+        )
+
     def test_parse_run_command_extracts_workspace_and_repo(self):
         command = (
             "/bin/bash /tmp/forge/agent-kernel/run.sh --agentic "
@@ -54,6 +65,8 @@ class ManageKillTests(unittest.TestCase):
 
     def test_find_managed_runs_filters_out_stale_and_non_matching_processes(self):
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage, "_configured_workspace_jobs", return_value=[]
+        ), patch.object(
             manage, "_list_workspace_ids", return_value=["worker-02", "worker-03", "worker-04"]
         ), patch.object(
             manage,
@@ -85,8 +98,80 @@ class ManageKillTests(unittest.TestCase):
             ],
         )
 
+    def test_find_managed_runs_uses_configured_repo_root_for_targeted_kill(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage,
+            "_configured_workspace_jobs",
+            return_value=[("worker-02", "github.com/alexjaniak/Forge")],
+        ), patch.object(
+            manage,
+            "_read_lock_pid",
+            side_effect=lambda path: {
+                "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock": 101,
+            }.get(path),
+        ), patch.object(
+            manage,
+            "_read_process_command",
+            return_value="/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+        ):
+            runs = manage.find_managed_runs(agent_id="worker-02")
+
+        self.assertEqual(
+            runs,
+            [
+                {
+                    "agent_id": "worker-02",
+                    "pid": 101,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+                }
+            ],
+        )
+
+    def test_find_managed_runs_scans_configured_repo_roots_for_bulk_kill(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage,
+            "_configured_workspace_jobs",
+            return_value=[
+                ("worker-02", "github.com/alexjaniak/Forge"),
+                ("worker-03", "/tmp/other-repo"),
+            ],
+        ), patch.object(
+            manage,
+            "_read_lock_pid",
+            side_effect=lambda path: {
+                "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock": 101,
+                "/tmp/other-repo/.worktrees/worker-03/.agent.lock": 202,
+            }.get(path),
+        ), patch.object(
+            manage,
+            "_read_process_command",
+            side_effect=lambda pid: {
+                101: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+                202: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 --repo /tmp/other-repo 'prompt'",
+            }.get(pid),
+        ):
+            runs = manage.find_managed_runs()
+
+        self.assertEqual(
+            runs,
+            [
+                {
+                    "agent_id": "worker-02",
+                    "pid": 101,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+                },
+                {
+                    "agent_id": "worker-03",
+                    "pid": 202,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 --repo /tmp/other-repo 'prompt'",
+                },
+            ],
+        )
+
     def test_find_managed_runs_rejects_reused_pid_from_other_checkout(self):
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage, "_configured_workspace_jobs", return_value=[]
+        ), patch.object(
             manage, "_list_workspace_ids", return_value=["worker-02"]
         ), patch.object(
             manage,


### PR DESCRIPTION
**@worker-02**

## Summary
- add managed-run discovery and kill helpers in `agent-kernel/cron/manage.py`
- validate lock-file PIDs still belong to this repo's `agent-kernel/run.sh --workspace <job-id>` processes before terminating them
- add focused backend tests for parsing, filtering, and kill reporting

## Testing
- `python3 -m unittest tests/test_manage_kill.py`
