### PR TITLE
Dashboard: surface issue lock ownership in agents and issues APIs

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -81,6 +81,16 @@ Returns all agents with computed status and metadata. Reads staged config from `
 
 Running state is detected via `.agent.lock` PID files in agent worktrees.
 
+When an agent holds a valid issue lock under `locks/issues/<number>.lock/info.json`, the response also includes:
+
+- `lockedIssue.number`
+- `lockedIssue.claimedAt`
+- `lockedIssue.repo`
+- `lockedIssue.repoUrl`
+- `lockedIssue.issueUrl`
+
+Malformed lock payloads, missing `info.json`, and stale locks with dead PIDs are ignored.
+
 ### `POST /api/agents`
 
 Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`. Auto-generates ID as `{type}-{N}` if not provided.
@@ -116,9 +126,19 @@ Returns up to 50 GitHub events from `apps/webhook-monitor/events.jsonl`, parsed 
 ### `GET /api/issues`
 Returns open GitHub issues via `gh issue list`. Response cached server-side for 5s. Returns `{ issues, labels, repo }`, where `labels` is the hardcoded canonical `status`, `role`, and `type` label set defined in app source so the Issues tab can render filter chips even when a label has zero open matches.
 
+Each issue may also include additive lock metadata when a valid issue lock exists:
+
+- `workingAgentId`
+- `workingLock.claimedAt`
+- `workingLock.repo`
+- `workingLock.repoUrl`
+- `workingLock.issueUrl`
+
+Malformed lock payloads, missing `info.json`, and stale locks with dead PIDs are ignored.
+
 ### `GET /api/issues/stream`
 
-Server-Sent Events endpoint for live issue snapshots. Sends an initial `{ issues, labels, repo }` snapshot immediately on connect, then emits updated snapshots when the GitHub event feed changes in ways that affect the Issues tab. The frontend falls back to polling `GET /api/issues` if the stream disconnects.
+Server-Sent Events endpoint for live issue snapshots. Sends an initial `{ issues, labels, repo }` snapshot immediately on connect, then emits updated snapshots when the GitHub event feed changes in ways that affect the Issues tab. Live snapshots include the same additive issue-lock metadata as `GET /api/issues`. The frontend falls back to polling `GET /api/issues` if the stream disconnects.
 
 ## Environment Variables
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -10,6 +10,7 @@ import {
   templatePath,
   worktreePath,
 } from "@/lib/paths";
+import { IssueLockMetadata, readIssueLocks } from "@/lib/issue-locks";
 
 interface CronJob {
   id: string;
@@ -89,7 +90,8 @@ function buildAgentFromJob(
   job: CronJob,
   jobState: CronState["jobs"][string] | undefined,
   status: "staged" | "active" | "modified" | "orphan",
-  stagedInterval?: string
+  stagedInterval?: string,
+  issueLock?: IssueLockMetadata
 ) {
   const intervalSeconds = parseIntervalSeconds(job.interval);
   const lastRun = jobState?.last_run ?? null;
@@ -133,6 +135,17 @@ function buildAgentFromJob(
     workspace: job.workspace,
     repo: job.repo ?? "",
     status,
+    ...(issueLock
+      ? {
+          lockedIssue: {
+            number: issueLock.issueNumber,
+            claimedAt: issueLock.claimedAt,
+            repo: issueLock.repo,
+            repoUrl: issueLock.repoUrl,
+            issueUrl: issueLock.issueUrl,
+          },
+        }
+      : {}),
     ...(stagedInterval ? { stagedInterval } : {}),
   };
 }
@@ -158,13 +171,32 @@ export async function GET() {
 
   const stagedIds = new Set(jobs.map((j) => j.id));
   const activeIds = new Set(Object.keys(state.jobs ?? {}));
+  const issueLocksByRepo = new Map<string, ReturnType<typeof readIssueLocks>>();
+
+  function getAgentIssueLock(agentId: string, repo?: string) {
+    const cacheKey = repo ?? "";
+    let locks = issueLocksByRepo.get(cacheKey);
+    if (!locks) {
+      locks = readIssueLocks(repo);
+      issueLocksByRepo.set(cacheKey, locks);
+    }
+
+    for (const lock of locks.values()) {
+      if (lock.agentId === agentId) {
+        return lock;
+      }
+    }
+
+    return undefined;
+  }
 
   const agents = jobs.map((job) => {
     const jobState = state.jobs?.[job.id];
     const inState = activeIds.has(job.id);
+    const issueLock = getAgentIssueLock(job.id, job.repo);
 
     if (!hasState || !inState) {
-      return buildAgentFromJob(job, undefined, "staged");
+      return buildAgentFromJob(job, undefined, "staged", undefined, issueLock);
     }
 
     const activeInterval = jobState?.interval;
@@ -172,10 +204,16 @@ export async function GET() {
       // interval field shows the active (running) interval
       // stagedInterval shows what it will change to on next apply
       const modifiedJob = { ...job, interval: activeInterval };
-      return buildAgentFromJob(modifiedJob, jobState, "modified", job.interval);
+      return buildAgentFromJob(
+        modifiedJob,
+        jobState,
+        "modified",
+        job.interval,
+        issueLock
+      );
     }
 
-    return buildAgentFromJob(job, jobState, "active");
+    return buildAgentFromJob(job, jobState, "active", undefined, issueLock);
   });
 
   // Add orphan agents (in state but not in staged config)
@@ -190,7 +228,15 @@ export async function GET() {
         agentic: false,
         workspace: false,
       };
-      agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
+      agents.push(
+        buildAgentFromJob(
+          orphanJob,
+          jobState,
+          "orphan",
+          undefined,
+          getAgentIssueLock(id)
+        )
+      );
     }
   }
 

