### PR TITLE
Resolve template example lookup and model propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each `info.json` contains `{"agent": "<id>", "pid": <pid>, "claimed_at": "<ISO t
 agent-kernel/    Core runtime — run.sh entry point, cron scheduling
 apps/            Applications (forge-cli, web dashboard)
 contexts/        Reusable context files that define agent behavior and protocols
-templates/       Agent configuration templates (worker.json, planner.json, super.json)
+templates/       Agent configuration templates (worker.json / worker.example.json, etc.)
 ```
 
 - **[agent-kernel](agent-kernel/README.md)** — one-shot Claude CLI wrapper with context assembly, worktree management, and cron-friendly execution

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -22,13 +22,14 @@ Run Forge commands from the repo root with `uv run forge ...`. Requires Python 3
 
 Add an agent from a template.
 
-`uv run forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--list]`
+`uv run forge add [AGENT_TYPE] [--id ID] [--interval INTERVAL] [--model MODEL] [--list]`
 
 | Flag | Description |
 |------|-------------|
 | `AGENT_TYPE` | Template name (e.g. `worker`, `planner`) |
 | `--id ID` | Custom agent ID (default: auto-generate, e.g. `worker-01`) |
 | `--interval INTERVAL` | Override template interval (e.g. `5m`, `1h`) |
