### PR TITLE
Fix forge-webhook duplicate deprecation warning

### DIFF
--- a/apps/forge-cli/tests/test_webhook_wrapper.py
+++ b/apps/forge-cli/tests/test_webhook_wrapper.py
@@ -1,0 +1,73 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest.mock import call, patch
+
+
+def _canonical_module(canonical_run):
+    canonical_module = types.ModuleType("forge_cli.webhook_server.main")
+    canonical_module.app = object()
+    canonical_module.run = canonical_run
+    return canonical_module
+
+
+def _load_wrapper_module():
+    sys.modules.pop("forge_webhook.main", None)
+    return importlib.import_module("forge_webhook.main")
+
+
+
+class WebhookWrapperTests(unittest.TestCase):
+    def test_wrapper_warns_once_and_marks_delegate_invocation(self):
+        observed_marker = None
+
+        def fake_canonical_run():
+            nonlocal observed_marker
+            observed_marker = os.environ.get("_FORGE_WH_INVOKED")
+
+        with patch.dict(
+            sys.modules,
+            {"forge_cli.webhook_server.main": _canonical_module(fake_canonical_run)},
+            clear=False,
+        ):
+            module = _load_wrapper_module()
+            with patch.dict(os.environ, {}, clear=True), patch("sys.stderr") as stderr:
+                module.run()
+
+        self.assertEqual(observed_marker, "1")
+        self.assertEqual(
+            stderr.write.call_args_list,
+            [
+                call("WARNING: 'forge-webhook' is deprecated. Use 'forge wh' instead."),
+                call("\n"),
+            ],
+        )
+        self.assertNotIn("_FORGE_WH_INVOKED", os.environ)
+
+    def test_wrapper_restores_existing_invocation_marker(self):
+        observed_marker = None
+
+        def fake_canonical_run():
+            nonlocal observed_marker
+            observed_marker = os.environ.get("_FORGE_WH_INVOKED")
+
+        with patch.dict(
+            sys.modules,
+            {"forge_cli.webhook_server.main": _canonical_module(fake_canonical_run)},
+            clear=False,
+        ):
+            module = _load_wrapper_module()
+            with patch.dict(
+                os.environ, {"_FORGE_WH_INVOKED": "existing"}, clear=True
+            ), patch("sys.stderr") as stderr:
+                module.run()
+                self.assertEqual(os.environ["_FORGE_WH_INVOKED"], "existing")
+
+        self.assertEqual(observed_marker, "1")
+        stderr.write.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/webhook-monitor/src/forge_webhook/main.py
+++ b/apps/webhook-monitor/src/forge_webhook/main.py
@@ -3,6 +3,7 @@ import sys
 
 from forge_cli.webhook_server.main import app
 
+
 def run():
     from forge_cli.webhook_server.main import run as canonical_run
 
@@ -12,4 +13,12 @@ def run():
             file=sys.stderr,
         )
 
-    canonical_run()
+    previous_invocation_marker = os.environ.get("_FORGE_WH_INVOKED")
+    os.environ["_FORGE_WH_INVOKED"] = "1"
+    try:
+        canonical_run()
+    finally:
+        if previous_invocation_marker is None:
+            os.environ.pop("_FORGE_WH_INVOKED", None)
+        else:
+            os.environ["_FORGE_WH_INVOKED"] = previous_invocation_marker


### PR DESCRIPTION
**@worker-04**

## Summary
- keep the deprecated `forge-webhook` wrapper warning single-shot by setting `_FORGE_WH_INVOKED` only around delegation into `forge_cli.webhook_server.main.run()`
- add a focused regression test for direct wrapper invocation and env restoration

## Testing
- `PYTHONPATH=apps/forge-cli/src:apps/webhook-monitor/src python3 -m unittest apps/forge-cli/tests/test_webhook_wrapper.py`
