### PR TITLE
Preserve template repo when staging forge add jobs

### DIFF
--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -102,6 +102,8 @@ def add(agent_types, agent_id, interval, list_templates, apply_flag):
         job["contexts"] = template.get("contexts", [])
         job["agentic"] = template.get("agentic", False)
         job["workspace"] = template.get("workspace", False)
+        if "repo" in template:
+            job["repo"] = template["repo"]
 
         cron_data.setdefault("jobs", []).append(job)
         existing_ids.append(aid)

--- a/apps/forge-cli/tests/test_agents_add.py
+++ b/apps/forge-cli/tests/test_agents_add.py
@@ -1,0 +1,47 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from forge_cli.agents import add
+
+
+class AddCommandTests(unittest.TestCase):
+    def test_add_preserves_template_repo_in_staged_job(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        template = json.loads((repo_root / "templates" / "worker.json").read_text(encoding="utf-8"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cron_path = Path(tmpdir) / "cron-jobs.json"
+
+            runner = CliRunner()
+            with patch("forge_cli.agents.cron_jobs_path", return_value=str(cron_path)):
+                result = runner.invoke(add, ["worker"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+
+            staged = json.loads(cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                staged,
+                {
+                    "stagger": True,
+                    "jobs": [
+                        {
+                            "id": "worker-01",
+                            "interval": template["interval"],
+                            "prompt": template["prompt"],
+                            "contexts": template["contexts"],
+                            "agentic": template["agentic"],
+                            "workspace": template["workspace"],
+                            "repo": template["repo"],
+                        }
+                    ],
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**@worker-03**

## Summary
- re-land the minimal issue-920 change on top of `epic/691-cli-redesign-rebased`
- preserve template `repo` when `forge add` stages jobs in the current git-style CLI flow
- add focused regression coverage for `forge add worker` staging

## Verification
- `PYTHONPATH=apps/forge-cli/src python3 -m unittest apps/forge-cli/tests/test_agents_add.py`
- `PYTHONPATH=apps/forge-cli/src python3 -m unittest apps/forge-cli/tests/test_cron_normalization.py`

## Notes
- Issue #927 described the runtime fix as already present on the parent branch, but `origin/epic/691-cli-redesign-rebased` still dropped the template `repo` field during staging. This PR keeps the replacement scope narrow by re-landing only that minimal runtime fix plus regression coverage.
