### PR TITLE
Dashboard: remove agentic/workspace API contract fields

### DIFF
--- a/apps/web/src/app/api/agents/[id]/force-run/route.ts
+++ b/apps/web/src/app/api/agents/[id]/force-run/route.ts
@@ -16,8 +16,6 @@ interface CronJob {
   interval: string;
   prompt: string;
   contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
   repo?: string;
 }
 
@@ -48,8 +46,7 @@ export async function POST(
   }
 
   const args: string[] = [];
-  if (agent.agentic) args.push("--agentic");
-  if (agent.workspace) args.push("--workspace", agent.id);
+  args.push("--workspace", agent.id);
   for (const ctx of agent.contexts) {
     args.push("--context", ctx);
   }

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -16,8 +16,6 @@ interface CronJob {
   interval: string;
   prompt: string;
   contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
   enabled?: boolean;
   repo?: string;
 }
@@ -129,8 +127,6 @@ function buildAgentFromJob(
     staggerOffset: jobState?.stagger_offset ?? 0,
     prompt: job.prompt,
     contexts: job.contexts,
-    agentic: job.agentic,
-    workspace: job.workspace,
     repo: job.repo ?? "",
     status,
     ...(stagedInterval ? { stagedInterval } : {}),
@@ -187,8 +183,6 @@ export async function GET() {
         interval: jobState.interval ?? "?",
         prompt: "",
         contexts: jobState.contexts ?? [],
-        agentic: false,
-        workspace: false,
       };
       agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
     }
@@ -284,8 +278,6 @@ export async function POST(request: NextRequest) {
       interval: body.interval ?? template.interval ?? "2m",
       prompt: template.prompt ?? "",
       contexts: template.contexts ?? [],
-      agentic: template.agentic ?? true,
-      workspace: template.workspace ?? true,
       repo: template.repo ?? "",
     };
 

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -23,8 +23,6 @@ export async function GET() {
       type,
       interval: data.interval ?? "2m",
       contexts: data.contexts ?? [],
-      agentic: data.agentic ?? true,
-      workspace: data.workspace ?? true,
       repo: data.repo ?? "",
     };
   });

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -16,8 +16,6 @@ interface Agent {
   overdue: boolean;
   prompt: string;
   contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
   repo: string;
   branch: string | null;
   status: AgentStatus;
@@ -248,8 +246,7 @@ interface Template {
   type: string;
   interval: string;
   contexts: string[];
-  agentic: boolean;
-  workspace: boolean;
+  repo: string;
 }
 
 function AddAgentModal({


### PR DESCRIPTION
**@planner-04**

Fixes #750

## Summary
- remove obsolete `agentic` / `workspace` fields from dashboard agent and template API payloads
- keep force-run aligned with the simplified runtime by always targeting the agent workspace
- preserve existing agent panel UI while trimming dead contract fields from local types

## Verification
- `git diff --check`
- `npm run lint` in `apps/web` could not run because `eslint` is not installed in this worktree
