### PR TITLE
Align status modified detection and CLI docs

### DIFF
--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -1,6 +1,6 @@
 # forge-cli
 
-Agent orchestration CLI for Forge. Manage agents, cron jobs, webhooks, and logs from a single command.
+Agent orchestration CLI for Forge. Manage staged/applied agents, webhooks, logs, and the local UI from a single command.
 
 ## Installation
 
@@ -42,27 +42,41 @@ uv run forge add worker --id worker-05 --interval 10m
 uv run forge add --list
 ```
 
-The agent is staged in `cron-jobs.json`. Run `uv run forge cron apply` to activate.
+The agent is staged in `cron-jobs.json`. Run `uv run forge apply` to activate.
 
-### `forge remove`
+### `forge rm`
 
 Remove an agent by ID.
 
-`uv run forge remove AGENT_ID`
+`uv run forge rm AGENT_ID`
 
 ```bash
-uv run forge remove worker-03
+uv run forge rm worker-03
 ```
 
-Removes the agent from `cron-jobs.json`. Run `uv run forge cron apply` to deactivate.
+Removes the agent from `cron-jobs.json`. Run `uv run forge apply` to deactivate.
 
 ### `forge status`
 
-Show all agents grouped by state: staged, active, and unstaged (active but not in config).
+Show the git-style staged vs applied agent status view.
 
 `uv run forge status`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+Displays pending staged changes (`new`, `modified`, `deleted`) plus the currently applied agents with last/next run timing. A staged change to any diffed field is surfaced as `modified`.
+
+### `forge diff`
+
+Show field-by-field differences between staged config and applied state.
+
+`uv run forge diff`
+
+Highlights changes to `interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`, and `enabled`.
+
+### `forge apply`
+
+Apply staged config to the managed crontab.
+
+`uv run forge apply`
 
 ### `forge logs`
 
@@ -101,70 +115,31 @@ Reset staged config — remove all agents from `cron-jobs.json`.
 uv run forge clear -y
 ```
 
-Run `uv run forge cron apply` afterwards to deactivate the cleared agents.
+Run `uv run forge apply` afterwards to deactivate the cleared agents.
 
-### `forge cron`
+### `forge reset`
 
-Manage agent cron jobs directly.
+Discard staged changes and restore the staged config from applied state.
 
-#### `forge cron apply`
+`uv run forge reset`
 
-Sync the system crontab to match `cron-jobs.json`.
+### `forge run`
 
-```bash
-uv run forge cron apply
-```
+Run a single agent immediately.
 
-#### `forge cron add`
+`uv run forge run AGENT_ID`
 
-Add a single cron job.
+### `forge locks`
 
-`uv run forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]`
+Inspect repo/issue lock state used by the agent kernel.
 
-**Arguments:**
+`uv run forge locks list`
 
-| Argument | Description |
-|----------|-------------|
-| `ID` | Job identifier |
-| `INTERVAL` | Schedule interval (e.g. `5m`, `1h`) |
-| `PROMPT` | Prompt text for the agent |
+### `forge ui`
 
-**Options:**
+Start the local Forge web UI.
 
-| Flag | Description |
-|------|-------------|
-| `--agentic` | Enable tool use |
-| `--workspace` | Run in isolated git worktree |
-| `--context TEXT` | Context file path (repeatable) |
-| `--repo REPO` | Target repo |
-
-```bash
-uv run forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
-```
-
-#### `forge cron remove`
-
-Remove a cron job by ID.
-
-```bash
-uv run forge cron remove summary-bot
-```
-
-#### `forge cron run`
-
-Run a job once immediately.
-
-```bash
-uv run forge cron run worker-01
-```
-
-#### `forge cron clear`
-
-Remove all agent-kernel cron jobs from the system crontab.
-
-```bash
-uv run forge cron clear
-```
+`uv run forge ui`
 
 ### `forge wh`
 

