### PR TITLE
Integrate rebased epic/691-cli-redesign onto latest main

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -246,7 +246,7 @@ RUNTIME_ARGS=()
 if [[ "$AGENT_RUNTIME" == "codex" ]]; then
   RUNTIME_ARGS+=(--dangerously-bypass-approvals-and-sandbox)
   if [[ -n "$SYSTEM_PROMPT" ]]; then
-    RUNTIME_ARGS+=(-c "instructions=$(printf '%s' "$SYSTEM_PROMPT")")
+    PROMPT="${SYSTEM_PROMPT}"$'\n\n'"${PROMPT}"
   fi
 else
   if [[ "$AGENTIC" == false ]]; then

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -102,6 +102,8 @@ def add(agent_types, agent_id, interval, list_templates, apply_flag):
         job["contexts"] = template.get("contexts", [])
         job["agentic"] = template.get("agentic", False)
         job["workspace"] = template.get("workspace", False)
+        if "repo" in template:
+            job["repo"] = template["repo"]
 
         cron_data.setdefault("jobs", []).append(job)
         existing_ids.append(aid)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -51,7 +51,7 @@ src/app/
 | **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (NEW, ACTIVE, MODIFIED, DELETED), role badges, interval/countdown info, and branch context. Supports add, delete, force-run, apply, clear, diff, and reset actions. Auto-refreshes every 5s. |
 | **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
 | **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
-| **IssuesPanel** | `issues-panel.tsx` | Polls `/api/issues` every 10s. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert for new `role:admin` issues. |
+| **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert only when an issue newly gains `role:admin`. |
 
 ### Data Flow
 
@@ -62,7 +62,8 @@ agent-kernel/cron/cron-jobs.json  → GET /api/agents       → AgentPanel
 agent-kernel/cron/cron-state.json → GET /api/agents       → AgentPanel
 agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
-gh issue list (via CLI)             → GET /api/issues       → IssuesPanel
+gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
+GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
 templates/{type}.json             → POST /api/agents      → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
@@ -124,7 +125,11 @@ Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed 
 
 ### `GET /api/issues`
 
-Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, repo }`.
+Returns the current GitHub issue snapshot for fallback polling. Response is cached server-side for 5s and returns `{ issues, repo }`.
+
+### `GET /api/issues/stream`
+
+Server-Sent Events endpoint for live issue snapshots. Sends an initial `{ issues, repo }` snapshot immediately on connect, then emits updated snapshots when the GitHub event feed changes in ways that affect the Issues tab. The frontend falls back to polling `GET /api/issues` if the stream disconnects.
 
 ## Environment Variables
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -72,9 +72,9 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function getWorktreeBranch(agentId: string): string | null {
+function getWorktreeBranch(agentId: string, repo?: string): string | null {
   try {
-    const wtPath = worktreePath(agentId);
+    const wtPath = worktreePath(agentId, repo);
     const dotGit = fs.readFileSync(path.join(wtPath, ".git"), "utf-8").trim();
     // Format: "gitdir: /path/to/.git/worktrees/<name>"
     const gitdir = dotGit.replace("gitdir: ", "");
@@ -105,7 +105,7 @@ function buildAgentFromJob(
 
   let running = false;
   try {
-    const lockContent = fs.readFileSync(lockFilePath(job.id), "utf-8").trim();
+    const lockContent = fs.readFileSync(lockFilePath(job.id, job.repo), "utf-8").trim();
     const pid = parseInt(lockContent, 10);
     if (!isNaN(pid)) {
       running = isProcessAlive(pid);
@@ -127,7 +127,7 @@ function buildAgentFromJob(
   return {
     id: job.id,
     role: inferRole(job.id),
-    branch: getWorktreeBranch(job.id),
+    branch: getWorktreeBranch(job.id, job.repo),
     interval: job.interval,
     intervalSeconds,
     enabled: job.enabled !== false,

--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,41 +1,11 @@
-import { execSync } from "child_process";
 import { NextResponse } from "next/server";
-import { getForgeRoot } from "@/lib/paths";
-
-let cache: { issues: unknown[]; repo: string; ts: number } | null = null;
-const TTL = 5000;
+import { getIssueSnapshot } from "@/lib/issues";
 
 export async function GET() {
-  const now = Date.now();
-  if (cache && now - cache.ts < TTL) {
-    return NextResponse.json({ issues: cache.issues, repo: cache.repo });
-  }
-
-  const cwd = getForgeRoot();
-
-  let issues: unknown[] = [];
-  let repo = "";
-
   try {
-    const raw = execSync(
-      "gh issue list --state open --json number,title,labels,assignees --limit 100",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    );
-    issues = JSON.parse(raw);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json(await getIssueSnapshot());
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ issues: [], repo: "", error: msg });
   }
-
-  try {
-    repo = execSync(
-      "gh repo view --json nameWithOwner -q '.nameWithOwner'",
-      { cwd, encoding: "utf-8", timeout: 10000 }
-    ).trim();
-  } catch {
-    // non-fatal — links just won't work
-  }
-
-  cache = { issues, repo, ts: now };
-  return NextResponse.json({ issues, repo });
 }

--- a/apps/web/src/app/api/issues/stream/route.ts
+++ b/apps/web/src/app/api/issues/stream/route.ts
@@ -1,0 +1,221 @@
+import fs from "fs";
+import path from "path";
+import { eventsPath } from "@/lib/paths";
+import { getIssueSnapshot, invalidateIssueSnapshot } from "@/lib/issues";
+
+const KEEPALIVE_MS = 15000;
+const ISSUE_EVENT_PREFIX = "issue.";
+
+export const dynamic = "force-dynamic";
+
+function encodeSse(event: string, payload: unknown): Uint8Array {
+  const encoder = new TextEncoder();
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+function isRelevantIssueEvent(line: string): boolean {
+  try {
+    const parsed = JSON.parse(line) as { event_type?: unknown };
+    return (
+      typeof parsed.event_type === "string" &&
+      parsed.event_type.startsWith(ISSUE_EVENT_PREFIX)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function GET(request: Request) {
+  const filePath = eventsPath();
+  const dirPath = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+
+  let fileWatcher: fs.FSWatcher | null = null;
+  let dirWatcher: fs.FSWatcher | null = null;
+  let keepalive: NodeJS.Timeout | null = null;
+  let closed = false;
+  let offset = 0;
+  let pendingLine = "";
+  let snapshotInFlight = false;
+  let snapshotQueued = false;
+
+  function cleanup() {
+    if (closed) return;
+    closed = true;
+
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      fileWatcher = null;
+    }
+
+    if (dirWatcher) {
+      try {
+        dirWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+      dirWatcher = null;
+    }
+  }
+
+  async function sendSnapshot(
+    controller: ReadableStreamDefaultController,
+    forceRefresh: boolean
+  ) {
+    if (closed) return;
+    if (snapshotInFlight) {
+      snapshotQueued = snapshotQueued || forceRefresh;
+      return;
+    }
+
+    snapshotInFlight = true;
+    let nextForceRefresh = forceRefresh;
+
+    try {
+      do {
+        const shouldForceRefresh = nextForceRefresh || snapshotQueued;
+        snapshotQueued = false;
+        nextForceRefresh = false;
+
+        try {
+          const snapshot = await getIssueSnapshot({
+            forceRefresh: shouldForceRefresh,
+          });
+          if (closed) return;
+          controller.enqueue(encodeSse("snapshot", snapshot));
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (closed) return;
+          controller.enqueue(
+            encodeSse("snapshot", { issues: [], repo: "", error: message })
+          );
+        }
+      } while (snapshotQueued);
+    } finally {
+      snapshotInFlight = false;
+    }
+  }
+
+  function watchFile(onChange: () => void) {
+    if (fileWatcher) {
+      try {
+        fileWatcher.close();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+
+    try {
+      fileWatcher = fs.watch(filePath, () => {
+        onChange();
+      });
+    } catch {
+      fileWatcher = null;
+    }
+  }
+
+  function readRelevantChanges(): boolean {
+    let fileSize = 0;
+    try {
+      fileSize = fs.statSync(filePath).size;
+    } catch {
+      offset = 0;
+      pendingLine = "";
+      return false;
+    }
+
+    if (offset > fileSize) {
+      offset = 0;
+      pendingLine = "";
+    }
+
+    if (offset === fileSize) {
+      return false;
+    }
+
+    const bytesToRead = fileSize - offset;
+    const fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.alloc(bytesToRead);
+
+    try {
+      fs.readSync(fd, buffer, 0, bytesToRead, offset);
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    offset = fileSize;
+    const chunk = pendingLine + buffer.toString("utf-8");
+    const lines = chunk.split("\n");
+    pendingLine = lines.pop() ?? "";
+
+    return lines.some((line) => line.trim() !== "" && isRelevantIssueEvent(line));
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      try {
+        fs.mkdirSync(dirPath, { recursive: true });
+      } catch {
+        // ignore setup errors
+      }
+
+      try {
+        offset = fs.statSync(filePath).size;
+      } catch {
+        offset = 0;
+      }
+
+      const handleChange = () => {
+        if (!readRelevantChanges()) {
+          return;
+        }
+        invalidateIssueSnapshot();
+        void sendSnapshot(controller, true);
+      };
+
+      watchFile(handleChange);
+
+      try {
+        dirWatcher = fs.watch(dirPath, (_eventType, filename) => {
+          if (filename && filename !== fileName) {
+            return;
+          }
+          watchFile(handleChange);
+          handleChange();
+        });
+      } catch {
+        dirWatcher = null;
+      }
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+      }, KEEPALIVE_MS);
+
+      void sendSnapshot(controller, false);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  request.signal.addEventListener("abort", cleanup, { once: true });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -119,3 +119,29 @@
     @apply font-mono;
   }
 }
+
+@layer utilities {
+  .dashboard-scrollbar {
+    --dashboard-scrollbar-surface: var(--surface);
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border: 2px solid var(--dashboard-scrollbar-surface);
+    border-radius: 9999px;
+  }
+
+  .dashboard-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: var(--muted-foreground);
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -38,7 +38,7 @@ function RightPanel() {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Tab bar */}
-      <div className="flex items-center gap-1 px-4 py-0 bg-surface border-b border-border shrink-0">
+      <div className="flex items-center gap-1 px-4 py-1 bg-surface border-b border-border shrink-0">
         <TabButton
           label="Logs"
           active={activeTab === "logs"}

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -187,38 +187,28 @@ function AgentCard({
         </button>
       </div>
 
-      {agent.branch && (
-        <div className="text-sm text-muted-foreground ml-4 mb-1 truncate" title={agent.branch}>
-          {agent.branch}
-        </div>
-      )}
+      <div className="text-sm text-muted-foreground ml-4 mb-1 truncate" title={agent.branch ?? undefined}>
+        {agent.branch ?? "\u2014"}
+      </div>
 
-      <div className="flex items-center gap-1.5 text-sm text-text ml-4 mb-2">
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 text-sm text-text ml-4 mb-2">
         <span className="text-muted-foreground">every</span>
-        <span title="Interval">{agent.interval}</span>
-        {agent.status === "modified" && agent.stagedInterval && (
-          <span className="text-accent-yellow" title="Pending interval change">
-            → {agent.stagedInterval}
-          </span>
-        )}
-        {agent.lastRun && (
-          <>
-            <span className="text-muted-foreground">·</span>
-            <span className="text-muted-foreground">ran</span>
-            <span title={`Last run: ${agent.lastRun}`}>
-              {relativeTime(agent.lastRun)}
+        <span>
+          <span title="Interval">{agent.interval}</span>
+          {agent.status === "modified" && agent.stagedInterval && (
+            <span className="text-accent-yellow ml-1" title="Pending interval change">
+              → {agent.stagedInterval}
             </span>
-          </>
-        )}
-        {agent.nextRun && (
-          <>
-            <span className="text-muted-foreground">·</span>
-            <span className="text-muted-foreground">next</span>
-            <span className="text-accent-cyan" title={`Next run: ${agent.nextRun}`}>
-              {countdown(agent.nextRun)}
-            </span>
-          </>
-        )}
+          )}
+        </span>
+        <span className="text-muted-foreground">ran</span>
+        <span title={agent.lastRun ? `Last run: ${agent.lastRun}` : undefined}>
+          {agent.lastRun ? relativeTime(agent.lastRun) : "\u2014"}
+        </span>
+        <span className="text-muted-foreground">next</span>
+        <span className={agent.nextRun ? "text-accent-cyan" : ""} title={agent.nextRun ? `Next run: ${agent.nextRun}` : undefined}>
+          {agent.nextRun ? countdown(agent.nextRun) : "\u2014"}
+        </span>
       </div>
 
       <div className="flex justify-end mr-1">
@@ -571,7 +561,7 @@ export function AgentPanel() {
   const hasStagedAgents = agents.filter((a) => a.status !== "deleted").length > 0;
 
   return (
-    <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
+    <div className="dashboard-scrollbar h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
       <div className="flex items-center gap-2 py-2">
         <button
           className="text-xs rounded px-2 py-1 border border-border text-text hover:bg-surface-hover transition-colors"

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -154,7 +154,7 @@ export function EventsPanel() {
         <div
           ref={containerRef}
           onScroll={handleScroll}
-          className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
+          className="dashboard-scrollbar flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
         >
           {events.map((event, i) => (
             <EventCard key={`${event.timestamp}-${i}`} event={event} />

--- a/apps/web/src/components/issues-panel.tsx
+++ b/apps/web/src/components/issues-panel.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
+const POLL_INTERVAL = 5000;
+
 interface Issue {
   number: number;
   title: string;
@@ -128,54 +130,106 @@ export function IssuesPanel() {
   });
   const prevIssuesRef = useRef<Issue[]>([]);
   const initialLoadRef = useRef(true);
+  const mutedRef = useRef<boolean>(muted);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const fallbackTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const mutedRef = useRef(muted);
-  mutedRef.current = muted;
+  const applySnapshot = useCallback((data: { issues?: Issue[]; repo?: string; error?: string }) => {
+    if (data.error) setError(data.error);
+    else setError("");
+
+    const newIssues = data.issues ?? [];
+    setIssues(newIssues);
+    if (typeof data.repo === "string") {
+      setRepo(data.repo);
+    }
+
+    if (initialLoadRef.current) {
+      initialLoadRef.current = false;
+      prevIssuesRef.current = newIssues;
+      return;
+    }
+
+    if (!mutedRef.current) {
+      const prevAdminIds = new Set(
+        prevIssuesRef.current
+          .filter((issue) => issue.labels.some((label) => label.name === "role:admin"))
+          .map((issue) => issue.number)
+      );
+      const hasNewAdminIssue = newIssues.some(
+        (issue) =>
+          issue.labels.some((label) => label.name === "role:admin") &&
+          !prevAdminIds.has(issue.number)
+      );
+      if (hasNewAdminIssue) {
+        playAdminAlert();
+      }
+    }
+
+    prevIssuesRef.current = newIssues;
+  }, []);
 
   const fetchIssues = useCallback(async () => {
     try {
       const res = await fetch("/api/issues");
       const data = await res.json();
-      if (data.error) setError(data.error);
-      else setError("");
-      const newIssues: Issue[] = data.issues ?? [];
-      setIssues(newIssues);
-      if (data.repo) setRepo(data.repo);
-
-      // Skip alert on initial load
-      if (initialLoadRef.current) {
-        initialLoadRef.current = false;
-        prevIssuesRef.current = newIssues;
-        return;
-      }
-
-      // Detect newly-added role:admin labels
-      if (!mutedRef.current) {
-        const prevAdminIds = new Set(
-          prevIssuesRef.current
-            .filter((i) => i.labels.some((l) => l.name === "role:admin"))
-            .map((i) => i.number)
-        );
-        const newAdminIssues = newIssues.filter(
-          (i) =>
-            i.labels.some((l) => l.name === "role:admin") &&
-            !prevAdminIds.has(i.number)
-        );
-        if (newAdminIssues.length > 0) {
-          playAdminAlert();
-        }
-      }
-      prevIssuesRef.current = newIssues;
+      applySnapshot(data);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Fetch failed");
+    }
+  }, [applySnapshot]);
+
+  const startFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) return;
+    fallbackTimerRef.current = setInterval(fetchIssues, POLL_INTERVAL);
+  }, [fetchIssues]);
+
+  const stopFallbackPolling = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearInterval(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
     }
   }, []);
 
   useEffect(() => {
-    fetchIssues();
-    const id = setInterval(fetchIssues, 5000);
-    return () => clearInterval(id);
-  }, [fetchIssues]);
+    const initialFetchId = window.setTimeout(() => {
+      void fetchIssues();
+    }, 0);
+
+    const es = new EventSource("/api/issues/stream");
+    eventSourceRef.current = es;
+
+    const handleSnapshot = (event: MessageEvent<string>) => {
+      try {
+        applySnapshot(JSON.parse(event.data));
+      } catch {
+        setError("Invalid issue stream payload");
+      }
+    };
+
+    es.onmessage = handleSnapshot;
+    es.addEventListener("snapshot", handleSnapshot as EventListener);
+
+    es.onerror = () => {
+      startFallbackPolling();
+    };
+
+    es.onopen = () => {
+      stopFallbackPolling();
+    };
+
+    return () => {
+      window.clearTimeout(initialFetchId);
+      es.removeEventListener("snapshot", handleSnapshot as EventListener);
+      es.close();
+      eventSourceRef.current = null;
+      stopFallbackPolling();
+    };
+  }, [applySnapshot, fetchIssues, startFallbackPolling, stopFallbackPolling]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+  }, [muted]);
 
   useEffect(() => {
     try { localStorage.setItem("forge-admin-alert-muted", String(muted)); } catch {}
@@ -275,7 +329,7 @@ export function IssuesPanel() {
       )}
 
       {/* Issue list */}
-      <div className="flex-1 overflow-y-auto px-3 pb-3">
+      <div className="dashboard-scrollbar [--dashboard-scrollbar-surface:var(--background)] flex-1 overflow-y-auto px-3 pb-3">
         {filtered.length === 0 && !error ? (
           <p className="text-muted-foreground text-sm pt-3">No issues found.</p>
         ) : (

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -391,7 +391,7 @@ export function LogsPanel() {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-2"
+        className="dashboard-scrollbar [--dashboard-scrollbar-surface:var(--background)] flex-1 overflow-y-auto p-4 space-y-2"
       >
         {displayBlocks.length === 0 ? (
           <div className="flex items-center justify-center h-full">
@@ -407,13 +407,6 @@ export function LogsPanel() {
   );
 }
 
-function getRoleDotColor(agentId: string): string {
-  if (agentId.startsWith("worker")) return "#98c379";
-  if (agentId.startsWith("planner")) return "#c678dd";
-  if (agentId.startsWith("super")) return "#e5c07b";
-  return "#abb2bf";
-}
-
 function formatDuration(startIso: string, endIso: string): string {
   const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
   if (ms < 0) return "";
@@ -426,7 +419,6 @@ function formatDuration(startIso: string, endIso: string): string {
 
 function LogCard({ block }: { block: LogBlock }) {
   const agentColor = getAgentColor(block.agentId);
-  const dotColor = getRoleDotColor(block.agentId);
   const duration =
     block.endTimestamp && block.timestamp
       ? formatDuration(block.timestamp, block.endTimestamp)
@@ -449,17 +441,13 @@ function LogCard({ block }: { block: LogBlock }) {
     >
       <div className="flex items-center gap-2 mb-2">
         <span
-          className="inline-flex items-center gap-1.5 text-sm font-semibold px-2 py-0.5 rounded"
+          className="inline-flex items-center text-sm font-semibold px-2 py-0.5 rounded"
           style={{
             backgroundColor: agentColor + "26",
             color: agentColor,
             border: `1px solid ${agentColor}4D`,
           }}
         >
-          <span
-            className="inline-block w-2 h-2 rounded-full shrink-0"
-            style={{ backgroundColor: dotColor }}
-          />
           {block.agentId}
         </span>
         <span className="text-sm text-muted-foreground">

--- a/apps/web/src/components/resizable-layout.tsx
+++ b/apps/web/src/components/resizable-layout.tsx
@@ -106,7 +106,7 @@ export function ResizableLayout({
   return (
     <div
       ref={containerRef}
-      className={`h-screen w-screen overflow-hidden flex bg-border${dragging ? " select-none" : ""}`}
+      className={`h-dvh w-screen overflow-hidden flex bg-border${dragging ? " select-none" : ""}`}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       style={{ cursor: dragging ? "col-resize" : undefined }}
@@ -127,7 +127,7 @@ export function ResizableLayout({
           className="overflow-hidden shrink-0 flex flex-col"
           style={{ width: sidebarWidth }}
         >
-          <div className="flex items-center justify-between px-3 pt-3 pb-1 shrink-0">
+          <div className="flex items-center justify-between px-3 pt-3 pb-2 shrink-0">
             <h2 className="text-text-bright font-semibold text-sm uppercase tracking-wide">Agents</h2>
             <button
               className="text-muted-foreground hover:text-text-bright text-sm px-1"

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -1,0 +1,45 @@
+import { execSync } from "child_process";
+import { getForgeRoot } from "@/lib/paths";
+
+export interface IssueSnapshot {
+  issues: unknown[];
+  repo: string;
+}
+
+let cache: (IssueSnapshot & { ts: number }) | null = null;
+const TTL_MS = 5000;
+
+export function invalidateIssueSnapshot(): void {
+  cache = null;
+}
+
+export async function getIssueSnapshot(options?: {
+  forceRefresh?: boolean;
+}): Promise<IssueSnapshot> {
+  const now = Date.now();
+  if (!options?.forceRefresh && cache && now - cache.ts < TTL_MS) {
+    return { issues: cache.issues, repo: cache.repo };
+  }
+
+  const cwd = getForgeRoot();
+  const raw = execSync(
+    "gh issue list --state open --json number,title,labels,assignees --limit 100",
+    { cwd, encoding: "utf-8", timeout: 10000 }
+  );
+
+  const issues = JSON.parse(raw) as unknown[];
+  let repo = "";
+
+  try {
+    repo = execSync("gh repo view --json nameWithOwner -q '.nameWithOwner'", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10000,
+    }).trim();
+  } catch {
+    // Non-fatal. Issue links fall back to plain cards.
+  }
+
+  cache = { issues, repo, ts: now };
+  return { issues, repo };
+}

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -19,12 +19,15 @@ export function cronStatePath(): string {
   return path.join(getForgeRoot(), "agent-kernel/cron/cron-state.json");
 }
 
-export function worktreePath(agentId: string): string {
+export function worktreePath(agentId: string, repo?: string): string {
+  if (repo) {
+    return path.join(getForgeRoot(), `.repos/${repo}/.worktrees/${agentId}`);
+  }
   return path.join(getForgeRoot(), `.worktrees/${agentId}`);
 }
 
-export function lockFilePath(agentId: string): string {
-  return path.join(getForgeRoot(), `.worktrees/${agentId}/.agent.lock`);
+export function lockFilePath(agentId: string, repo?: string): string {
+  return path.join(worktreePath(agentId, repo), ".agent.lock");
 }
 
 export function agentLogPath(agentId: string): string {


### PR DESCRIPTION
**@worker-05**

## Summary
- integrate the rebased `epic/691-cli-redesign` history back onto the latest epic tip without force-pushing the shared branch
- resolve the remaining `apps/forge-cli/src/forge_cli/agents.py` conflict by preserving epic multi-agent add/rm behavior and restoring `repo` passthrough from `main`
- hand the planner a mergeable branch that moves the epic branch ancestry onto current `main` once merged
