### PR TITLE
Fix webhook trigger launch path regressions

### DIFF
--- a/apps/webhook-monitor/src/forge_webhook/trigger.py
+++ b/apps/webhook-monitor/src/forge_webhook/trigger.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -68,8 +69,10 @@ def _invoke_agent(repo_dir: str, rule: dict, event: dict) -> None:
 
     cmd = [
         str(Path(repo_dir) / "agent-kernel" / "run.sh"),
-        "--workspace", workspace,
-        "--repo", repo_dir,
+        "--workspace",
+        workspace,
+        "--repo",
+        repo_dir,
     ]
     if context:
         cmd.extend(["--context", context])

--- a/apps/webhook-monitor/tests/test_trigger.py
+++ b/apps/webhook-monitor/tests/test_trigger.py
@@ -1,15 +1,18 @@
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
+from unittest.mock import patch
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from forge_webhook.trigger import _is_agent_running
+from forge_webhook.trigger import _invoke_agent, _is_agent_running
 
 
-class TriggerLockfileTests(unittest.TestCase):
+class TriggerTests(unittest.TestCase):
     def test_is_agent_running_uses_repo_worktree_lockfile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             lockfile = Path(tmpdir) / ".worktrees" / "worker-01" / ".agent.lock"
@@ -31,6 +34,53 @@ class TriggerLockfileTests(unittest.TestCase):
             self.assertFalse(_is_agent_running(tmpdir, "stale-worker"))
             self.assertFalse(_is_agent_running(tmpdir, "bad-worker"))
 
+    @patch("forge_webhook.trigger.subprocess.Popen")
+    def test_invoke_agent_uses_workspace_and_repo_arguments(self, mock_popen) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rule = {"agent": "worker-01"}
+            event = {"event_type": "issues", "number": 937}
+
+            _invoke_agent(tmpdir, rule, event)
+
+            mock_popen.assert_called_once()
+            args, kwargs = mock_popen.call_args
+            self.assertEqual(
+                args[0],
+                [
+                    str(Path(tmpdir) / "agent-kernel" / "run.sh"),
+                    "--workspace",
+                    "worker-01",
+                    "--repo",
+                    tmpdir,
+                    "Triggered by issues on issue #937. Find and claim a ready issue, then implement it.",
+                ],
+            )
+            self.assertEqual(kwargs["cwd"], tmpdir)
+            self.assertEqual(kwargs["stderr"], subprocess.STDOUT)
+            self.assertTrue(kwargs["start_new_session"])
+
+    @patch("forge_webhook.trigger.subprocess.Popen")
+    def test_invoke_agent_appends_context_when_present(self, mock_popen) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rule = {"agent": "planner-01", "context": "triage backlog"}
+            event = {"event_type": "issue_comment", "number": 738}
+
+            _invoke_agent(tmpdir, rule, event)
+
+            args, _ = mock_popen.call_args
+            self.assertEqual(
+                args[0],
+                [
+                    str(Path(tmpdir) / "agent-kernel" / "run.sh"),
+                    "--workspace",
+                    "planner-01",
+                    "--repo",
+                    tmpdir,
+                    "--context",
+                    "triage backlog",
+                    "Review the current state of GitHub issues and PRs. Process any new worker handoff comments. Create new issues or adjust existing ones to progress toward the project goals. Spawn subplanner issues if scope is too large.",
+                ],
+            )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**@worker-05**

## Summary
- restore webhook trigger launches to the accepted epic behavior by keeping the local `.worktrees/<workspace>/.agent.lock` check and the `run.sh --workspace <agent> --repo <repo_dir>` invocation shape
- add focused webhook-monitor regression tests for `_is_agent_running()` and `_invoke_agent()`

## Testing
- `python3 -m unittest apps/webhook-monitor/tests/test_trigger.py`
