### PR TITLE
Add top-level forge kill command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Unified command-line interface for managing agents.
 | `forge remove <id>` | Remove an agent |
 | `forge apply` | Sync staged agent config to live crontab |
 | `forge run <id>` | Run an agent once immediately |
+| `forge kill <id>` | Terminate one running managed agent |
+| `forge kill --all` | Terminate all running managed agents |
 | `forge clear` | Clear active crontab and state |
 | `forge clear --staged` | Clear only staged config |
 | `forge list` | Show all agents (staged, active, unstaged) |

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -89,6 +89,30 @@ forge logs worker-01 -f
 forge logs -n 200
 ```
 
+### `forge kill`
+
+Terminate a running managed agent process.
+
+```
+forge kill AGENT_ID
+forge kill --all
+```
+
+| Flag | Description |
+|------|-------------|
+| `AGENT_ID` | Terminate one running managed agent by ID |
+| `--all` | Terminate all running managed agents |
+
+```bash
+# Stop one managed agent run
+forge kill worker-01
+
+# Stop all currently running managed agent runs
+forge kill --all
+```
+
+If no matching managed run is active, Forge prints a message instead of failing.
+
 ### `forge clear`
 
 Reset staged config — remove all agents from `cron-jobs.json`.

--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -3,6 +3,7 @@ import click
 from forge_cli.agents import add, remove
 from forge_cli.apply_cmd import apply_cmd
 from forge_cli.clear_cmd import clear_cmd
+from forge_cli.kill_cmd import kill_cmd
 from forge_cli.list_cmd import list_cmd
 from forge_cli.logs import logs
 from forge_cli.run_cmd import run_cmd
@@ -18,6 +19,7 @@ def main():
 main.add_command(add)
 main.add_command(apply_cmd, name="apply")
 main.add_command(clear_cmd, name="clear")
+main.add_command(kill_cmd, name="kill")
 main.add_command(list_cmd, name="list")
 main.add_command(logs)
 main.add_command(remove)

--- a/apps/forge-cli/src/forge_cli/kill_cmd.py
+++ b/apps/forge-cli/src/forge_cli/kill_cmd.py
@@ -1,0 +1,19 @@
+"""forge kill — terminate managed agent runs."""
+
+from types import SimpleNamespace
+
+import click
+
+from forge_cli.paths import _get_manage
+
+
+@click.command("kill")
+@click.argument("agent_id", required=False)
+@click.option("--all", "kill_all", is_flag=True, help="Terminate all running managed agents.")
+def kill_cmd(agent_id, kill_all):
+    """Terminate a managed agent run."""
+    if bool(agent_id) == kill_all:
+        raise click.UsageError("kill requires exactly one of: <agent-id> or --all")
+
+    m = _get_manage()
+    m.cmd_kill(SimpleNamespace(id=agent_id, all=kill_all))

--- a/tests/test_forge_cli_kill.py
+++ b/tests/test_forge_cli_kill.py
@@ -1,0 +1,59 @@
+import pathlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CLI_SRC = REPO_ROOT / "apps" / "forge-cli" / "src"
+if str(CLI_SRC) not in sys.path:
+    sys.path.insert(0, str(CLI_SRC))
+
+from forge_cli.cli import main
+
+
+class ForgeCliKillTests(unittest.TestCase):
+    def test_kill_dispatches_agent_id_to_backend(self):
+        runner = CliRunner()
+
+        with patch("forge_cli.kill_cmd._get_manage") as get_manage:
+            result = runner.invoke(main, ["kill", "worker-02"])
+
+        self.assertEqual(result.exit_code, 0)
+        get_manage.return_value.cmd_kill.assert_called_once_with(
+            SimpleNamespace(id="worker-02", all=False)
+        )
+
+    def test_kill_all_dispatches_bulk_flag_to_backend(self):
+        runner = CliRunner()
+
+        with patch("forge_cli.kill_cmd._get_manage") as get_manage:
+            result = runner.invoke(main, ["kill", "--all"])
+
+        self.assertEqual(result.exit_code, 0)
+        get_manage.return_value.cmd_kill.assert_called_once_with(
+            SimpleNamespace(id=None, all=True)
+        )
+
+    def test_kill_requires_agent_id_or_all(self):
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["kill"])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("kill requires exactly one of: <agent-id> or --all", result.output)
+
+    def test_kill_rejects_agent_id_with_all(self):
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["kill", "worker-02", "--all"])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("kill requires exactly one of: <agent-id> or --all", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**@worker-04**

## Summary
- add a top-level `forge kill` Click command wired to the shared cron kill backend
- cover CLI dispatch and invalid invocation shapes with focused tests
- document `forge kill <agent-id>` and `forge kill --all` in the CLI and root READMEs
