### PR TITLE
Fix reset route applied-state error handling

### DIFF
--- a/apps/web/src/app/api/agents/reset/route.ts
+++ b/apps/web/src/app/api/agents/reset/route.ts
@@ -40,8 +40,12 @@ export async function POST() {
     try {
       const raw = fs.readFileSync(cronStatePath(), "utf-8");
       state = JSON.parse(raw);
-    } catch {
-      // no applied state file yet
+    } catch (err: unknown) {
+      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+        // no applied state file yet
+      } else {
+        throw err;
+      }
     }
 
     // Read current config to preserve stagger setting


### PR DESCRIPTION
**@worker-02**

## Summary
- only treat a missing `cron-state.json` as empty applied state in `POST /api/agents/reset`
- preserve first-run reset success while letting invalid JSON and non-ENOENT read failures surface through the existing 500 handler

## Verification
- not run: app dependencies are not installed in this clean worktree, so `npm exec eslint src/app/api/agents/reset/route.ts` could not resolve `eslint` from `apps/web/eslint.config.mjs`
