### PR TITLE
Hardcode issue filter labels

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -114,7 +114,7 @@ Server-Sent Events endpoint for live log streaming. Uses `fs.watch()` on log fil
 Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed from newline-delimited JSON.
 
 ### `GET /api/issues`
-Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, labels, repo }`, where `labels` is the canonical `status`, `role`, and `type` label set parsed from `contexts/LABELS.md` so the Issues tab can render filter chips even when a label has zero open matches.
+Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, labels, repo }`, where `labels` is the hardcoded canonical `status`, `role`, and `type` label set defined in app source so the Issues tab can render filter chips even when a label has zero open matches.
 
 ### `GET /api/issues/stream`
 

--- a/apps/web/src/lib/github-labels.ts
+++ b/apps/web/src/lib/github-labels.ts
@@ -1,48 +1,27 @@
-import fs from "fs";
-import path from "path";
-import { getForgeRoot } from "@/lib/paths";
-
 export interface CanonicalIssueLabels {
   status: string[];
   role: string[];
   type: string[];
 }
 
-const EMPTY_LABELS: CanonicalIssueLabels = {
-  status: [],
-  role: [],
-  type: [],
+const CANONICAL_ISSUE_LABELS: CanonicalIssueLabels = {
+  status: [
+    "status:ready-for-planning",
+    "status:planning",
+    "status:ready-for-work",
+    "status:in-progress",
+    "status:needs-review",
+    "status:blocked",
+    "status:done",
+  ],
+  role: ["role:worker", "role:planner", "role:super", "role:admin"],
+  type: ["type:epic", "type:task", "type:fix"],
 };
 
-function parseSection(
-  markdown: string,
-  heading: string,
-  prefix: "status" | "role" | "type"
-): string[] {
-  const start = markdown.indexOf(heading);
-  if (start === -1) {
-    return [];
-  }
-
-  const rest = markdown.slice(start + heading.length);
-  const end = rest.search(/\n##\s+/);
-  const section = end === -1 ? rest : rest.slice(0, end);
-  const matches = section.matchAll(new RegExp("`(" + prefix + ":[^`]+)`", "g"));
-
-  return [...new Set(Array.from(matches, (match) => match[1]))];
-}
-
 export function readCanonicalIssueLabels(): CanonicalIssueLabels {
-  try {
-    const labelsPath = path.join(getForgeRoot(), "contexts/LABELS.md");
-    const markdown = fs.readFileSync(labelsPath, "utf-8");
-
-    return {
-      status: parseSection(markdown, "## Status (lifecycle)", "status"),
-      role: parseSection(markdown, "## Role (who acts on it)", "role"),
-      type: parseSection(markdown, "## Type", "type"),
-    };
-  } catch {
-    return EMPTY_LABELS;
-  }
+  return {
+    status: [...CANONICAL_ISSUE_LABELS.status],
+    role: [...CANONICAL_ISSUE_LABELS.role],
+    type: [...CANONICAL_ISSUE_LABELS.type],
+  };
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- hardcode the canonical Issues tab `status`, `role`, and `type` label lists in app source
- remove the runtime dependency on `contexts/LABELS.md` for issue filter chips
- update `apps/web/README.md` to describe the hardcoded label source

## Validation
- `npm run lint -- --file src/lib/github-labels.ts --file src/lib/issues.ts --file src/components/issues-panel.tsx` *(fails in this worktree because `eslint` is unavailable: `node_modules` is not installed)*