--- a/apps/forge-cli/src/forge_cli/diff_cmd.py
+++ b/apps/forge-cli/src/forge_cli/diff_cmd.py
@@ -35,6 +35,20 @@ def _get_field(job, field):
     return job.get(field)
 
 
+def get_modified_fields(staged_job, applied_job):
+    """Return staged-vs-applied field changes for a single job."""
+    changes = []
+    for field in DIFF_FIELDS:
+        staged_val = _get_field(staged_job, field)
+        applied_val = _get_field(applied_job, field)
+        if (
+            normalize_optional_cron_field(field, staged_val)
+            != normalize_optional_cron_field(field, applied_val)
+        ):
+            changes.append((field, applied_val, staged_val))
+    return changes
+
+
 @click.command("diff")
 def diff_cmd():
     """Show differences between staged config and applied state."""
@@ -60,15 +74,7 @@ def diff_cmd():
     # Find modified agents among common ones
     modified = {}
     for agent_id in common_ids:
-        changes = []
-        for field in DIFF_FIELDS:
-            staged_val = _get_field(staged_jobs[agent_id], field)
-            applied_val = _get_field(applied_jobs[agent_id], field)
-            if (
-                normalize_optional_cron_field(field, staged_val)
-                != normalize_optional_cron_field(field, applied_val)
-            ):
-                changes.append((field, applied_val, staged_val))
+        changes = get_modified_fields(staged_jobs[agent_id], applied_jobs[agent_id])
         if changes:
             modified[agent_id] = changes
 

--- a/apps/forge-cli/src/forge_cli/list_cmd.py
+++ b/apps/forge-cli/src/forge_cli/list_cmd.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 import click
 
+from forge_cli.diff_cmd import get_modified_fields
 from forge_cli.paths import _get_manage
 
 
@@ -56,7 +57,7 @@ def list_cmd():
 
     modified_ids = set()
     for agent_id in common_ids:
-        if staged_jobs[agent_id]["interval"] != active_jobs[agent_id].get("interval"):
+        if get_modified_fields(staged_jobs[agent_id], active_jobs[agent_id]):
             modified_ids.add(agent_id)
 
     has_changes = new_ids or deleted_ids or modified_ids
@@ -71,11 +72,11 @@ def list_cmd():
                 f"        {click.style('new:', fg='green')}      {click.style(agent_id, fg='green')}"
             )
         for agent_id in sorted(modified_ids):
-            old_interval = active_jobs[agent_id].get("interval", "?")
-            new_interval = staged_jobs[agent_id]["interval"]
+            changed_fields = [field for field, _, _ in get_modified_fields(staged_jobs[agent_id], active_jobs[agent_id])]
+            summary = ", ".join(changed_fields)
             click.echo(
                 f"        {click.style('modified:', fg='yellow')} {click.style(agent_id, fg='yellow')}"
-                f"  {click.style(f'(interval: {old_interval} → {new_interval})', fg='yellow')}"
+                f"  {click.style(f'(fields: {summary})', fg='yellow')}"
             )
         for agent_id in sorted(deleted_ids):
             click.echo(


### PR DESCRIPTION
**@worker-04**

## Summary
- align `forge status` modified detection with the same staged-vs-applied field comparison used by `forge diff`
- update the CLI README to match the rebased command surface (`apply`, `diff`, `reset`, `rm`, `run`, `locks`, `ui`, `status`, `wh`)

## Verification
- `PYTHONPATH=src python3 - <<'PY' ... CliRunner().invoke(main, ['--help']) ... PY` confirmed the rebased command table
- `PYTHONPATH=src python3 - <<'PY' ... get_modified_fields ... PY` verified each diff field (`interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`, `enabled`) is detected as modified
- `PYTHONPATH=src python3 - <<'PY' ... CliRunner().invoke(list_cmd, []) ... PY` confirmed `forge status` reports a prompt-only staged drift as `modified`
- `rg -n "forge (remove|cron|list)\\b|uv run forge (remove|cron|list)\\b" apps/forge-cli/README.md` returned no matches
