### PR TITLE
Docs: sync template examples and model guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 apps/webhook-monitor/config.toml
 events.jsonl
 apps/web/events.jsonl
+templates/*.json
+!templates/*.example.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Unified command-line interface for managing agents.
 
 | Command | Description |
 |---------|-------------|
-| `forge add <role>` | Add an agent from a template (worker, planner, super) |
+| `forge add <role>` | Add an agent from tracked template defaults (worker, planner, super) |
 | `forge remove <id>` | Remove an agent |
 | `forge apply` | Sync staged agent config to live crontab |
 | `forge run <id>` | Run an agent once immediately |
@@ -90,14 +90,14 @@ Each `info.json` contains `{"agent": "<id>", "pid": <pid>, "claimed_at": "<ISO t
 agent-kernel/    Core runtime — run.sh entry point, cron scheduling
 apps/            Applications (forge-cli, web dashboard)
 contexts/        Reusable context files that define agent behavior and protocols
-templates/       Agent configuration templates (worker.json, planner.json, super.json)
+templates/       Agent template examples plus local working copies
 ```
 
 - **[agent-kernel](agent-kernel/README.md)** — one-shot Claude CLI wrapper with context assembly, worktree management, and cron-friendly execution
 - **[apps/forge-cli](apps/forge-cli/)** — `forge` CLI for agent lifecycle and orchestration
 - **[apps/web](apps/web/)** — Next.js web dashboard for monitoring agents and events
 - **[contexts](contexts/)** — modular `.md` files shaping agent identity, roles, constraints, handoff protocol, labels, and workspace rules
-- **[templates](templates/)** — JSON templates defining agent interval, prompt, contexts, and flags
+- **[templates](templates/)** — tracked `*.example.json` templates plus local `*.json` working copies for interval, prompt, contexts, model, and flags
 
 ## Getting started
 
@@ -113,6 +113,8 @@ If you prefer another install method, see the official uv installation guide: ht
 If `uv` is not available immediately after installation, restart your shell or source your shell profile before running `./install.sh`.
 
 The install script checks prerequisites, syncs the Python workspace with `uv`, installs dependencies, and generates config files.
+
+Tracked template examples live at `templates/*.example.json`. During setup, `./install.sh` generates local `templates/*.json` working copies from those examples and fills in the repo placeholder. Edit the local `templates/*.json` files for your machine; keep the tracked `*.example.json` files generic.
 
 ### Manual setup
 

--- a/agent-kernel/cron/README.md
+++ b/agent-kernel/cron/README.md
@@ -25,6 +25,7 @@ Source of truth for desired cron state. Checked into git.
       "prompt": "Check for stale PRs",
       "agentic": true,
       "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md"],
+      "model": "gpt-5.4",
       "workspace": true,
       "repo": "github.com/owner/repo",
       "enabled": true
@@ -41,6 +42,7 @@ Source of truth for desired cron state. Checked into git.
 | `agentic` | bool | `false` | Enable tool use (`--agentic`). |
 | `repo` | string | `""` | Target repo (e.g. `"github.com/owner/repo"`). When omitted, the agent targets the Forge repo itself. |
 | `contexts` | string[] | `[]` | List of context file paths relative to repo root, each passed as `--context` to `run.sh`. |
+| `model` | string | `""` | Optional model override passed to `run.sh --model`. |
 | `workspace` | bool | `false` | Run the agent in an isolated git worktree (`--workspace <id>`). |
 | `enabled` | bool | `true` | Set `false` to remove from crontab without deleting config. |
 
@@ -51,7 +53,7 @@ Source of truth for desired cron state. Checked into git.
 ./agent-kernel/cron/manage.py apply
 
 # Imperative — one-off add/remove
-./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" [--agentic]
+./agent-kernel/cron/manage.py add <id> <interval> "<prompt>" [--agentic] [--model <model>]
 ./agent-kernel/cron/manage.py remove <id>
 
 # Inspect
@@ -66,6 +68,8 @@ Source of truth for desired cron state. Checked into git.
 `cron-state.json` is auto-generated and gitignored. It tracks what's actually installed in crontab so `list` works without parsing `crontab -l`.
 
 If the state file gets deleted or out of sync, just run `apply` — it reconverges.
+
+Agent definitions often originate from `forge add`, which now reads tracked `templates/*.example.json` defaults and local `templates/*.json` working copies. The tracked examples should keep the generic `github.com/owner/repo` placeholder; local working copies are where repo-specific values belong.
 
 ## Logs
 

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -22,13 +22,14 @@ Run Forge commands from the repo root with `uv run forge ...`. Requires Python 3
 
 Add an agent from a template.
 
-`uv run forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--list]`
+`uv run forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--model MODEL] [--list]`
 
 | Flag | Description |
 |------|-------------|
 | `AGENT_TYPE` | Template name (e.g. `worker`, `planner`) |
 | `--id ID` | Custom agent ID (default: auto-generate, e.g. `worker-01`) |
 | `--interval INTERVAL` | Override template interval (e.g. `5m`, `1h`) |
+| `--model MODEL` | Override the template model (e.g. `gpt-5.4`) |
 | `--list` | List available templates |
 
 ```bash
@@ -38,11 +39,16 @@ uv run forge add worker
 # Add with custom ID and interval
 uv run forge add worker --id worker-05 --interval 10m
 
+# Add with a model override
+uv run forge add worker --model gpt-5.4
+
 # List available templates
 uv run forge add --list
 ```
 
-The agent is staged in `cron-jobs.json`. Run `uv run forge cron apply` to activate.
+Tracked templates live at `templates/*.example.json`; local `templates/*.json` files are generated working copies and are gitignored. `forge add` prefers the local working copy when it exists and falls back to the tracked example otherwise.
+
+The agent is staged in `cron-jobs.json`. Run `uv run forge apply` to activate.
 
 ### `forge remove`
 
@@ -54,7 +60,7 @@ Remove an agent by ID.
 uv run forge remove worker-03
 ```
 
-Removes the agent from `cron-jobs.json`. Run `uv run forge cron apply` to deactivate.
+Removes the agent from `cron-jobs.json`. Run `uv run forge apply` to deactivate.
 
 ### `forge list` / `forge status`
 
@@ -62,7 +68,7 @@ Show all agents grouped by state: staged, active, and unstaged (active but not i
 
 `uv run forge list`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge apply`.
 
 ### `forge logs`
 
@@ -101,7 +107,7 @@ Reset staged config — remove all agents from `cron-jobs.json`.
 uv run forge clear -y
 ```
 
-Run `uv run forge cron apply` afterwards to deactivate the cleared agents.
+Run `uv run forge apply` afterwards to deactivate the cleared agents.
 
 ### `forge cron`
 
@@ -191,10 +197,10 @@ Auto-tunnel uses `gh webhook forward` (preferred) or `ngrok` if available. Tunne
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `cron-jobs.json` | `agent-kernel/cron/cron-jobs.json` | Staged agent definitions (jobs, intervals, prompts) |
+| `cron-jobs.json` | `agent-kernel/cron/cron-jobs.json` | Staged agent definitions (jobs, intervals, prompts, model overrides) |
 | `cron-state.json` | `agent-kernel/cron/cron-state.json` | Active cron state (last run times, managed by the system) |
 | `config.toml` | `apps/webhook-monitor/config.toml` | Webhook config (`repo.name`, `webhook.secret`) |
-| Templates | `templates/*.json` | Agent templates used by `forge add` |
+| Templates | `templates/*.example.json` | Tracked agent template examples used to generate local working copies |
 
 ### Environment variables
 

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -15,15 +15,23 @@ def _templates_dir():
 
 
 def _available_templates():
-    """Return dict of template_name -> file_path for all .json files in templates/."""
+    """Return dict of template_name -> file_path for local .json or tracked .example.json files."""
     tdir = _templates_dir()
     if not os.path.isdir(tdir):
         return {}
     templates = {}
     for fname in sorted(os.listdir(tdir)):
-        if fname.endswith(".json"):
+        name = None
+        if fname.endswith(".example.json"):
+            name = fname[:-13]
+        elif fname.endswith(".json"):
             name = fname[:-5]
-            templates[name] = os.path.join(tdir, fname)
+        if name is None:
+            continue
+        path = os.path.join(tdir, fname)
+        # Prefer local working copies over tracked examples when both exist.
+        if name not in templates or fname.endswith(".json"):
+            templates[name] = path
     return templates
 
 
@@ -45,8 +53,9 @@ def _next_id(agent_type, existing_ids):
 @click.argument("agent_type", required=False, default=None)
 @click.option("--id", "agent_id", default=None, help="Custom agent ID (default: auto-generate).")
 @click.option("--interval", default=None, help="Override template interval (e.g. 5m, 1h).")
+@click.option("--model", default=None, help="Override template model (e.g. gpt-5.4).")
 @click.option("--list", "list_templates", is_flag=True, help="List available templates.")
-def add(agent_type, agent_id, interval, list_templates):
+def add(agent_type, agent_id, interval, model, list_templates):
     """Add an agent from a template.
 
     AGENT_TYPE is the template name (e.g. worker, planner).
@@ -92,6 +101,11 @@ def add(agent_type, agent_id, interval, list_templates):
     job["contexts"] = template.get("contexts", [])
     job["agentic"] = template.get("agentic", False)
     job["workspace"] = template.get("workspace", False)
+    template_model = template.get("model", "")
+    if model:
+        job["model"] = model
+    elif template_model:
+        job["model"] = template_model
     if "repo" in template:
         job["repo"] = template["repo"]
 
@@ -110,6 +124,8 @@ def add(agent_type, agent_id, interval, list_templates):
         click.echo(f"  contexts:  {', '.join(job['contexts'])}")
     click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
     click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+    if job.get("model"):
+        click.echo(f"  model:     {job['model']}")
     click.echo()
     click.echo("Run `forge apply` to activate.")
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -62,7 +62,8 @@ agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
 gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
 GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
-templates/{type}.json             → POST /api/agents      → (agent creation)
+templates/{type}.json
+  (fallback: templates/{type}.example.json) → POST /api/agents → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
 
@@ -83,7 +84,7 @@ Running state is detected via `.agent.lock` PID files in agent worktrees.
 
 ### `POST /api/agents`
 
-Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`. Auto-generates ID as `{type}-{N}` if not provided.
+Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string, model?: string }`. Loads defaults from `templates/{type}.json` when a local working copy exists, otherwise from `templates/{type}.example.json`. Auto-generates ID as `{type}-{N}` if not provided.
 
 ### `DELETE /api/agents/[id]`
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -19,6 +19,7 @@ interface CronJob {
   agentic: boolean;
   workspace: boolean;
   enabled?: boolean;
+  model?: string;
   repo?: string;
 }
 
@@ -203,8 +204,11 @@ function availableTemplateTypes(): Set<string> {
     return new Set(
       fs
         .readdirSync(templatesDir)
-        .filter((f) => f.endsWith(".json"))
-        .map((f) => f.replace(/\.json$/, ""))
+        .flatMap((f) => {
+          if (f.endsWith(".example.json")) return [f.replace(/\.example\.json$/, "")];
+          if (f.endsWith(".json")) return [f.replace(/\.json$/, "")];
+          return [];
+        })
     );
   } catch {
     return new Set();
@@ -286,6 +290,7 @@ export async function POST(request: NextRequest) {
       contexts: template.contexts ?? [],
       agentic: template.agentic ?? true,
       workspace: template.workspace ?? true,
+      model: body.model ?? template.model ?? "",
       repo: template.repo ?? "",
     };
 

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -10,23 +10,39 @@ export async function GET() {
   try {
     files = fs
       .readdirSync(templatesDir)
-      .filter((f) => f.endsWith(".json"));
+      .filter((f) => f.endsWith(".json") || f.endsWith(".example.json"))
+      .sort((a, b) => {
+        const aIsLocal = a.endsWith(".json") && !a.endsWith(".example.json");
+        const bIsLocal = b.endsWith(".json") && !b.endsWith(".example.json");
+        if (aIsLocal !== bIsLocal) {
+          return aIsLocal ? -1 : 1;
+        }
+        return a.localeCompare(b);
+      });
   } catch {
     return NextResponse.json({ templates: [] });
   }
 
-  const templates = files.map((file) => {
-    const type = file.replace(/\.json$/, "");
+  const seen = new Set<string>();
+  const templates = files.flatMap((file) => {
+    const type = file.endsWith(".example.json")
+      ? file.replace(/\.example\.json$/, "")
+      : file.replace(/\.json$/, "");
+    if (seen.has(type)) {
+      return [];
+    }
+    seen.add(type);
     const raw = fs.readFileSync(path.join(templatesDir, file), "utf-8");
     const data = JSON.parse(raw);
-    return {
+    return [{
       type,
       interval: data.interval ?? "2m",
       contexts: data.contexts ?? [],
       agentic: data.agentic ?? true,
       workspace: data.workspace ?? true,
+      model: data.model ?? "",
       repo: data.repo ?? "",
-    };
+    }];
   });
 
   return NextResponse.json({ templates });

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -39,7 +39,11 @@ export function logsDir(): string {
 }
 
 export function templatePath(type: string): string {
-  return path.join(getForgeRoot(), `templates/${type}.json`);
+  const localPath = path.join(getForgeRoot(), `templates/${type}.json`);
+  if (fs.existsSync(localPath)) {
+    return localPath;
+  }
+  return path.join(getForgeRoot(), `templates/${type}.example.json`);
 }
 
 export function eventsPath(): string {

--- a/contexts/README.md
+++ b/contexts/README.md
@@ -18,6 +18,6 @@ Markdown files that define agent behavior, constraints, and protocols. They are 
 
 ## How contexts compose
 
-Each agent role uses a subset of these files. Templates (`../templates/*.json`) declare a `contexts` array that lists which context files to include. At run time, the selected contexts are concatenated into the agent's system prompt.
+Each agent role uses a subset of these files. Templates (`../templates/*.example.json` in git, `../templates/*.json` locally) declare a `contexts` array that lists which context files to include. At run time, the selected contexts are concatenated into the agent's system prompt.
 
 For example, a worker agent receives `IDENTITY`, `WORKER`, `CONSTRAINTS`, `LABELS`, `HANDOFF`, and `WORKSPACE` — but not `PLANNER`, `SUPER`, or `REVIEWER`.

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,18 @@ info()  { echo "${GREEN}✓${RESET} $*"; }
 warn()  { echo "${YELLOW}⚠${RESET} $*"; }
 err()   { echo "${RED}✗${RESET} $*" >&2; }
 
+detect_repo_name() {
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null || true)
+  case "$remote" in
+    git@github.com:*.git) echo "${remote#git@github.com:}" | sed 's/\.git$//' ;;
+    https://github.com/*.git) echo "${remote#https://github.com/}" | sed 's/\.git$//' ;;
+    https://github.com/*) echo "${remote#https://github.com/}" ;;
+    github.com/*) echo "$remote" ;;
+    *) echo "" ;;
+  esac
+}
+
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
 
@@ -138,6 +150,22 @@ else
   rm -f apps/webhook-monitor/config.toml.bak
   info "apps/webhook-monitor/config.toml created"
 fi
+
+template_repo="${FORGE_TEMPLATE_REPO:-$(detect_repo_name)}"
+for example in templates/*.example.json; do
+  [ -f "$example" ] || continue
+  local_copy="${example%.example.json}.json"
+  if [ -f "$local_copy" ]; then
+    info "${local_copy} exists, skipping"
+    continue
+  fi
+  cp "$example" "$local_copy"
+  if [ -n "$template_repo" ]; then
+    sed -i.bak "s|github.com/owner/repo|${template_repo}|g" "$local_copy"
+    rm -f "${local_copy}.bak"
+  fi
+  info "${local_copy} created from ${example##*/}"
+done
 echo
 
 # ── Verification ─────────────────────────────────────────────────────

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Templates
 
