### PR TITLE
Preserve canonical issue labels on API errors

### DIFF
--- a/apps/web/src/app/api/issues/route.ts
+++ b/apps/web/src/app/api/issues/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import { getIssueSnapshot } from "@/lib/issues";
+import { getIssueErrorSnapshot, getIssueSnapshot } from "@/lib/issues";
 
 export async function GET() {
   try {
     return NextResponse.json(await getIssueSnapshot());
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    return NextResponse.json({ issues: [], labels: { status: [], role: [], type: [] }, repo: "", error: msg });
+    return NextResponse.json(getIssueErrorSnapshot(error));
   }
 }

--- a/apps/web/src/app/api/issues/stream/route.ts
+++ b/apps/web/src/app/api/issues/stream/route.ts
@@ -1,7 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { eventsPath } from "@/lib/paths";
-import { getIssueSnapshot, invalidateIssueSnapshot } from "@/lib/issues";
+import {
+  getIssueErrorSnapshot,
+  getIssueSnapshot,
+  invalidateIssueSnapshot,
+} from "@/lib/issues";
 
 const KEEPALIVE_MS = 15000;
 const ISSUE_EVENT_PREFIX = "issue.";
@@ -93,12 +97,8 @@ export async function GET(request: Request) {
           if (closed) return;
           controller.enqueue(encodeSse("snapshot", snapshot));
         } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
           if (closed) return;
-          controller.enqueue(
-            encodeSse("snapshot", { issues: [], repo: "", error: message })
-          );
+          controller.enqueue(encodeSse("snapshot", getIssueErrorSnapshot(error)));
         }
       } while (snapshotQueued);
     } finally {

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -8,6 +8,10 @@ export interface IssueSnapshot {
   repo: string;
 }
 
+export interface IssueErrorSnapshot extends IssueSnapshot {
+  error: string;
+}
+
 let cache: (IssueSnapshot & { ts: number }) | null = null;
 const TTL_MS = 5000;
 
@@ -45,4 +49,14 @@ export async function getIssueSnapshot(options?: {
 
   cache = { issues, labels, repo, ts: now };
   return { issues, labels, repo };
+}
+
+export function getIssueErrorSnapshot(error: unknown): IssueErrorSnapshot {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    issues: [],
+    labels: readCanonicalIssueLabels(),
+    repo: "",
+    error: message,
+  };
 }


### PR DESCRIPTION
**@worker-02**

## Summary
- preserve the hardcoded canonical issue label payload on `/api/issues` error responses
- reuse the same canonical error snapshot for the issues stream snapshot fallback
- keep successful snapshots and the Issues tab UI behavior unchanged

## Verification
- `npx tsc --noEmit`
- `npx eslint src/lib/issues.ts src/app/api/issues/route.ts src/app/api/issues/stream/route.ts`
