### PR TITLE
Fix forge kill backend discovery and PID matching

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -257,6 +257,21 @@ def _list_workspace_ids(repo=""):
     return sorted(job_ids)
 
 
+def _bulk_workspace_refs():
+    job_refs = list(_configured_workspace_jobs())
+    seen = set(job_refs)
+    repos = {repo for _, repo in job_refs}
+    repos.add("")
+    for repo in sorted(repos):
+        for job_id in _list_workspace_ids(repo):
+            ref = (job_id, repo)
+            if ref in seen:
+                continue
+            seen.add(ref)
+            job_refs.append(ref)
+    return job_refs
+
+
 def _configured_workspace_jobs():
     state = load_state()
     jobs = []
@@ -348,7 +363,7 @@ def _parse_run_command(command):
     }
 
 
-def _matches_managed_run(job_id, pid, command):
+def _matches_managed_run(job_id, pid, command, repo=""):
     parsed = _parse_run_command(command)
     if not parsed:
         return None
@@ -366,6 +381,11 @@ def _matches_managed_run(job_id, pid, command):
         if os.path.normpath(cwd or "") != REPO_DIR:
             return None
 
+    expected_repo_dir = os.path.normpath(_resolve_work_repo_dir(parsed["repo"] or ""))
+    lock_repo_dir = os.path.normpath(_resolve_work_repo_dir(repo))
+    if expected_repo_dir != lock_repo_dir:
+        return None
+
     return {
         "agent_id": job_id,
         "pid": pid,
@@ -378,9 +398,7 @@ def find_managed_runs(agent_id=None):
         configured_jobs = dict(_configured_workspace_jobs())
         job_refs = [(agent_id, configured_jobs.get(agent_id, ""))]
     else:
-        job_refs = _configured_workspace_jobs()
-        if not job_refs:
-            job_refs = [(job_id, "") for job_id in _list_workspace_ids()]
+        job_refs = _bulk_workspace_refs()
 
     runs = []
     for job_id, repo in job_refs:
@@ -391,7 +409,7 @@ def find_managed_runs(agent_id=None):
         command = _read_process_command(pid)
         if not command:
             continue
-        run = _matches_managed_run(job_id, pid, command)
+        run = _matches_managed_run(job_id, pid, command, repo)
         if run:
             runs.append(run)
     return runs
@@ -408,7 +426,10 @@ def _pid_is_alive(pid):
 
 
 def _terminate_pid(pid, timeout=2.0):
-    os.kill(pid, signal.SIGTERM)
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "SIGTERM"
 
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -416,7 +437,10 @@ def _terminate_pid(pid, timeout=2.0):
             return "SIGTERM"
         time.sleep(0.05)
 
-    os.kill(pid, signal.SIGKILL)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return "SIGTERM"
     return "SIGKILL"
 
 

--- a/tests/test_manage_kill.py
+++ b/tests/test_manage_kill.py
@@ -214,6 +214,51 @@ class ManageKillTests(unittest.TestCase):
             ],
         )
 
+    def test_find_managed_runs_uses_union_of_configured_and_discovered_workspaces(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage,
+            "_configured_workspace_jobs",
+            return_value=[("worker-02", "github.com/alexjaniak/Forge")],
+        ), patch.object(
+            manage,
+            "_list_workspace_ids",
+            side_effect=lambda repo="": {
+                "": ["worker-03"],
+                "github.com/alexjaniak/Forge": ["worker-02"],
+            }.get(repo, []),
+        ), patch.object(
+            manage,
+            "_read_lock_pid",
+            side_effect=lambda path: {
+                "/tmp/forge/.repos/github.com/alexjaniak/Forge/.worktrees/worker-02/.agent.lock": 101,
+                "/tmp/forge/.worktrees/worker-03/.agent.lock": 303,
+            }.get(path),
+        ), patch.object(
+            manage,
+            "_read_process_command",
+            side_effect=lambda pid: {
+                101: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+                303: "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 'prompt'",
+            }.get(pid),
+        ):
+            runs = manage.find_managed_runs()
+
+        self.assertEqual(
+            runs,
+            [
+                {
+                    "agent_id": "worker-02",
+                    "pid": 101,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/alexjaniak/Forge 'prompt'",
+                },
+                {
+                    "agent_id": "worker-03",
+                    "pid": 303,
+                    "command": "/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-03 'prompt'",
+                },
+            ],
+        )
+
     def test_find_managed_runs_rejects_reused_pid_from_other_checkout(self):
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
             manage, "_configured_workspace_jobs", return_value=[]
@@ -231,6 +276,24 @@ class ManageKillTests(unittest.TestCase):
             manage,
             "_read_process_cwd",
             return_value="/tmp/other-checkout",
+        ):
+            runs = manage.find_managed_runs()
+
+        self.assertEqual(runs, [])
+
+    def test_find_managed_runs_rejects_repo_mismatch_for_same_workspace_id(self):
+        with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
+            manage,
+            "_configured_workspace_jobs",
+            return_value=[("worker-02", "github.com/acme/one")],
+        ), patch.object(
+            manage,
+            "_read_lock_pid",
+            return_value=101,
+        ), patch.object(
+            manage,
+            "_read_process_command",
+            return_value="/bin/bash /tmp/forge/agent-kernel/run.sh --workspace worker-02 --repo github.com/acme/two 'prompt'",
         ):
             runs = manage.find_managed_runs()
 
@@ -254,6 +317,28 @@ class ManageKillTests(unittest.TestCase):
                 {"agent_id": "worker-03", "pid": 202, "command": "cmd-2", "signal": "SIGKILL"},
             ],
         )
+
+    def test_terminate_pid_treats_missing_process_during_term_as_exited(self):
+        with patch.object(manage, "os") as os_module:
+            os_module.kill.side_effect = ProcessLookupError
+
+            signal_used = manage._terminate_pid(101)
+
+        self.assertEqual(signal_used, "SIGTERM")
+
+    def test_terminate_pid_treats_missing_process_during_kill_as_exited(self):
+        with patch.object(manage, "_pid_is_alive", return_value=True), patch.object(
+            manage, "time"
+        ) as time_module, patch.object(
+            manage, "os"
+        ) as os_module:
+            time_module.time.side_effect = [0.0, 0.0, 3.0]
+            time_module.sleep.return_value = None
+            os_module.kill.side_effect = [None, ProcessLookupError]
+
+            signal_used = manage._terminate_pid(101)
+
+        self.assertEqual(signal_used, "SIGTERM")
 
     def test_cmd_kill_prints_specific_no_match_message(self):
         with patch.object(manage, "kill_managed_runs", return_value=[]), patch(


### PR DESCRIPTION
**@worker-01**

## Summary
Fix `forge kill` backend correctness gaps called out in super review for #839.

## What Changed
- probe the union of configured workspace jobs and discovered lock-backed workspaces during bulk kill
- reject repo-mismatched processes when the workspace id matches but the lock belongs to a different repo root
- treat `ProcessLookupError` during TERM/KILL races as an already-exited process instead of crashing
- add focused backend tests for the union discovery path, repo-aware matching, and termination races

## Testing
- `python3 -m unittest tests.test_manage_kill`

Closes #839
