### PR TITLE
Fix issue API fallback labels

### DIFF
--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { getIssueSnapshot } from "@/lib/issues";
+import { getEmptyIssueSnapshot, getIssueSnapshot } from "@/lib/issues";
 
 export async function GET() {
   try {
     return NextResponse.json(await getIssueSnapshot());
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    return NextResponse.json({ issues: [], labels: { status: [], role: [], type: [] }, repo: "", error: msg });
+    return NextResponse.json({ ...getEmptyIssueSnapshot(), error: msg });
   }
 }

--- a/apps/web/src/app/api/issues/stream/route.ts
+++ b/apps/web/src/app/api/issues/stream/route.ts
@@ -1,7 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { eventsPath } from "@/lib/paths";
-import { getIssueSnapshot, invalidateIssueSnapshot } from "@/lib/issues";
+import {
+  getEmptyIssueSnapshot,
+  getIssueSnapshot,
+  invalidateIssueSnapshot,
+} from "@/lib/issues";
 
 const KEEPALIVE_MS = 15000;
 const ISSUE_EVENT_PREFIX = "issue.";
@@ -97,7 +101,10 @@ export async function GET(request: Request) {
             error instanceof Error ? error.message : String(error);
           if (closed) return;
           controller.enqueue(
-            encodeSse("snapshot", { issues: [], repo: "", error: message })
+            encodeSse("snapshot", {
+              ...getEmptyIssueSnapshot(),
+              error: message,
+            })
           );
         }
       } while (snapshotQueued);

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -15,6 +15,14 @@ export function invalidateIssueSnapshot(): void {
   cache = null;
 }
 
+export function getEmptyIssueSnapshot(): IssueSnapshot {
+  return {
+    issues: [],
+    labels: readCanonicalIssueLabels(),
+    repo: "",
+  };
+}
+
 export async function getIssueSnapshot(options?: {
   forceRefresh?: boolean;
 }): Promise<IssueSnapshot> {


### PR DESCRIPTION
**@worker-05**

## Summary
- preserve canonical issue labels in `/api/issues` error responses by reusing a shared empty snapshot helper
- preserve canonical issue labels in `/api/issues/stream` snapshot error payloads with the same helper

## Verification
- `npx eslint src/app/api/issues/route.ts src/app/api/issues/stream/route.ts src/lib/issues.ts`
- `npm run lint` currently fails on pre-existing issues in `src/components/agent-panel.tsx` and `src/components/resizable-layout.tsx`
