### PR TITLE
Switch role templates to example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ agent-kernel/logs/*
 *.egg-info/
 __pycache__/
 apps/webhook-monitor/config.toml
+templates/*.json
+!templates/*.example.json
 events.jsonl
 apps/web/events.jsonl

--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,15 @@ else
   rm -f apps/webhook-monitor/config.toml.bak
   info "apps/webhook-monitor/config.toml created"
 fi
+
+for role in worker planner super; do
+  if [ -f "templates/${role}.json" ]; then
+    info "templates/${role}.json exists, skipping"
+  else
+    cp "templates/${role}.example.json" "templates/${role}.json"
+    info "templates/${role}.json created"
+  fi
+done
 echo
 
 # ── Verification ─────────────────────────────────────────────────────

--- a/templates/planner.example.json
+++ b/templates/planner.example.json
@@ -4,5 +4,6 @@
   "contexts": ["contexts/IDENTITY.md", "contexts/PLANNER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo",
+  "model": "claude"
 }

--- a/templates/super.example.json
+++ b/templates/super.example.json
@@ -4,5 +4,6 @@
   "contexts": ["contexts/IDENTITY.md", "contexts/SUPER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/REVIEWER.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo",
+  "model": "claude"
 }

--- a/templates/worker.example.json
+++ b/templates/worker.example.json
@@ -4,5 +4,6 @@
   "contexts": ["contexts/IDENTITY.md", "contexts/WORKER.md", "contexts/ASSIGNED_ISSUE.md", "contexts/CONSTRAINTS.md", "contexts/LABELS.md", "contexts/HANDOFF.md", "contexts/WORKSPACE.md"],
   "agentic": true,
   "workspace": true,
-  "repo": "github.com/alexjaniak/Forge"
+  "repo": "github.com/owner/repo",
+  "model": "codex"
 }


### PR DESCRIPTION
**@worker-03**

## Summary
- rename tracked role templates from `templates/*.json` to `templates/*.example.json`
- add generic repo placeholders plus a `model` field to each committed example template
- ignore generated local `templates/*.json` copies and have `install.sh` create them only when missing

## Testing
- `PATH="$HOME/.local/bin:$PATH" ./install.sh`
- verified the installer reported `templates/worker.json exists, skipping`, `templates/planner.json exists, skipping`, and `templates/super.json exists, skipping` on re-run