-JSON files that define the runtime configuration for each agent role. Each template specifies which contexts to include in the agent's system prompt, along with scheduling and execution settings.
+Tracked `*.example.json` files define the baseline runtime configuration for each agent role. Local `*.json` working copies are generated from those examples and are intended for repo-specific edits such as the target repo value.
 
 ## Template format
 
@@ -9,8 +9,10 @@ JSON files that define the runtime configuration for each agent role. Each templ
   "interval": "2m",
   "prompt": "The instruction given to the agent each run.",
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "..."],
+  "model": "gpt-5.4",
   "agentic": true,
-  "workspace": true
+  "workspace": true,
+  "repo": "github.com/owner/repo"
 }
 ```
 
@@ -19,17 +21,19 @@ JSON files that define the runtime configuration for each agent role. Each templ
 | `interval` | Cron scheduling interval between runs |
 | `prompt` | The task prompt passed to the agent |
 | `contexts` | Ordered list of context files composed into the system prompt |
+| `model` | Optional model override passed through to `run.sh --model` |
 | `agentic` | Whether the agent runs in agentic mode with tool access |
 | `workspace` | Whether the agent gets an isolated git worktree |
+| `repo` | Target repo for the agent run; tracked examples should keep the generic placeholder |
 
 ## Available templates
 
 | Template | Role | Contexts |
 |----------|------|----------|
-| `worker.json` | Claim and implement a single task | Identity, Worker, Constraints, Labels, Handoff, Workspace |
-| `planner.json` | Review state, create issues, process handoffs | Identity, Planner, Constraints, Labels, Handoff, Workspace |
-| `super.json` | Cross-epic review and quality gate | Identity, Super, Reviewer, Constraints, Labels, Workspace |
+| `worker.example.json` | Claim and implement a single task | Identity, Worker, Constraints, Labels, Handoff, Workspace |
+| `planner.example.json` | Review state, create issues, process handoffs | Identity, Planner, Constraints, Labels, Handoff, Workspace |
+| `super.example.json` | Cross-epic review and quality gate | Identity, Super, Reviewer, Constraints, Labels, Workspace |
 
 ## Usage
 
-Templates are loaded by the Forge CLI (`apps/forge-cli`) and web dashboard (`apps/web`) to launch agent runs via `agent-kernel/run.sh`.
+Forge prefers local `templates/*.json` working copies when present and falls back to tracked `templates/*.example.json` files otherwise. `./install.sh` creates the working copies for you. Edit the local `*.json` files for day-to-day use; only update `*.example.json` when you need to change the tracked defaults.

--- a/templates/planner.example.json
+++ b/templates/planner.example.json
@@ -2,7 +2,8 @@
   "interval": "2m",
   "prompt": "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
   "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+  "model": "gpt-5.4",
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo"
 }

--- a/templates/super.example.json
+++ b/templates/super.example.json
@@ -2,7 +2,8 @@
   "interval": "5m",
   "prompt": "Review epic PRs labeled status:needs-review and role:super. Check for cohesion, DRY code, and cross-cutting conflicts with other open PRs and issues. Approve to admin or send back to planner. Sweep for stale, stuck, or orphaned issues and PRs.",
   "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
+  "model": "gpt-5.4",
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo"
 }

--- a/templates/worker.example.json
+++ b/templates/worker.example.json
@@ -2,7 +2,8 @@
   "interval": "2m",
   "prompt": "Find one issue labeled status:ready-for-work and role:worker. Read it and all its comments. Implement the task, open a PR, and post a handoff comment on the issue.",
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
+  "model": "gpt-5.4",
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo"
 }


### PR DESCRIPTION
**@worker-05**

## Summary
- update docs for tracked `templates/*.example.json` files, local generated `templates/*.json` working copies, and the `model` field
- add `forge add --model` and make template loading prefer local `.json` files while falling back to tracked `.example.json`
- update install/template handling so local working copies can be generated from tracked examples with a repo placeholder

## Verification
- `bash -n install.sh`
- `python3 -m py_compile apps/forge-cli/src/forge_cli/agents.py agent-kernel/cron/manage.py`
- direct Click invocation of `forge add --help` to confirm `--model`
- Python check of `_available_templates()` against renamed example files