+| `--model MODEL` | Override template model (e.g. `gpt-5.4`) |
 | `--list` | List available templates |
 
 ```bash
@@ -37,6 +38,9 @@ uv run forge add worker
 
 # Add with custom ID and interval
 uv run forge add worker --id worker-05 --interval 10m
+
+# Add with an explicit model override
+uv run forge add worker --model gpt-5.4
 
 # List available templates
 uv run forge add --list
@@ -194,7 +198,7 @@ Auto-tunnel uses `gh webhook forward` (preferred) or `ngrok` if available. Tunne
 | `cron-jobs.json` | `agent-kernel/cron/cron-jobs.json` | Staged agent definitions (jobs, intervals, prompts) |
 | `cron-state.json` | `agent-kernel/cron/cron-state.json` | Active cron state (last run times, managed by the system) |
 | `config.toml` | `apps/webhook-monitor/config.toml` | Webhook config (`repo.name`, `webhook.secret`) |
-| Templates | `templates/*.json` | Agent templates used by `forge add` |
+| Templates | `templates/*.json` or `templates/*.example.json` | Agent templates used by `forge add` |
 
 ### Environment variables
 

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -14,16 +14,31 @@ def _templates_dir():
     return os.path.join(repo_root(), "templates")
 
 
+def _template_candidates(template_name):
+    tdir = _templates_dir()
+    return [
+        os.path.join(tdir, f"{template_name}.json"),
+        os.path.join(tdir, f"{template_name}.example.json"),
+    ]
+
+
 def _available_templates():
-    """Return dict of template_name -> file_path for all .json files in templates/."""
+    """Return dict of template_name -> file_path for resolved templates in templates/."""
     tdir = _templates_dir()
     if not os.path.isdir(tdir):
         return {}
     templates = {}
     for fname in sorted(os.listdir(tdir)):
-        if fname.endswith(".json"):
+        if fname.endswith(".example.json"):
+            name = fname[:-13]
+        elif fname.endswith(".json"):
             name = fname[:-5]
-            templates[name] = os.path.join(tdir, fname)
+        else:
+            continue
+        for candidate in _template_candidates(name):
+            if os.path.isfile(candidate):
+                templates[name] = candidate
+                break
     return templates
 
 
@@ -45,8 +60,9 @@ def _next_id(agent_type, existing_ids):
 @click.argument("agent_type", required=False, default=None)
 @click.option("--id", "agent_id", default=None, help="Custom agent ID (default: auto-generate).")
 @click.option("--interval", default=None, help="Override template interval (e.g. 5m, 1h).")
+@click.option("--model", default=None, help="Override template model (e.g. gpt-5.4).")
 @click.option("--list", "list_templates", is_flag=True, help="List available templates.")
-def add(agent_type, agent_id, interval, list_templates):
+def add(agent_type, agent_id, interval, model, list_templates):
     """Add an agent from a template.
 
     AGENT_TYPE is the template name (e.g. worker, planner).
@@ -94,6 +110,9 @@ def add(agent_type, agent_id, interval, list_templates):
     job["workspace"] = template.get("workspace", False)
     if "repo" in template:
         job["repo"] = template["repo"]
+    resolved_model = model if model is not None else template.get("model")
+    if resolved_model:
+        job["model"] = resolved_model
 
     cron_data.setdefault("jobs", []).append(job)
     save_cron_jobs(cron_path, cron_data)
@@ -110,6 +129,8 @@ def add(agent_type, agent_id, interval, list_templates):
         click.echo(f"  contexts:  {', '.join(job['contexts'])}")
     click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
     click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+    if job.get("model"):
+        click.echo(f"  model:     {job['model']}")
     click.echo()
     click.echo("Run `forge apply` to activate.")
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -62,7 +62,8 @@ agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
 gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
 GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
-templates/{type}.json             → POST /api/agents      → (agent creation)
+templates/{type}.json or
+templates/{type}.example.json     → POST /api/agents      → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
 
@@ -83,7 +84,7 @@ Running state is detected via `.agent.lock` PID files in agent worktrees.
 
 ### `POST /api/agents`
 
-Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`. Auto-generates ID as `{type}-{N}` if not provided.
+Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string }`. Loads defaults from `templates/{type}.json`, falling back to `templates/{type}.example.json`. Auto-generates ID as `{type}-{N}` if not provided.
 
 ### `DELETE /api/agents/[id]`
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
 import {
+  availableTemplateTypes,
   atomicWriteJsonSync,
   cronJobsPath,
   cronStatePath,
-  getForgeRoot,
   lockFilePath,
   templatePath,
   worktreePath,
@@ -20,6 +20,7 @@ interface CronJob {
   workspace: boolean;
   enabled?: boolean;
   repo?: string;
+  model?: string;
 }
 
 interface CronState {
@@ -132,6 +133,7 @@ function buildAgentFromJob(
     agentic: job.agentic,
     workspace: job.workspace,
     repo: job.repo ?? "",
+    model: job.model ?? "",
     status,
     ...(stagedInterval ? { stagedInterval } : {}),
   };
@@ -197,20 +199,6 @@ export async function GET() {
   return NextResponse.json({ agents });
 }
 
-function availableTemplateTypes(): Set<string> {
-  const templatesDir = path.join(getForgeRoot(), "templates");
-  try {
-    return new Set(
-      fs
-        .readdirSync(templatesDir)
-        .filter((f) => f.endsWith(".json"))
-        .map((f) => f.replace(/\.json$/, ""))
-    );
-  } catch {
-    return new Set();
-  }
-}
-
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 
 export async function POST(request: NextRequest) {
@@ -219,9 +207,9 @@ export async function POST(request: NextRequest) {
     const type: string = body.type;
 
     const validTypes = availableTemplateTypes();
-    if (!type || !validTypes.has(type)) {
+    if (!type || !validTypes.includes(type)) {
       return NextResponse.json(
-        { error: `type must be one of: ${[...validTypes].sort().join(", ")}` },
+        { error: `type must be one of: ${validTypes.join(", ")}` },
         { status: 400 }
       );
     }
@@ -287,6 +275,7 @@ export async function POST(request: NextRequest) {
       agentic: template.agentic ?? true,
       workspace: template.workspace ?? true,
       repo: template.repo ?? "",
+      model: template.model ?? "",
     };
 
     data.jobs.push(newJob);

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -1,23 +1,15 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
-import { getForgeRoot } from "@/lib/paths";
+import { availableTemplateTypes, templatePath } from "@/lib/paths";
 
 export async function GET() {
-  const templatesDir = path.join(getForgeRoot(), "templates");
-
-  let files: string[];
-  try {
-    files = fs
-      .readdirSync(templatesDir)
-      .filter((f) => f.endsWith(".json"));
-  } catch {
+  const types = availableTemplateTypes();
+  if (types.length === 0) {
     return NextResponse.json({ templates: [] });
   }
 
-  const templates = files.map((file) => {
-    const type = file.replace(/\.json$/, "");
-    const raw = fs.readFileSync(path.join(templatesDir, file), "utf-8");
+  const templates = types.map((type) => {
+    const raw = fs.readFileSync(templatePath(type), "utf-8");
     const data = JSON.parse(raw);
     return {
       type,
@@ -26,6 +18,7 @@ export async function GET() {
       agentic: data.agentic ?? true,
       workspace: data.workspace ?? true,
       repo: data.repo ?? "",
+      model: data.model ?? "",
     };
   });
 

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -19,6 +19,7 @@ interface Agent {
   agentic: boolean;
   workspace: boolean;
   repo: string;
+  model: string;
   branch: string | null;
   status: AgentStatus;
   stagedInterval?: string;
@@ -250,6 +251,7 @@ interface Template {
   contexts: string[];
   agentic: boolean;
   workspace: boolean;
+  model: string;
 }
 
 function AddAgentModal({
@@ -270,6 +272,20 @@ function AddAgentModal({
   const [loading, setLoading] = useState(true);
   const backdropRef = useRef<HTMLDivElement>(null);
 
+  const getAutoId = useCallback(
+    (type: string) => {
+      const existing = agents
+        .filter((a) => a.role === type)
+        .map((a) => {
+          const match = a.id.match(new RegExp(`^${type}-(\\d+)$`));
+          return match ? parseInt(match[1], 10) : 0;
+        });
+      const next = existing.length > 0 ? Math.max(...existing) + 1 : 1;
+      return `${type}-${String(next).padStart(2, "0")}`;
+    },
+    [agents]
+  );
+
   useEffect(() => {
     fetch("/api/templates")
       .then((res) => res.json())
@@ -288,7 +304,7 @@ function AddAgentModal({
       })
       .catch(() => setError("Failed to load templates"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [getAutoId]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -308,20 +324,6 @@ function AddAgentModal({
     setAgentId(getAutoId(tpl.type));
     setError(null);
   };
-
-  const getAutoId = useCallback(
-    (type: string) => {
-      const existing = agents
-        .filter((a) => a.role === type)
-        .map((a) => {
-          const match = a.id.match(new RegExp(`^${type}-(\\d+)$`));
-          return match ? parseInt(match[1], 10) : 0;
-        });
-      const next = existing.length > 0 ? Math.max(...existing) + 1 : 1;
-      return `${type}-${String(next).padStart(2, "0")}`;
-    },
-    [agents]
-  );
 
   const handleSubmit = async () => {
     if (!selected) return;

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -39,7 +39,28 @@ export function logsDir(): string {
 }
 
 export function templatePath(type: string): string {
-  return path.join(getForgeRoot(), `templates/${type}.json`);
+  const forgeRoot = getForgeRoot();
+  const localPath = path.join(forgeRoot, `templates/${type}.json`);
+  if (fs.existsSync(localPath)) {
+    return localPath;
+  }
+  return path.join(forgeRoot, `templates/${type}.example.json`);
+}
+
+export function availableTemplateTypes(): string[] {
+  const templatesDir = path.join(getForgeRoot(), "templates");
+  try {
+    const types = new Set<string>();
+    for (const file of fs.readdirSync(templatesDir)) {
+      const match = file.match(/^(.+?)(?:\.example)?\.json$/);
+      if (match?.[1]) {
+        types.add(match[1]);
+      }
+    }
+    return [...types].sort();
+  } catch {
+    return [];
+  }
 }
 
 export function eventsPath(): string {


### PR DESCRIPTION
**@worker-04**

## Summary
Resolve template consumers to support logical template names and carry model defaults/overrides through CLI and web staging.

## Testing
- `pnpm exec tsc --noEmit`
- CLI simulation in a temporary git repo with only `templates/worker.example.json`, covering `forge add --list`, `forge add worker`, and `forge add worker --model codex`
- `pnpm lint` (fails on pre-existing `apps/web/src/components/resizable-layout.tsx` eslint error)
