### PR TITLE
forge status: show locked issue ownership for applied agents

### DIFF
--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -62,7 +62,13 @@ Show all agents grouped by state: staged, active, and unstaged (active but not i
 
 `uv run forge list`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+Displays each agent's ID, role, interval, last run time, next run countdown, and any currently locked issue for active agents. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+
+Example active line with an issue lock:
+
+```text
+  worker-04            worker     5m    last: 12s ago                 next: 4m 48s (issue #892)
+```
 
 ### `forge logs`
 

--- a/apps/forge-cli/src/forge_cli/list_cmd.py
+++ b/apps/forge-cli/src/forge_cli/list_cmd.py
@@ -1,11 +1,13 @@
 """forge list — unified staged vs active agent view."""
 
+import json
 import os
 import re
+from pathlib import Path
 
 import click
 
-from forge_cli.paths import _get_manage
+from forge_cli.paths import _get_manage, common_repo_root
 
 
 def _role_from_id(agent_id):
@@ -27,6 +29,34 @@ def _format_relative(seconds):
     return f"{secs}s"
 
 
+def _load_issue_locks():
+    """Return a map of agent_id -> issue number for valid local repo issue locks."""
+    issue_locks = {}
+    issues_dir = Path(common_repo_root()) / "locks" / "issues"
+    if not issues_dir.is_dir():
+        return issue_locks
+
+    for lock_dir in sorted(issues_dir.glob("*.lock")):
+        info_file = lock_dir / "info.json"
+        if not info_file.is_file():
+            continue
+
+        try:
+            with open(info_file) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        agent_id = data.get("agent")
+        issue_number = lock_dir.name.removesuffix(".lock")
+        if not isinstance(agent_id, str) or not agent_id or not issue_number.isdigit():
+            continue
+
+        issue_locks.setdefault(agent_id, issue_number)
+
+    return issue_locks
+
+
 @click.command("list")
 def list_cmd():
     """Show all agents grouped by state (staged, active, orphan)."""
@@ -45,6 +75,7 @@ def list_cmd():
     # Load active state (cron-state.json)
     state = manage.load_state()
     active_jobs = state.get("jobs", {})
+    issue_locks = _load_issue_locks()
 
     staged_ids = set(staged_jobs.keys())
     active_ids = set(active_jobs.keys())
@@ -125,10 +156,15 @@ def list_cmd():
                 last_str = "last: never"
                 next_str = "next: —"
 
+            issue_suffix = ""
+            if agent_id in issue_locks:
+                issue_suffix = f" {click.style(f'(issue #{issue_locks[agent_id]})', dim=True)}"
+
             click.echo(
                 f"  {agent_id:<20} {role:<10} {interval:<6}"
                 f"{click.style(last_str, fg='cyan'):<30} "
                 f"{click.style(next_str, fg='cyan')}"
+                f"{issue_suffix}"
             )
         click.echo()
     elif not active_jobs:

--- a/apps/forge-cli/src/forge_cli/paths.py
+++ b/apps/forge-cli/src/forge_cli/paths.py
@@ -22,6 +22,21 @@ def repo_root():
         sys.exit(1)
 
 
+def common_repo_root():
+    """Return the shared repository root, resolving git worktrees correctly."""
+    try:
+        git_common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        click.echo("Error: not inside a git repository.", err=True)
+        sys.exit(1)
+
+    return os.path.dirname(git_common_dir)
+
+
 def cron_jobs_path():
     return os.path.join(repo_root(), "agent-kernel", "cron", "cron-jobs.json")
 

--- a/tests/test_forge_cli_status.py
+++ b/tests/test_forge_cli_status.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from forge_cli.list_cmd import list_cmd
+
+
+class _FakeManage:
+    def __init__(self, jobs_file: Path, active_jobs: dict):
+        self.JOBS_FILE = str(jobs_file)
+        self._active_jobs = active_jobs
+
+    def load_state(self):
+        return {"jobs": self._active_jobs}
+
+    def compute_next_run(self, last_run, interval):
+        return None
+
+
+def test_status_shows_locked_issue_and_ignores_malformed_lock(tmp_path, monkeypatch):
+    jobs_file = tmp_path / "agent-kernel" / "cron" / "cron-jobs.json"
+    jobs_file.parent.mkdir(parents=True)
+    jobs_file.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"id": "worker-01", "interval": "5m"},
+                    {"id": "worker-02", "interval": "10m"},
+                ]
+            }
+        )
+    )
+
+    locks_dir = tmp_path / "locks" / "issues"
+    (locks_dir / "892.lock").mkdir(parents=True)
+    (locks_dir / "892.lock" / "info.json").write_text(
+        json.dumps({"agent": "worker-01", "pid": 123, "claimed_at": "2026-03-18T00:00:00Z"})
+    )
+    (locks_dir / "893.lock").mkdir()
+    (locks_dir / "893.lock" / "info.json").write_text("{not-json")
+
+    active_jobs = {
+        "worker-01": {"interval": "5m"},
+        "worker-02": {"interval": "10m"},
+    }
+    manage = _FakeManage(jobs_file, active_jobs)
+
+    monkeypatch.setattr("forge_cli.list_cmd._get_manage", lambda: manage)
+    monkeypatch.setattr("forge_cli.list_cmd.common_repo_root", lambda: str(tmp_path))
+
+    result = CliRunner().invoke(list_cmd)
+
+    assert result.exit_code == 0
+    assert "worker-01" in result.output
+    assert "(issue #892)" in result.output
+    assert "worker-02" in result.output
+    assert "(issue #893)" not in result.output


### PR DESCRIPTION
**@worker-04**

## Summary
- show active `forge status` agents with inline locked issue metadata when a valid local repo issue lock exists
- resolve lock discovery against the shared git repo root so status works from worktrees
- document the new output and add regression coverage for malformed lock files

Closes #892
