### PR TITLE
Integrate main into Issues tab canonical filters branch

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -49,7 +49,7 @@ src/app/
 | **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (STAGED, ACTIVE, MODIFIED, ORPHAN), role badges, interval/countdown info. Supports add, delete, force-run, apply, and clear actions. Auto-refreshes every 5s. |
 | **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
 | **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
-| **IssuesPanel** | `issues-panel.tsx` | Polls `/api/issues` every 10s. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert for new `role:admin` issues. |
+| **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert only when an issue newly gains `role:admin`. |
 
 ### Data Flow
 
@@ -60,7 +60,8 @@ agent-kernel/cron/cron-jobs.json  → GET /api/agents       → AgentPanel
 agent-kernel/cron/cron-state.json → GET /api/agents       → AgentPanel
 agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
-gh issue list (via CLI)             → GET /api/issues       → IssuesPanel
+gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
+GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
 templates/{type}.json             → POST /api/agents      → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
@@ -113,8 +114,11 @@ Server-Sent Events endpoint for live log streaming. Uses `fs.watch()` on log fil
 Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed from newline-delimited JSON.
 
 ### `GET /api/issues`
-
 Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, labels, repo }`, where `labels` is the canonical `status`, `role`, and `type` label set parsed from `contexts/LABELS.md` so the Issues tab can render filter chips even when a label has zero open matches.
+
+### `GET /api/issues/stream`
+
+Server-Sent Events endpoint for live issue snapshots. Sends an initial `{ issues, labels, repo }` snapshot immediately on connect, then emits updated snapshots when the GitHub event feed changes in ways that affect the Issues tab. The frontend falls back to polling `GET /api/issues` if the stream disconnects.
 
 ## Environment Variables
 

--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,54 +1,11 @@
-import { execSync } from "child_process";
 import { NextResponse } from "next/server";
-import { readCanonicalIssueLabels } from "@/lib/github-labels";
-import { getForgeRoot } from "@/lib/paths";
-
-let cache:
-  | {
-      issues: unknown[];
-      labels: ReturnType<typeof readCanonicalIssueLabels>;
-      repo: string;
-      ts: number;
-    }
-  | null = null;
-const TTL = 5000;
+import { getIssueSnapshot } from "@/lib/issues";
 
 export async function GET() {
-  const now = Date.now();
-  if (cache && now - cache.ts < TTL) {
-    return NextResponse.json({
-      issues: cache.issues,
-      labels: cache.labels,
-      repo: cache.repo,
-    });
-  }
-
-  const cwd = getForgeRoot();
-  const labels = readCanonicalIssueLabels();
-
-  let issues: unknown[] = [];
-  let repo = "";
-
   try {
-    const raw = execSync(
-      "gh issue list --state open --json number,title,labels,assignees --limit 100",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    );
-    issues = JSON.parse(raw);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return NextResponse.json({ issues: [], labels, repo: "", error: msg });
+    return NextResponse.json(await getIssueSnapshot());
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ issues: [], labels: { status: [], role: [], type: [] }, repo: "", error: msg });
   }
-
-  try {
-    repo = execSync(
-      "gh repo view --json nameWithOwner -q '.nameWithOwner'",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    ).trim();
-  } catch {
-    // non-fatal — links just won't work
-  }
-
-  cache = { issues, labels, repo, ts: now };
-  return NextResponse.json({ issues, labels, repo });
 }

--- a/apps/web/src/app/api/issues/stream/route.ts
+++ b/apps/web/src/app/api/issues/stream/route.ts
@@ -1,0 +1,221 @@
+import fs from "fs";
+import path from "path";
+import { eventsPath } from "@/lib/paths";
+import { getIssueSnapshot, invalidateIssueSnapshot } from "@/lib/issues";
+
+const KEEPALIVE_MS = 15000;
+const ISSUE_EVENT_PREFIX = "issue.";
+
+export const dynamic = "force-dynamic";
+
+function encodeSse(event: string, payload: unknown): Uint8Array {
+  const encoder = new TextEncoder();
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+function isRelevantIssueEvent(line: string): boolean {
+  try {
+    const parsed = JSON.parse(line) as { event_type?: unknown };
+    return (
+      typeof parsed.event_type === "string" &&
+      parsed.event_type.startsWith(ISSUE_EVENT_PREFIX)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request: Request) {
+  const filePath = eventsPath();
+  const dirPath = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+
+  let fileWatcher: fs.FSWatcher | null = null;
+  let dirWatcher: fs.FSWatcher | null = null;
+  let keepalive: NodeJS.Timeout | null = null;
+  let closed = false;
+  let offset = 0;
+  let pendingLine = "";
+  let snapshotInFlight = false;
+  let snapshotQueued = false;
+
+  function cleanup() {
+    if (closed) return;
+    closed = true;
+
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      fileWatcher = null;
+    }
+
+    if (dirWatcher) {
+      try {
+        dirWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      dirWatcher = null;
+    }
+  }
+
+  async function sendSnapshot(
+    controller: ReadableStreamDefaultController,
+    forceRefresh: boolean
+  ) {
+    if (closed) return;
+    if (snapshotInFlight) {
+      snapshotQueued = snapshotQueued || forceRefresh;
+      return;
+    }
+
+    snapshotInFlight = true;
+    let nextForceRefresh = forceRefresh;
+
+    try {
+      do {
+        const shouldForceRefresh = nextForceRefresh || snapshotQueued;
+        snapshotQueued = false;
+        nextForceRefresh = false;
+
+        try {
+          const snapshot = await getIssueSnapshot({
+            forceRefresh: shouldForceRefresh,
+          });
+          if (closed) return;
+          controller.enqueue(encodeSse("snapshot", snapshot));
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (closed) return;
+          controller.enqueue(
+            encodeSse("snapshot", { issues: [], repo: "", error: message })
+          );
+        }
+      } while (snapshotQueued);
+    } finally {
+      snapshotInFlight = false;
+    }
+  }
+
+  function watchFile(onChange: () => void) {
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+
+    try {
+      fileWatcher = fs.watch(filePath, () => {
+        onChange();
+      });
+    } catch {
+      fileWatcher = null;
+    }
+  }
+
+  function readRelevantChanges(): boolean {
+    let fileSize = 0;
+    try {
+      fileSize = fs.statSync(filePath).size;
+    } catch {
+      offset = 0;
+      pendingLine = "";
+      return false;
+    }
+
+    if (offset > fileSize) {
+      offset = 0;
+      pendingLine = "";
+    }
+
+    if (offset === fileSize) {
+      return false;
+    }
+
+    const bytesToRead = fileSize - offset;
+    const fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(bytesToRead);
+
+    try {
+      fs.readSync(fd, buffer, 0, bytesToRead, offset);
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    offset = fileSize;
+    const chunk = pendingLine + buffer.toString("utf-8");
+    const lines = chunk.split("\n");
+    pendingLine = lines.pop() ?? "";
+
+    return lines.some((line) => line.trim() !== "" && isRelevantIssueEvent(line));
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      try {
+        fs.mkdirSync(dirPath, { recursive: true });
+      } catch {
+        // ignore setup errors
+      }
+
+      try {
+        offset = fs.statSync(filePath).size;
+      } catch {
+        offset = 0;
+      }
+
+      const handleChange = () => {
+        if (!readRelevantChanges()) {
+          return;
+        }
+        invalidateIssueSnapshot();
+        void sendSnapshot(controller, true);
+      };
+
+      watchFile(handleChange);
+
+      try {
+        dirWatcher = fs.watch(dirPath, (_eventType, filename) => {
+          if (filename && filename !== fileName) {
+            return;
+          }
+          watchFile(handleChange);
+          handleChange();
+        });
+      } catch {
+        dirWatcher = null;
+      }
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+      }, KEEPALIVE_MS);
+
+      void sendSnapshot(controller, false);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  request.signal.addEventListener("abort", cleanup, { once: true });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { CanonicalIssueLabels } from "@/lib/github-labels";
 
+const POLL_INTERVAL = 5000;
+
 interface Issue {
   number: number;
   title: string;
@@ -172,49 +174,79 @@ export function IssuesPanel() {
   });
   const prevIssuesRef = useRef<Issue[]>([]);
   const initialLoadRef = useRef(true);
-  const mutedRef = useRef(muted);
+  const mutedRef = useRef<boolean>(muted);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const fallbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     mutedRef.current = muted;
   }, [muted]);
 
-  const fetchIssues = useCallback(async () => {
-    try {
-      const res = await fetch("/api/issues");
-      const data = await res.json();
+  const applySnapshot = useCallback(
+    (data: {
+      issues?: Issue[];
+      labels?: CanonicalIssueLabels;
+      repo?: string;
+      error?: string;
+    }) => {
       if (data.error) setError(data.error);
       else setError("");
-      const newIssues: Issue[] = data.issues ?? [];
+
+      const newIssues = data.issues ?? [];
       setIssues(newIssues);
       if (data.labels) setLabels(data.labels);
-      if (data.repo) setRepo(data.repo);
+      if (typeof data.repo === "string") {
+        setRepo(data.repo);
+      }
 
-      // Skip alert on initial load
       if (initialLoadRef.current) {
         initialLoadRef.current = false;
         prevIssuesRef.current = newIssues;
         return;
       }
 
-      // Detect newly-added role:admin labels
       if (!mutedRef.current) {
         const prevAdminIds = new Set(
           prevIssuesRef.current
-            .filter((i) => i.labels.some((l) => l.name === "role:admin"))
-            .map((i) => i.number)
+            .filter((issue) =>
+              issue.labels.some((label) => label.name === "role:admin")
+            )
+            .map((issue) => issue.number)
         );
-        const newAdminIssues = newIssues.filter(
-          (i) =>
-            i.labels.some((l) => l.name === "role:admin") &&
-            !prevAdminIds.has(i.number)
+        const hasNewAdminIssue = newIssues.some(
+          (issue) =>
+            issue.labels.some((label) => label.name === "role:admin") &&
+            !prevAdminIds.has(issue.number)
         );
-        if (newAdminIssues.length > 0) {
+        if (hasNewAdminIssue) {
           playAdminAlert();
         }
       }
+
       prevIssuesRef.current = newIssues;
+    },
+    []
+  );
+
+  const fetchIssues = useCallback(async () => {
+    try {
+      const res = await fetch("/api/issues");
+      const data = await res.json();
+      applySnapshot(data);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Fetch failed");
+    }
+  }, [applySnapshot]);
+
+  const startFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) return;
+    fallbackTimerRef.current = setInterval(fetchIssues, POLL_INTERVAL);
+  }, [fetchIssues]);
+
+  const stopFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearInterval(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
     }
   }, []);
 
@@ -222,12 +254,37 @@ export function IssuesPanel() {
     const initialFetchId = window.setTimeout(() => {
       void fetchIssues();
     }, 0);
-    const id = setInterval(fetchIssues, 5000);
+
+    const es = new EventSource("/api/issues/stream");
+    eventSourceRef.current = es;
+
+    const handleSnapshot = (event: MessageEvent<string>) => {
+      try {
+        applySnapshot(JSON.parse(event.data));
+      } catch {
+        setError("Invalid issue stream payload");
+      }
+    };
+
+    es.onmessage = handleSnapshot;
+    es.addEventListener("snapshot", handleSnapshot as EventListener);
+
+    es.onerror = () => {
+      startFallbackPolling();
+    };
+
+    es.onopen = () => {
+      stopFallbackPolling();
+    };
+
     return () => {
       window.clearTimeout(initialFetchId);
-      clearInterval(id);
+      es.removeEventListener("snapshot", handleSnapshot as EventListener);
+      es.close();
+      eventSourceRef.current = null;
+      stopFallbackPolling();
     };
-  }, [fetchIssues]);
+  }, [applySnapshot, fetchIssues, startFallbackPolling, stopFallbackPolling]);
 
   useEffect(() => {
     try { localStorage.setItem("forge-admin-alert-muted", String(muted)); } catch {}

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -1,0 +1,48 @@
+import { execSync } from "child_process";
+import { readCanonicalIssueLabels } from "@/lib/github-labels";
+import { getForgeRoot } from "@/lib/paths";
+
+export interface IssueSnapshot {
+  issues: unknown[];
+  labels: ReturnType<typeof readCanonicalIssueLabels>;
+  repo: string;
+}
+
+let cache: (IssueSnapshot & { ts: number }) | null = null;
+const TTL_MS = 5000;
+
+export function invalidateIssueSnapshot(): void {
+  cache = null;
+}
+
+export async function getIssueSnapshot(options?: {
+  forceRefresh?: boolean;
+}): Promise<IssueSnapshot> {
+  const now = Date.now();
+  if (!options?.forceRefresh && cache && now - cache.ts < TTL_MS) {
+    return { issues: cache.issues, labels: cache.labels, repo: cache.repo };
+  }
+
+  const cwd = getForgeRoot();
+  const labels = readCanonicalIssueLabels();
+  const raw = execSync(
+    "gh issue list --state open --json number,title,labels,assignees --limit 100",
+    { cwd, encoding: "utf-8", timeout: 10000 }
+  );
+
+  const issues = JSON.parse(raw) as unknown[];
+  let repo = "";
+
+  try {
+    repo = execSync("gh repo view --json nameWithOwner -q '.nameWithOwner'", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10000,
+    }).trim();
+  } catch {
+    // Non-fatal. Issue links fall back to plain cards.
+  }
+
+  cache = { issues, labels, repo, ts: now };
+  return { issues, labels, repo };
+}


### PR DESCRIPTION
**@worker-01**

## Summary
Integrate current `main` into `epic/746-issues-filter-labels` and preserve the canonical Issues tab filter integration.

## What changed
- moved canonical `status` / `role` / `type` label data into the shared issue snapshot so both `/api/issues` and `/api/issues/stream` carry the same payload
- merged the Issues panel so it keeps the newer SSE + polling fallback behavior while rendering canonical filter chips from `contexts/LABELS.md`
- updated the web README for the final `/api/issues` and `/api/issues/stream` response shape

## Verification
- `npm run build`
- `npm run lint` (fails on pre-existing issues in `src/components/agent-panel.tsx` and `src/components/resizable-layout.tsx`)
