### PR TITLE
Resolve repo-backed workspace lockfiles for managed runs

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -232,19 +232,45 @@ def add_job_to_crontab(crontab, job_id, cron_expr, command):
     return entry
 
 
-def _workspace_lock_path(job_id):
-    return os.path.join(REPO_DIR, ".worktrees", job_id, ".agent.lock")
+def _work_repo_dir(repo=None):
+    if not repo:
+        return REPO_DIR
+    if os.path.isabs(repo):
+        return os.path.normpath(repo)
+    if repo.startswith("github.com/"):
+        return os.path.join(REPO_DIR, ".repos", repo)
+    return os.path.normpath(repo)
 
 
-def _list_workspace_ids():
-    worktrees_dir = os.path.join(REPO_DIR, ".worktrees")
-    if not os.path.isdir(worktrees_dir):
+def _workspace_lock_path(job_id, repo=None):
+    return os.path.join(_work_repo_dir(repo), ".worktrees", job_id, ".agent.lock")
+
+
+def _normalize_repo(repo):
+    if not repo:
+        return ""
+    if os.path.isabs(repo):
+        return os.path.normpath(repo)
+    return repo
+
+
+def _load_managed_jobs(agent_id=None):
+    try:
+        with open(JOBS_FILE) as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
         return []
-    job_ids = []
-    for entry in os.listdir(worktrees_dir):
-        if os.path.isfile(_workspace_lock_path(entry)):
-            job_ids.append(entry)
-    return sorted(job_ids)
+
+    jobs = []
+    for job in config.get("jobs", []):
+        if not job.get("enabled", True):
+            continue
+        if not job.get("workspace", False):
+            continue
+        if agent_id and job.get("id") != agent_id:
+            continue
+        jobs.append(job)
+    return jobs
 
 
 def _read_lock_pid(lock_path):
@@ -312,7 +338,7 @@ def _parse_run_command(command):
     }
 
 
-def _matches_managed_run(job_id, pid, command):
+def _matches_managed_run(job, pid, command):
     parsed = _parse_run_command(command)
     if not parsed:
         return None
@@ -320,28 +346,29 @@ def _matches_managed_run(job_id, pid, command):
     run_path = parsed["run_path"]
     if os.path.isabs(run_path) and os.path.normpath(run_path) != os.path.join(REPO_DIR, "agent-kernel", "run.sh"):
         return None
-    if parsed["workspace_id"] != job_id:
+    if parsed["workspace_id"] != job["id"]:
+        return None
+    if _normalize_repo(parsed["repo"]) != _normalize_repo(job.get("repo")):
         return None
 
     return {
-        "agent_id": job_id,
+        "agent_id": job["id"],
         "pid": pid,
         "command": command,
     }
 
 
 def find_managed_runs(agent_id=None):
-    job_ids = [agent_id] if agent_id else _list_workspace_ids()
     runs = []
-    for job_id in job_ids:
-        lock_path = _workspace_lock_path(job_id)
+    for job in _load_managed_jobs(agent_id):
+        lock_path = _workspace_lock_path(job["id"], job.get("repo"))
         pid = _read_lock_pid(lock_path)
         if pid is None:
             continue
         command = _read_process_command(pid)
         if not command:
             continue
-        run = _matches_managed_run(job_id, pid, command)
+        run = _matches_managed_run(job, pid, command)
         if run:
             runs.append(run)
     return runs

--- a/tests/test_manage_kill.py
+++ b/tests/test_manage_kill.py
@@ -15,6 +15,17 @@ spec.loader.exec_module(manage)
 
 
 class ManageKillTests(unittest.TestCase):
+    def test_workspace_lock_path_uses_repo_backed_and_self_repo_layouts(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"):
+            self.assertEqual(
+                manage._workspace_lock_path("worker-02", "github.com/alexjaniak/Forge"),
+                "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock",
+            )
+            self.assertEqual(
+                manage._workspace_lock_path("worker-03"),
+                "/tmp/forge/.worktrees/worker-03/.agent.lock",
+            )
+
     def test_parse_run_command_extracts_workspace_and_repo(self):
         command = (
             "/bin/bash /tmp/forge/agent-kernel/run.sh --agentic "
@@ -27,24 +38,36 @@ class ManageKillTests(unittest.TestCase):
         self.assertEqual(parsed["workspace_id"], "worker-02")
         self.assertEqual(parsed["repo"], "github.com/alexjaniak/Forge")
 
-    def test_find_managed_runs_filters_out_stale_and_non_matching_processes(self):
+    def test_find_managed_runs_resolves_repo_backed_and_self_repo_lockfiles(self):
+        jobs = [
+            {"id": "worker-02", "repo": "github.com/alexjaniak/Forge", "workspace": True},
+            {"id": "worker-03", "repo": "", "workspace": True},
+            {"id": "worker-04", "repo": "github.com/alexjaniak/Other", "workspace": True},
+        ]
+
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
-            manage, "_list_workspace_ids", return_value=["worker-02", "worker-03", "worker-04"]
+            manage, "_load_managed_jobs", return_value=jobs
         ), patch.object(
             manage,
             "_read_lock_pid",
             side_effect=lambda path: {
-                "/tmp/forge/.worktrees/worker-02/.agent.lock": 101,
+                "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock": 101,
                 "/tmp/forge/.worktrees/worker-03/.agent.lock": 102,
-                "/tmp/forge/.worktrees/worker-04/.agent.lock": 103,
+                "/tmp/forge/.repos/github.com/alexjaniak/Other/.worktrees/worker-04/.agent.lock": 103,
             }.get(path),
         ), patch.object(
             manage,
             "_read_process_command",
             side_effect=lambda pid: {
-                101: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 'prompt'",
-                102: "/bin/bash /tmp/other/agent-kernel/run.sh --workspace worker-03 'prompt'",
-                103: None,
+                101: (
+                    "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 "
+                    "--repo github.com/alexjaniak/Forge 'prompt'"
+                ),
+                102: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 'prompt'",
+                103: (
+                    "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-04 "
+                    "--repo github.com/alexjaniak/Wrong 'prompt'"
+                ),
             }.get(pid),
         ):
             runs = manage.find_managed_runs()
@@ -55,10 +78,28 @@ class ManageKillTests(unittest.TestCase):
                 {
                     "agent_id": "worker-02",
                     "pid": 101,
-                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 'prompt'",
-                }
+                    "command": (
+                        "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 "
+                        "--repo github.com/alexjaniak/Forge 'prompt'"
+                    ),
+                },
+                {
+                    "agent_id": "worker-03",
+                    "pid": 102,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 'prompt'",
+                },
             ],
         )
+
+    def test_find_managed_runs_only_checks_jobs_from_cron_config(self):
+        with patch.object(manage, "_load_managed_jobs", return_value=[]), patch.object(
+            manage, "_read_lock_pid"
+        ) as read_lock_pid, patch.object(manage, "_read_process_command") as read_process_command:
+            runs = manage.find_managed_runs()
+
+        self.assertEqual(runs, [])
+        read_lock_pid.assert_not_called()
+        read_process_command.assert_not_called()
 
     def test_kill_managed_runs_returns_killed_runs(self):
         runs = [


### PR DESCRIPTION
**@worker-05**

## Summary
- cherry-pick the existing managed-run kill backend onto `epic/803-forge-kill`
- resolve managed-run lockfiles from scheduled job `id` plus `repo`, including Forge-root and `.repos/...` worktrees
- restrict kill discovery to workspace-enabled jobs from this repo's `cron-jobs.json` and add focused unit coverage

## Testing
- `python3 -m unittest tests/test_manage_kill.py`
