### PR TITLE
Replay forge kill parent branch onto current main

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Unified command-line interface for managing agents.
 | `forge remove <id>` | Remove an agent |
 | `forge apply` | Sync staged agent config to live crontab |
 | `forge run <id>` | Run an agent once immediately |
-| `forge kill <id>` | Terminate one running managed agent |
-| `forge kill --all` | Terminate all running managed agents |
 | `forge clear` | Clear active crontab and state |
 | `forge clear --staged` | Clear only staged config |
 | `forge list` | Show all agents (staged, active, unstaged) |
@@ -32,6 +30,8 @@ Unified command-line interface for managing agents.
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge ui` | Start the web dashboard |
 | `forge wh` | Start webhook monitor with auto-tunnel |
+| `forge kill <id>` | Terminate one running managed agent |
+| `forge kill --all` | Terminate all running managed agents |
 
 Install: `pip install -e apps/forge-cli`
 

--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -3,12 +3,12 @@ import click
 from forge_cli.agents import add, remove
 from forge_cli.apply_cmd import apply_cmd
 from forge_cli.clear_cmd import clear_cmd
-from forge_cli.kill_cmd import kill_cmd
 from forge_cli.list_cmd import list_cmd
 from forge_cli.logs import logs
 from forge_cli.run_cmd import run_cmd
 from forge_cli.ui import ui
 from forge_cli.webhook import wh
+from forge_cli.kill_cmd import kill_cmd
 
 
 @click.group()
@@ -19,7 +19,6 @@ def main():
 main.add_command(add)
 main.add_command(apply_cmd, name="apply")
 main.add_command(clear_cmd, name="clear")
-main.add_command(kill_cmd, name="kill")
 main.add_command(list_cmd, name="list")
 main.add_command(logs)
 main.add_command(remove)
@@ -27,3 +26,4 @@ main.add_command(run_cmd, name="run")
 main.add_command(list_cmd, name="status")
 main.add_command(ui)
 main.add_command(wh)
+main.add_command(kill_cmd, name="kill")


### PR DESCRIPTION
**@worker-04**

## Summary
- replay the forge kill root README entry onto the current main-era command table without reintroducing older wording
- register `kill_cmd` in the CLI from a non-conflicting location so `forge kill` survives while newer `main` commands remain intact

## Verification
- `git merge-tree --write-tree origin/main efc80311954478024a0a91b9c7e0a10f0cef5b59` exits cleanly
- runtime tests not run locally: `uv` is not installed in this environment and system `python3` does not have `pytest`
