### PR TITLE
Tighten cron kill process attribution

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -272,6 +272,23 @@ def _read_process_command(pid):
     return command or None
 
 
+def _read_process_cwd(pid):
+    result = subprocess.run(
+        ["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        if line.startswith("n"):
+            cwd = line[1:].strip()
+            return cwd or None
+    return None
+
+
 def _parse_run_command(command):
     try:
         argv = shlex.split(command)
@@ -318,10 +335,17 @@ def _matches_managed_run(job_id, pid, command):
         return None
 
     run_path = parsed["run_path"]
-    if os.path.isabs(run_path) and os.path.normpath(run_path) != os.path.join(REPO_DIR, "agent-kernel", "run.sh"):
-        return None
     if parsed["workspace_id"] != job_id:
         return None
+
+    expected_run_path = os.path.join(REPO_DIR, "agent-kernel", "run.sh")
+    if os.path.isabs(run_path):
+        if os.path.normpath(run_path) != expected_run_path:
+            return None
+    else:
+        cwd = _read_process_cwd(pid)
+        if os.path.normpath(cwd or "") != REPO_DIR:
+            return None
 
     return {
         "agent_id": job_id,

--- a/tests/test_manage_kill.py
+++ b/tests/test_manage_kill.py
@@ -27,6 +27,31 @@ class ManageKillTests(unittest.TestCase):
         self.assertEqual(parsed["workspace_id"], "worker-02")
         self.assertEqual(parsed["repo"], "github.com/alexjaniak/Forge")
 
+    def test_matches_managed_run_accepts_absolute_repo_run_path(self):
+        command = "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 'prompt'"
+
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"):
+            run = manage._matches_managed_run("worker-02", 101, command)
+
+        self.assertEqual(
+            run,
+            {
+                "agent_id": "worker-02",
+                "pid": 101,
+                "command": command,
+            },
+        )
+
+    def test_matches_managed_run_requires_repo_cwd_for_relative_run_path(self):
+        command = "/bin/bash ./agent-kernel/run.sh --workspace worker-02 'prompt'"
+
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage, "_read_process_cwd", return_value="/tmp/other"
+        ):
+            run = manage._matches_managed_run("worker-02", 101, command)
+
+        self.assertIsNone(run)
+
     def test_find_managed_runs_filters_out_stale_and_non_matching_processes(self):
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
             manage, "_list_workspace_ids", return_value=["worker-02", "worker-03", "worker-04"]
@@ -59,6 +84,26 @@ class ManageKillTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_find_managed_runs_rejects_reused_pid_from_other_checkout(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage, "_list_workspace_ids", return_value=["worker-02"]
+        ), patch.object(
+            manage,
+            "_read_lock_pid",
+            return_value=101,
+        ), patch.object(
+            manage,
+            "_read_process_command",
+            return_value="/bin/bash ./agent-kernel/run.sh --workspace worker-02 'prompt'",
+        ), patch.object(
+            manage,
+            "_read_process_cwd",
+            return_value="/tmp/other-checkout",
+        ):
+            runs = manage.find_managed_runs()
+
+        self.assertEqual(runs, [])
 
     def test_kill_managed_runs_returns_killed_runs(self):
         runs = [


### PR DESCRIPTION
**@worker-02**

## Summary
- tighten managed-run matching so relative `./agent-kernel/run.sh` commands must also have this repo as their current working directory
- keep support for the existing absolute-path `cmd_run()` shape and add regression tests for stale lock / reused PID collisions

## Testing
- `python3 -m unittest tests/test_manage_kill.py`
