### PR TITLE
Fix #954 replay against epic branch

### DIFF
--- a/agent-kernel/cron/manage.py
+++ b/agent-kernel/cron/manage.py
@@ -510,8 +510,7 @@ def cmd_run(args):
 
     cmd = [os.path.join(REPO_DIR, "agent-kernel", "run.sh")]
     cmd += ["--workspace", job["id"]]
-    if job.get("repo"):
-        cmd += ["--repo", job["repo"]]
+    cmd += ["--repo", require_repo(job.get("repo"), f"job '{args.id}'")]
     if job.get("model"):
         cmd += ["--model", job["model"]]
     for ctx in job.get("contexts", []):

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -1,6 +1,6 @@
 # forge-cli
 
-Agent orchestration CLI for Forge. Manage agents, cron jobs, webhooks, and logs from a single command.
+Agent orchestration CLI for Forge. Manage staged/applied agents, webhooks, logs, and the local UI from a single command.
 
 ## Installation
 
@@ -42,27 +42,41 @@ uv run forge add worker --id worker-05 --interval 10m
 uv run forge add --list
 ```
 
-The agent is staged in `cron-jobs.json`. Run `uv run forge cron apply` to activate.
+The agent is staged in `cron-jobs.json`. Run `uv run forge apply` to activate.
 
-### `forge remove`
+### `forge rm`
 
 Remove an agent by ID.
 
-`uv run forge remove AGENT_ID`
+`uv run forge rm AGENT_ID`
 
 ```bash
-uv run forge remove worker-03
+uv run forge rm worker-03
 ```
 
-Removes the agent from `cron-jobs.json`. Run `uv run forge cron apply` to deactivate.
+Removes the agent from `cron-jobs.json`. Run `uv run forge apply` to deactivate.
 
-### `forge list` / `forge status`
+### `forge status`
 
-Show all agents grouped by state: staged, active, and unstaged (active but not in config).
+Show the git-style staged vs applied agent status view.
 
-`uv run forge list`
+`uv run forge status`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+Displays pending staged changes (`new`, `modified`, `deleted`) plus the currently applied agents with last/next run timing. A staged change to any diffed field is surfaced as `modified`.
+
+### `forge diff`
+
+Show field-by-field differences between staged config and applied state.
+
+`uv run forge diff`
+
+Highlights changes to `interval`, `prompt`, `contexts`, `repo`, `runtime`, `model`, and `enabled`.
+
+### `forge apply`
+
+Apply staged config to the managed crontab.
+
+`uv run forge apply`
 
 ### `forge logs`
 
@@ -101,70 +115,31 @@ Reset staged config — remove all agents from `cron-jobs.json`.
 uv run forge clear -y
 ```
 
-Run `uv run forge cron apply` afterwards to deactivate the cleared agents.
+Run `uv run forge apply` afterwards to deactivate the cleared agents.
 
-### `forge cron`
+### `forge reset`
 
-Manage agent cron jobs directly.
+Discard staged changes and restore the staged config from applied state.
 
-#### `forge cron apply`
+`uv run forge reset`
 
-Sync the system crontab to match `cron-jobs.json`.
+### `forge run`
 
-```bash
-uv run forge cron apply
-```
+Run a single agent immediately.
 
-#### `forge cron add`
+`uv run forge run AGENT_ID`
 
-Add a single cron job.
+### `forge locks`
 
-`uv run forge cron add ID INTERVAL PROMPT [--context TEXT] --repo REPO`
+Inspect repo/issue lock state used by the agent kernel.
 
-**Arguments:**
+`uv run forge locks list`
 
-| Argument | Description |
-|----------|-------------|
-| `ID` | Job identifier |
-| `INTERVAL` | Schedule interval (e.g. `5m`, `1h`) |
-| `PROMPT` | Prompt text for the agent |
+### `forge ui`
 
-**Options:**
+Start the local Forge web UI.
 
-| Flag | Description |
-|------|-------------|
-| `--context TEXT` | Context file path (repeatable) |
-| `--repo REPO` | Target repo |
-
-```bash
-uv run forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md --repo github.com/owner/repo
-```
-
-Forge-managed cron jobs always run with tool access in an isolated worktree named after the job ID under the target repo, so those runtime behaviors are no longer exposed as flags.
-
-#### `forge cron remove`
-
-Remove a cron job by ID.
-
-```bash
-uv run forge cron remove summary-bot
-```
-
-#### `forge cron run`
-
-Run a job once immediately.
-
-```bash
-uv run forge cron run worker-01
-```
-
-#### `forge cron clear`
-
-Remove all agent-kernel cron jobs from the system crontab.
-
-```bash
-uv run forge cron clear
-```
+`uv run forge ui`
 
 ### `forge wh`
 


### PR DESCRIPTION
**@worker-05**

## Summary
Rebased the #954 replay onto `epic/738-agentic-workspace-always-true` as a new mergeable branch by keeping only the repo-required runtime enforcement in `agent-kernel/cron/manage.py` and aligning the Forge CLI README with the current staged/applied command surface.

## What changed
- require `--repo` at runtime in `agent-kernel/cron/manage.py` even when running an existing job from staged config
- update `apps/forge-cli/README.md` to document the current `forge rm` / `forge status` / `forge diff` / `forge apply` / `forge reset` flow
- remove stale `agentic` / `workspace` mentions from the `forge diff` field list

## Verification
- `python3 -m unittest agent-kernel/cron/test_manage.py`
- `PYTHONPATH=apps/webhook-monitor/src python3 -m unittest discover -s apps/webhook-monitor/tests -p 'test_trigger.py'`
- `python3 -m py_compile agent-kernel/cron/manage.py`
