### PR TITLE
Ignore stale issue locks in forge list

### DIFF
--- a/apps/forge-cli/src/forge_cli/list_cmd.py
+++ b/apps/forge-cli/src/forge_cli/list_cmd.py
@@ -1,12 +1,12 @@
 """forge list — unified staged vs active agent view."""
 
-import json
 import os
 import re
 from pathlib import Path
 
 import click
 
+from forge_cli.locks import _parse_lock
 from forge_cli.paths import _get_manage, common_repo_root
 
 
@@ -37,14 +37,8 @@ def _load_issue_locks():
         return issue_locks
 
     for lock_dir in sorted(issues_dir.glob("*.lock")):
-        info_file = lock_dir / "info.json"
-        if not info_file.is_file():
-            continue
-
-        try:
-            with open(info_file) as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, OSError):
+        data = _parse_lock(lock_dir)
+        if data is None or data["stale"]:
             continue
 
         agent_id = data.get("agent")

--- a/tests/test_forge_cli_status.py
+++ b/tests/test_forge_cli_status.py
@@ -37,6 +37,10 @@ def test_status_shows_locked_issue_and_ignores_malformed_lock(tmp_path, monkeypa
     (locks_dir / "892.lock" / "info.json").write_text(
         json.dumps({"agent": "worker-01", "pid": 123, "claimed_at": "2026-03-18T00:00:00Z"})
     )
+    (locks_dir / "894.lock").mkdir()
+    (locks_dir / "894.lock" / "info.json").write_text(
+        json.dumps({"agent": "worker-02", "pid": 999, "claimed_at": "2026-03-18T00:00:00Z"})
+    )
     (locks_dir / "893.lock").mkdir()
     (locks_dir / "893.lock" / "info.json").write_text("{not-json")
 
@@ -48,6 +52,7 @@ def test_status_shows_locked_issue_and_ignores_malformed_lock(tmp_path, monkeypa
 
     monkeypatch.setattr("forge_cli.list_cmd._get_manage", lambda: manage)
     monkeypatch.setattr("forge_cli.list_cmd.common_repo_root", lambda: str(tmp_path))
+    monkeypatch.setattr("forge_cli.locks._pid_alive", lambda pid: pid == 123)
 
     result = CliRunner().invoke(list_cmd)
 
@@ -56,3 +61,4 @@ def test_status_shows_locked_issue_and_ignores_malformed_lock(tmp_path, monkeypa
     assert "(issue #892)" in result.output
     assert "worker-02" in result.output
     assert "(issue #893)" not in result.output
+    assert "(issue #894)" not in result.output


### PR DESCRIPTION
**@worker-03**

## Summary
Ignore stale issue locks in `forge list` by reusing the existing CLI lock parser, so only valid live issue locks render the `(issue #N)` suffix.

## Testing
- `pytest tests/test_forge_cli_status.py`
