### PR TITLE
Fix dashboard refresh for inactive right-side tabs

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -47,14 +47,14 @@ src/app/
 |-----------|------|---------|
 | **ResizableLayout** | `resizable-layout.tsx` | Three-panel layout: sidebar (agents), top-right (logs), bottom-right (events). Panels are resizable with drag handles and collapsible on double-click. Sizes persist to localStorage. |
 | **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (STAGED, ACTIVE, MODIFIED, ORPHAN), role badges, interval/countdown info. Supports add, delete, force-run, apply, and clear actions. Auto-refreshes every 5s. |
-| **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
-| **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
-| **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status, role, and type labels. Audio alert only when an issue newly gains `role:admin`. |
+| **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). The dashboard refresh control triggers an immediate refresh even when Logs is not the active tab. Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
+| **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s and refreshes immediately when the dashboard refresh control is clicked, even if Events is inactive. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
+| **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. The dashboard refresh control triggers an immediate refresh without disabling the live stream path, even when Issues is inactive. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status, role, and type labels. Audio alert only when an issue newly gains `role:admin`. |
 
 ### Dashboard UX
 
-- The right-panel tab bar persists the active tab in the URL hash, so reloads and shared links reopen the same Logs, Events, or Issues view.
-- The manual refresh control in the tab bar triggers immediate refreshes for Issues, Events, and Logs without waiting for their polling intervals.
+- The right-side tab selection persists in the URL hash, so reloads and shared links reopen the same Logs, Events, or Issues tab.
+- The dashboard refresh control immediately refreshes Logs, Events, and Issues, even when some of those tabs are inactive.
 
 ### Data Flow
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -85,7 +85,6 @@ function RightPanel({ refreshKey, onRefresh }: { refreshKey: number; onRefresh: 
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Tab bar */}
       <div className="flex items-center gap-1 px-4 py-1 bg-surface border-b border-border shrink-0">
         <TabButton
           label="Logs"
@@ -107,15 +106,16 @@ function RightPanel({ refreshKey, onRefresh }: { refreshKey: number; onRefresh: 
         </div>
       </div>
 
-      {/* Active panel */}
-      <div className="flex-1 overflow-hidden min-h-0">
-        {activeTab === "logs" ? (
+      <div className="flex-1 overflow-hidden min-h-0 relative">
+        <div className={activeTab === "logs" ? "h-full" : "hidden h-full"}>
           <LogsPanel refreshKey={refreshKey} />
-        ) : activeTab === "events" ? (
+        </div>
+        <div className={activeTab === "events" ? "h-full" : "hidden h-full"}>
           <EventsPanel refreshKey={refreshKey} />
-        ) : (
+        </div>
+        <div className={activeTab === "issues" ? "h-full" : "hidden h-full"}>
           <IssuesPanel refreshKey={refreshKey} />
-        )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
**@worker-04**

## Summary
- keep the Logs, Events, and Issues panels mounted so the shared dashboard refresh signal reaches inactive tabs
- preserve URL-hash tab persistence and the existing Issues SSE stream with polling fallback
- update the web README to describe the shipped refresh behavior precisely

## Testing
- `pnpm --dir apps/web lint src/app/page.tsx src/components/events-panel.tsx src/components/issues-panel.tsx src/components/logs-panel.tsx src/components/agent-panel.tsx`
  - existing warning in `apps/web/src/components/agent-panel.tsx:291` about `getAutoId` hook deps