--- a/apps/web/src/lib/issue-locks.ts
+++ b/apps/web/src/lib/issue-locks.ts
@@ -1,0 +1,136 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { issueLocksPath, repoRootPath } from "@/lib/paths";
+
+export interface IssueLockMetadata {
+  issueNumber: number;
+  agentId: string;
+  claimedAt: string;
+  pid: number;
+  repo: string;
+  repoUrl: string | null;
+  issueUrl: string | null;
+}
+
+export interface IssueLinkMetadata {
+  repo: string;
+  repoUrl: string | null;
+  issueUrl: string | null;
+}
+
+const repoMetadataCache = new Map<string, { repo: string; repoUrl: string | null }>();
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && err.code === "EPERM") {
+      return true;
+    }
+    return false;
+  }
+}
+
+function readRepoMetadata(repo?: string): { repo: string; repoUrl: string | null } {
+  const cacheKey = repo ?? "";
+  const cached = repoMetadataCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  let repoName = "";
+  if (repo?.startsWith("github.com/")) {
+    repoName = repo.slice("github.com/".length);
+  } else {
+    try {
+      repoName = execSync("gh repo view --json nameWithOwner -q '.nameWithOwner'", {
+        cwd: repoRootPath(repo),
+        encoding: "utf-8",
+        timeout: 10000,
+      }).trim();
+    } catch {
+      repoName = "";
+    }
+  }
+
+  const metadata = {
+    repo: repoName,
+    repoUrl: repoName ? `https://github.com/${repoName}` : null,
+  };
+  repoMetadataCache.set(cacheKey, metadata);
+  return metadata;
+}
+
+function parseIssueNumber(dirName: string): number | null {
+  const match = dirName.match(/^(\d+)\.lock$/);
+  if (!match) {
+    return null;
+  }
+  const number = Number.parseInt(match[1], 10);
+  return Number.isFinite(number) ? number : null;
+}
+
+export function readIssueLocks(repo?: string): Map<number, IssueLockMetadata> {
+  const locks = new Map<number, IssueLockMetadata>();
+  const locksDir = issueLocksPath(repo);
+  const repoMetadata = readRepoMetadata(repo);
+
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(locksDir, { withFileTypes: true });
+  } catch {
+    return locks;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const issueNumber = parseIssueNumber(entry.name);
+    if (issueNumber === null) {
+      continue;
+    }
+
+    try {
+      const infoPath = path.join(locksDir, entry.name, "info.json");
+      const raw = fs.readFileSync(infoPath, "utf-8");
+      const parsed = JSON.parse(raw) as {
+        agent?: unknown;
+        claimed_at?: unknown;
+        pid?: unknown;
+      };
+
+      if (
+        typeof parsed.agent !== "string" ||
+        parsed.agent.trim() === "" ||
+        typeof parsed.claimed_at !== "string" ||
+        parsed.claimed_at.trim() === "" ||
+        typeof parsed.pid !== "number" ||
+        !Number.isInteger(parsed.pid) ||
+        parsed.pid <= 0 ||
+        !isProcessAlive(parsed.pid)
+      ) {
+        continue;
+      }
+
+      locks.set(issueNumber, {
+        issueNumber,
+        agentId: parsed.agent,
+        claimedAt: parsed.claimed_at,
+        pid: parsed.pid,
+        repo: repoMetadata.repo,
+        repoUrl: repoMetadata.repoUrl,
+        issueUrl: repoMetadata.repo
+          ? `https://github.com/${repoMetadata.repo}/issues/${issueNumber}`
+          : null,
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return locks;
+}

--- a/apps/web/src/lib/issues.ts
+++ b/apps/web/src/lib/issues.ts
@@ -1,9 +1,19 @@
 import { execSync } from "child_process";
 import { readCanonicalIssueLabels } from "@/lib/github-labels";
 import { getForgeRoot } from "@/lib/paths";
+import { IssueLinkMetadata, readIssueLocks } from "@/lib/issue-locks";
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  labels: { name: string; color: string }[];
+  assignees: { login: string }[];
+  workingAgentId?: string;
+  workingLock?: IssueLinkMetadata & { claimedAt: string };
+}
 
 export interface IssueSnapshot {
-  issues: unknown[];
+  issues: GitHubIssue[];
   labels: ReturnType<typeof readCanonicalIssueLabels>;
   repo: string;
 }
@@ -38,7 +48,8 @@ export async function getIssueSnapshot(options?: {
     { cwd, encoding: "utf-8", timeout: 10000 }
   );
 
-  const issues = JSON.parse(raw) as unknown[];
+  const issues = JSON.parse(raw) as GitHubIssue[];
+  const issueLocks = readIssueLocks();
   let repo = "";
 
   try {
@@ -51,6 +62,24 @@ export async function getIssueSnapshot(options?: {
     // Non-fatal. Issue links fall back to plain cards.
   }
 
-  cache = { issues, labels, repo, ts: now };
-  return { issues, labels, repo };
+  const issuesWithLockMetadata = issues.map((issue) => {
+    const issueLock = issueLocks.get(issue.number);
+    if (!issueLock) {
+      return issue;
+    }
+
+    return {
+      ...issue,
+      workingAgentId: issueLock.agentId,
+      workingLock: {
+        claimedAt: issueLock.claimedAt,
+        repo: issueLock.repo,
+        repoUrl: issueLock.repoUrl,
+        issueUrl: issueLock.issueUrl,
+      },
+    };
+  });
+
+  cache = { issues: issuesWithLockMetadata, labels, repo, ts: now };
+  return { issues: issuesWithLockMetadata, labels, repo };
 }

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -19,15 +19,26 @@ export function cronStatePath(): string {
   return path.join(getForgeRoot(), "agent-kernel/cron/cron-state.json");
 }
 
-export function worktreePath(agentId: string, repo?: string): string {
-  if (repo) {
-    return path.join(getForgeRoot(), `.repos/${repo}/.worktrees/${agentId}`);
+export function repoRootPath(repo?: string): string {
+  if (!repo) {
+    return getForgeRoot();
   }
-  return path.join(getForgeRoot(), `.worktrees/${agentId}`);
+  if (path.isAbsolute(repo)) {
+    return repo;
+  }
+  return path.join(getForgeRoot(), `.repos/${repo}`);
+}
+
+export function worktreePath(agentId: string, repo?: string): string {
+  return path.join(repoRootPath(repo), `.worktrees/${agentId}`);
 }
 
 export function lockFilePath(agentId: string, repo?: string): string {
   return path.join(worktreePath(agentId, repo), ".agent.lock");
+}
+
+export function issueLocksPath(repo?: string): string {
+  return path.join(repoRootPath(repo), "locks/issues");
 }
 
 export function agentLogPath(agentId: string): string {


### PR DESCRIPTION
**@worker-03**

## Summary
- add a shared issue-lock reader that tolerates missing, malformed, and stale lock entries
- extend `/api/agents` with additive `lockedIssue` metadata for agents holding valid issue locks
- extend `/api/issues` and stream snapshots with additive `workingAgentId` and lock link metadata
- document the new response fields in `apps/web/README.md`
