### PR TITLE
Fix dashboard reset first-run semantics and docs

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -78,7 +78,7 @@ Returns all agents with computed status and metadata. Reads staged config from `
 
 - **new** — in staged config but not applied state yet
 - **active** — in both with matching applied interval
-- **modified** — in both, but the staged interval differs from the running interval
+- **modified** — in both, but one or more compared fields differ between staged and applied config (`interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`)
 - **deleted** — in applied state but removed from staged config
 
 Running state is detected via `.agent.lock` PID files in agent worktrees.
@@ -109,7 +109,7 @@ Returns a field-level staged vs applied diff for agent records. Response shape i
 
 ### `POST /api/agents/reset`
 
-Rebuilds staged config from the currently applied state while preserving the top-level `stagger` setting from `cron-jobs.json`.
+Rebuilds staged config from the currently applied state while preserving the top-level `stagger` setting from `cron-jobs.json`. If `cron-state.json` does not exist yet, reset treats the applied state as empty and clears staged-only changes instead of returning an error.
 
 ### `GET /api/logs/[agentId]?offset={n}`
 

--- a/apps/web/src/app/api/agents/reset/route.ts
+++ b/apps/web/src/app/api/agents/reset/route.ts
@@ -35,15 +35,13 @@ interface CronJobsConfig {
 
 export async function POST() {
   try {
+    // Match CLI reset semantics: no applied state means "reset to empty".
     let state: CronState = { jobs: {} };
     try {
       const raw = fs.readFileSync(cronStatePath(), "utf-8");
       state = JSON.parse(raw);
     } catch {
-      return NextResponse.json(
-        { error: "No applied state found" },
-        { status: 400 }
-      );
+      // no applied state file yet
     }
 
     // Read current config to preserve stagger setting


### PR DESCRIPTION
**@worker-03**

## Summary
- treat a missing `cron-state.json` as an empty applied state in `POST /api/agents/reset`
- preserve the existing reset response shape while clearing staged-only changes on first run
- update the web README to document full staged-vs-applied `modified` semantics and first-run reset behavior

## Verification
- `npm run lint` in `apps/web` (fails due to pre-existing issues in `src/components/agent-panel.tsx` and `src/components/resizable-layout.tsx`)
