### PR TITLE
Dashboard UX replay fix: restore current panel presentation

### DIFF
--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -187,38 +187,28 @@ function AgentCard({
         </button>
       </div>
 
-      {agent.branch && (
-        <div className="text-sm text-muted-foreground ml-4 mb-1 truncate" title={agent.branch}>
-          {agent.branch}
-        </div>
-      )}
+      <div className="text-sm text-muted-foreground ml-4 mb-1 truncate" title={agent.branch ?? undefined}>
+        {agent.branch ?? "\u2014"}
+      </div>
 
-      <div className="flex items-center gap-1.5 text-sm text-text ml-4 mb-2">
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 text-sm text-text ml-4 mb-2">
         <span className="text-muted-foreground">every</span>
-        <span title="Interval">{agent.interval}</span>
-        {agent.status === "modified" && agent.stagedInterval && (
-          <span className="text-accent-yellow" title="Pending interval change">
-            → {agent.stagedInterval}
-          </span>
-        )}
-        {agent.lastRun && (
-          <>
-            <span className="text-muted-foreground">·</span>
-            <span className="text-muted-foreground">ran</span>
-            <span title={`Last run: ${agent.lastRun}`}>
-              {relativeTime(agent.lastRun)}
+        <span>
+          <span title="Interval">{agent.interval}</span>
+          {agent.status === "modified" && agent.stagedInterval && (
+            <span className="text-accent-yellow ml-1" title="Pending interval change">
+              → {agent.stagedInterval}
             </span>
-          </>
-        )}
-        {agent.nextRun && (
-          <>
-            <span className="text-muted-foreground">·</span>
-            <span className="text-muted-foreground">next</span>
-            <span className="text-accent-cyan" title={`Next run: ${agent.nextRun}`}>
-              {countdown(agent.nextRun)}
-            </span>
-          </>
-        )}
+          )}
+        </span>
+        <span className="text-muted-foreground">ran</span>
+        <span title={agent.lastRun ? `Last run: ${agent.lastRun}` : undefined}>
+          {agent.lastRun ? relativeTime(agent.lastRun) : "\u2014"}
+        </span>
+        <span className="text-muted-foreground">next</span>
+        <span className={agent.nextRun ? "text-accent-cyan" : ""} title={agent.nextRun ? `Next run: ${agent.nextRun}` : undefined}>
+          {agent.nextRun ? countdown(agent.nextRun) : "\u2014"}
+        </span>
       </div>
 
       <div className="flex justify-end mr-1">
@@ -560,7 +550,7 @@ export function AgentPanel({ refreshKey }: { refreshKey?: number }) {
   const hasStagedAgents = agents.filter((a) => a.status !== "orphan").length > 0;
 
   return (
-    <div className="h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
+    <div className="dashboard-scrollbar h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
       <div className="flex items-center gap-2 py-2">
         <button
           className="text-xs rounded px-2 py-1 border border-border text-text hover:bg-surface-hover transition-colors"

--- a/apps/web/src/components/events-panel.tsx
+++ b/apps/web/src/components/events-panel.tsx
@@ -161,7 +161,7 @@ export function EventsPanel({ refreshKey }: { refreshKey?: number }) {
         <div
           ref={containerRef}
           onScroll={handleScroll}
-          className="flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
+          className="dashboard-scrollbar flex flex-col gap-2 flex-1 overflow-y-auto min-h-0"
         >
           {events.map((event, i) => (
             <EventCard key={`${event.timestamp}-${i}`} event={event} />

--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -398,7 +398,7 @@ export function LogsPanel({ refreshKey }: { refreshKey?: number }) {
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-2"
+        className="dashboard-scrollbar [--dashboard-scrollbar-surface:var(--background)] flex-1 overflow-y-auto p-4 space-y-2"
       >
         {displayBlocks.length === 0 ? (
           <div className="flex items-center justify-center h-full">
@@ -414,13 +414,6 @@ export function LogsPanel({ refreshKey }: { refreshKey?: number }) {
   );
 }
 
-function getRoleDotColor(agentId: string): string {
-  if (agentId.startsWith("worker")) return "#98c379";
-  if (agentId.startsWith("planner")) return "#c678dd";
-  if (agentId.startsWith("super")) return "#e5c07b";
-  return "#abb2bf";
-}
-
 function formatDuration(startIso: string, endIso: string): string {
   const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
   if (ms < 0) return "";
@@ -433,7 +426,6 @@ function formatDuration(startIso: string, endIso: string): string {
 
 function LogCard({ block }: { block: LogBlock }) {
   const agentColor = getAgentColor(block.agentId);
-  const dotColor = getRoleDotColor(block.agentId);
   const duration =
     block.endTimestamp && block.timestamp
       ? formatDuration(block.timestamp, block.endTimestamp)
@@ -456,17 +448,13 @@ function LogCard({ block }: { block: LogBlock }) {
     >
       <div className="flex items-center gap-2 mb-2">
         <span
-          className="inline-flex items-center gap-1.5 text-sm font-semibold px-2 py-0.5 rounded"
+          className="inline-flex items-center text-sm font-semibold px-2 py-0.5 rounded"
           style={{
             backgroundColor: agentColor + "26",
             color: agentColor,
             border: `1px solid ${agentColor}4D`,
           }}
         >
-          <span
-            className="inline-block w-2 h-2 rounded-full shrink-0"
-            style={{ backgroundColor: dotColor }}
-          />
           {block.agentId}
         </span>
         <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
**@worker-04**

Fixes #917

## Summary
- restore Agent, Events, and Logs panel presentation to match current `main` while keeping the accepted manual-refresh plumbing from #727
- leave Issues panel on a single `type:` chip render path while preserving SSE, polling fallback, and refresh-key fetch behavior already present on `epic/727-dashboard-ux`

## Verification
- `git diff origin/main...HEAD -- apps/web/src/components/agent-panel.tsx apps/web/src/components/events-panel.tsx apps/web/src/components/issues-panel.tsx apps/web/src/components/logs-panel.tsx` only shows the accepted refresh wiring plus the panel-presentation reverts
- `rg -n "typeLabels\\.map|labels\\.type\\.map|refreshKey|EventSource|setInterval\\(fetchIssues|setInterval\\(fetchEvents|fetchInitialLogs\\(" apps/web/src/components/issues-panel.tsx apps/web/src/components/events-panel.tsx apps/web/src/components/logs-panel.tsx` confirms a single `typeLabels.map(...)` render path and retained refresh/SSE logic
- `gh pr view 733 --json mergeable` still reports `CONFLICTING`, so the parent mergeability acceptance item is not yet satisfied in current repo state
