### PR TITLE
Restack forge kill workspace discovery fix

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -280,8 +280,9 @@ def _load_jobs_config():
 def _configured_workspace_jobs():
     jobs = []
     for job in _load_jobs_config().get("jobs", []):
-        if job.get("workspace"):
-            jobs.append((job["id"], job.get("repo", "")))
+        if not job.get("enabled", True):
+            continue
+        jobs.append((job["id"], job.get("repo", "")))
     return jobs
 
 

--- a/tests/test_manage_kill.py
+++ b/tests/test_manage_kill.py
@@ -18,21 +18,17 @@ class ManageKillTests(unittest.TestCase):
     def test_configured_workspace_jobs_use_cron_jobs_file_not_persisted_state(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "github.com/alexjaniak/Forge"},
-                {"id": "worker-03", "workspace": True, "repo": "repos/demo"},
-                {"id": "worker-04", "workspace": False, "repo": "github.com/acme/skip"},
+                {"id": "worker-02", "repo": "github.com/alexjaniak/Forge"},
+                {"id": "worker-03", "repo": "repos/demo"},
+                {"id": "worker-04", "repo": "github.com/acme/skip", "enabled": False},
             ]
-        }
-        state = {
-            "jobs": {
-                "worker-02": {"repo": "github.com/acme/old"},
-                "worker-03": {"repo": "repos/old"},
-            }
         }
 
         with patch.object(manage.os.path, "exists", return_value=True), patch(
             "builtins.open", mock_open(read_data=manage.json.dumps(cron_jobs))
-        ), patch.object(manage, "load_state", return_value=state):
+        ), patch.object(
+            manage, "load_state", side_effect=AssertionError("should not read persisted state")
+        ):
             jobs = manage._configured_workspace_jobs()
 
         self.assertEqual(
@@ -138,14 +134,13 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_uses_configured_repo_root_for_targeted_kill(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "github.com/alexjaniak/Forge"}
+                {"id": "worker-02", "repo": "github.com/alexjaniak/Forge"}
             ]
         }
-        state = {"jobs": {"worker-02": {"repo": "github.com/acme/old"}}}
 
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
-            manage, "load_state", return_value=state
-        ), patch.object(manage.os.path, "exists", return_value=True), patch(
+            manage.os.path, "exists", return_value=True
+        ), patch(
             "builtins.open", mock_open(read_data=manage.json.dumps(cron_jobs))
         ), patch.object(
             manage,
@@ -174,14 +169,13 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_uses_relative_configured_repo_root_for_targeted_kill(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "repos/demo"}
+                {"id": "worker-02", "repo": "repos/demo"}
             ]
         }
-        state = {"jobs": {"worker-02": {"repo": "repos/old"}}}
 
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
-            manage, "load_state", return_value=state
-        ), patch.object(manage.os.path, "exists", return_value=True), patch(
+            manage.os.path, "exists", return_value=True
+        ), patch(
             "builtins.open", mock_open(read_data=manage.json.dumps(cron_jobs))
         ), patch.object(
             manage,
@@ -210,22 +204,15 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_scans_configured_repo_roots_for_bulk_kill(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "github.com/alexjaniak/Forge"},
-                {"id": "worker-03", "workspace": True, "repo": "/tmp/other-repo"},
-                {"id": "worker-04", "workspace": True, "repo": "repos/demo"},
+                {"id": "worker-02", "repo": "github.com/alexjaniak/Forge"},
+                {"id": "worker-03", "repo": "/tmp/other-repo"},
+                {"id": "worker-04", "repo": "repos/demo"},
             ]
-        }
-        state = {
-            "jobs": {
-                "worker-02": {"repo": "github.com/acme/old"},
-                "worker-03": {"repo": "/tmp/elsewhere"},
-                "worker-04": {},
-            }
         }
 
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
-            manage, "load_state", return_value=state
-        ), patch.object(manage.os.path, "exists", return_value=True), patch(
+            manage.os.path, "exists", return_value=True
+        ), patch(
             "builtins.open", mock_open(read_data=manage.json.dumps(cron_jobs))
         ), patch.object(
             manage,
@@ -270,7 +257,7 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_uses_union_of_configured_and_discovered_workspaces(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "github.com/alexjaniak/Forge"}
+                {"id": "worker-02", "repo": "github.com/alexjaniak/Forge"}
             ]
         }
 
@@ -343,7 +330,7 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_rejects_repo_mismatch_for_same_workspace_id(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-02", "workspace": True, "repo": "github.com/acme/one"}
+                {"id": "worker-02", "repo": "github.com/acme/one"}
             ]
         }
 
@@ -367,14 +354,14 @@ class ManageKillTests(unittest.TestCase):
     def test_find_managed_runs_targeted_kill_scans_all_configured_repos_without_state_entry(self):
         cron_jobs = {
             "jobs": [
-                {"id": "worker-03", "workspace": True, "repo": "github.com/alexjaniak/Forge"},
-                {"id": "worker-04", "workspace": True, "repo": "repos/demo"},
+                {"id": "worker-03", "repo": "github.com/alexjaniak/Forge"},
+                {"id": "worker-04", "repo": "repos/demo"},
             ]
         }
 
         with patch.object(manage, "REPO_DIR", "/tmp/forge"), patch.object(
-            manage, "load_state", return_value={"jobs": {}}
-        ), patch.object(manage.os.path, "exists", return_value=True), patch(
+            manage.os.path, "exists", return_value=True
+        ), patch(
             "builtins.open", mock_open(read_data=manage.json.dumps(cron_jobs))
         ), patch.object(
             manage,


### PR DESCRIPTION
**@worker-05**

## Summary
- restack the kill backend workspace-discovery fix onto `epic/803-forge-kill` without unrelated files
- stop filtering configured managed runs on the staged `workspace` flag
- update focused kill tests to cover workspace-less staged job fixtures while preserving #839 protections

## Testing
- `python3 tests/test_manage_kill.py`
