### PR TITLE
Replay template-model fixes and add regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Unified command-line interface for managing agents.
 
 | Command | Description |
 |---------|-------------|
-| `forge add <role>` | Add an agent from tracked template defaults (worker, planner, super) |
-| `forge remove <id>` | Remove an agent |
+| `forge add <role>` | Add an agent from a template (worker, planner, super) |
+| `forge rm <id>` | Remove staged agents by ID |
 | `forge apply` | Sync staged agent config to live crontab |
+| `forge diff` | Show git-style staged vs applied config changes |
+| `forge reset [agent-id]` | Reset staged config to match applied state |
 | `forge run <id>` | Run an agent once immediately |
-| `forge clear` | Clear active crontab and state |
-| `forge clear --staged` | Clear only staged config |
-| `forge list` | Show all agents (staged, active, unstaged) |
-| `forge status` | Alias for `forge list` |
+| `forge clear` | Clear staged config (`cron-jobs.json`) |
+| `forge status` | Show staged changes and applied agents |
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge ui` | Start the web dashboard |
 | `forge locks list` | Show all held issue/PR locks across repos |
@@ -90,14 +90,14 @@ Each `info.json` contains `{"agent": "<id>", "pid": <pid>, "claimed_at": "<ISO t
 agent-kernel/    Core runtime — run.sh entry point, cron scheduling
 apps/            Applications (forge-cli, web dashboard)
 contexts/        Reusable context files that define agent behavior and protocols
-templates/       Agent template examples plus local working copies
+templates/       Agent configuration templates (worker.json / worker.example.json, etc.)
 ```
 
 - **[agent-kernel](agent-kernel/README.md)** — one-shot Claude CLI wrapper with context assembly, worktree management, and cron-friendly execution
 - **[apps/forge-cli](apps/forge-cli/)** — `forge` CLI for agent lifecycle and orchestration
 - **[apps/web](apps/web/)** — Next.js web dashboard for monitoring agents and events
 - **[contexts](contexts/)** — modular `.md` files shaping agent identity, roles, constraints, handoff protocol, labels, and workspace rules
-- **[templates](templates/)** — tracked `*.example.json` templates plus local `*.json` working copies for interval, prompt, contexts, model, and flags
+- **[templates](templates/)** — JSON templates defining agent interval, prompt, contexts, and flags
 
 ## Getting started
 
@@ -114,8 +114,6 @@ If `uv` is not available immediately after installation, restart your shell or s
 
 The install script checks prerequisites, syncs the Python workspace with `uv`, installs dependencies, and generates config files.
 
-Tracked template examples live at `templates/*.example.json`. During setup, `./install.sh` generates local `templates/*.json` working copies from those examples and fills in the repo placeholder. Edit the local `templates/*.json` files for your machine; keep the tracked `*.example.json` files generic.
-
 ### Manual setup
 
 If you prefer manual setup:
@@ -124,4 +122,11 @@ If you prefer manual setup:
 3. `cd apps/web && npm install` — Install dashboard dependencies
 4. `cp agent-kernel/.env.example agent-kernel/.env` — Configure credentials
 5. `cp apps/webhook-monitor/config.example.toml apps/webhook-monitor/config.toml` — Configure webhooks
+
+Typical workflow after setup:
+1. `forge add worker` — Stage a new agent from the template
+2. `forge status` — Review staged changes and applied agents
+3. `forge diff` — Inspect field-level staged vs applied differences
+4. `forge apply` — Activate the staged config
+5. `forge reset` — Discard staged changes and restore the applied config
 6. `uv run forge --help` — Verify the Forge CLI is available

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -1,6 +1,6 @@
 # forge-cli
 
-Agent orchestration CLI for Forge. Manage agents, cron jobs, webhooks, and logs from a single command.
+Agent orchestration CLI for Forge. Manage staged/applied agents, webhooks, logs, and the local UI from a single command.
 
 ## Installation
 
@@ -29,7 +29,7 @@ Add an agent from a template.
 | `AGENT_TYPE` | Template name (e.g. `worker`, `planner`) |
 | `--id ID` | Custom agent ID (default: auto-generate, e.g. `worker-01`) |
 | `--interval INTERVAL` | Override template interval (e.g. `5m`, `1h`) |
-| `--model MODEL` | Override the template model (e.g. `gpt-5.4`) |
+| `--model MODEL` | Override template model (e.g. `gpt-5.4`) |
 | `--list` | List available templates |
 
 ```bash
@@ -39,36 +39,48 @@ uv run forge add worker
 # Add with custom ID and interval
 uv run forge add worker --id worker-05 --interval 10m
 
-# Add with a model override
-uv run forge add worker --model gpt-5.4
+# Add with an explicit model override
+uv run forge add --model gpt-5.4 worker
 
 # List available templates
 uv run forge add --list
 ```
 
-Tracked templates live at `templates/*.example.json`; local `templates/*.json` files are generated working copies and are gitignored. `forge add` prefers the local working copy when it exists and falls back to the tracked example otherwise.
-
 The agent is staged in `cron-jobs.json`. Run `uv run forge apply` to activate.
 
-### `forge remove`
+### `forge rm`
 
 Remove an agent by ID.
 
-`uv run forge remove AGENT_ID`
+`uv run forge rm AGENT_ID`
 
 ```bash
-uv run forge remove worker-03
+uv run forge rm worker-03
 ```
 
 Removes the agent from `cron-jobs.json`. Run `uv run forge apply` to deactivate.
 
-### `forge list` / `forge status`
+### `forge status`
 
-Show all agents grouped by state: staged, active, and unstaged (active but not in config).
+Show the git-style staged vs applied agent status view.
 
-`uv run forge list`
+`uv run forge status`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge apply`.
+Displays pending staged changes (`new`, `modified`, `deleted`) plus the currently applied agents with last/next run timing. A staged change to any diffed field is surfaced as `modified`.
+
+### `forge diff`
+
+Show field-by-field differences between staged config and applied state.
+
+`uv run forge diff`
+
+Highlights changes to `interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`, and `enabled`.
+
+### `forge apply`
+
+Apply staged config to the managed crontab.
+
+`uv run forge apply`
 
 ### `forge logs`
 
@@ -109,68 +121,29 @@ uv run forge clear -y
 
 Run `uv run forge apply` afterwards to deactivate the cleared agents.
 
-### `forge cron`
+### `forge reset`
 
-Manage agent cron jobs directly.
+Discard staged changes and restore the staged config from applied state.
 
-#### `forge cron apply`
+`uv run forge reset`
 
-Sync the system crontab to match `cron-jobs.json`.
+### `forge run`
 
-```bash
-uv run forge cron apply
-```
+Run a single agent immediately.
 
-#### `forge cron add`
+`uv run forge run AGENT_ID`
 
-Add a single cron job.
+### `forge locks`
 
-`uv run forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]`
+Inspect repo/issue lock state used by the agent kernel.
 
-**Arguments:**
+`uv run forge locks list`
 
-| Argument | Description |
-|----------|-------------|
-| `ID` | Job identifier |
-| `INTERVAL` | Schedule interval (e.g. `5m`, `1h`) |
-| `PROMPT` | Prompt text for the agent |
+### `forge ui`
 
-**Options:**
+Start the local Forge web UI.
 
-| Flag | Description |
-|------|-------------|
-| `--agentic` | Enable tool use |
-| `--workspace` | Run in isolated git worktree |
-| `--context TEXT` | Context file path (repeatable) |
-| `--repo REPO` | Target repo |
-
-```bash
-uv run forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
-```
-
-#### `forge cron remove`
-
-Remove a cron job by ID.
-
-```bash
-uv run forge cron remove summary-bot
-```
-
-#### `forge cron run`
-
-Run a job once immediately.
-
-```bash
-uv run forge cron run worker-01
-```
-
-#### `forge cron clear`
-
-Remove all agent-kernel cron jobs from the system crontab.
-
-```bash
-uv run forge cron clear
-```
+`uv run forge ui`
 
 ### `forge wh`
 
@@ -197,10 +170,10 @@ Auto-tunnel uses `gh webhook forward` (preferred) or `ngrok` if available. Tunne
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `cron-jobs.json` | `agent-kernel/cron/cron-jobs.json` | Staged agent definitions (jobs, intervals, prompts, model overrides) |
+| `cron-jobs.json` | `agent-kernel/cron/cron-jobs.json` | Staged agent definitions (jobs, intervals, prompts) |
 | `cron-state.json` | `agent-kernel/cron/cron-state.json` | Active cron state (last run times, managed by the system) |
 | `config.toml` | `apps/webhook-monitor/config.toml` | Webhook config (`repo.name`, `webhook.secret`) |
-| Templates | `templates/*.example.json` | Tracked agent template examples used to generate local working copies |
+| Templates | `templates/*.json` or `templates/*.example.json` | Agent templates used by `forge add` |
 
 ### Environment variables
 

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -1,37 +1,45 @@
-"""forge add / forge remove — template-based agent management."""
+"""forge add / forge rm — template-based agent management."""
 
 import json
 import os
 import re
 import sys
+from types import SimpleNamespace
 
 import click
 
-from forge_cli.paths import cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
+from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
 
 
 def _templates_dir():
     return os.path.join(repo_root(), "templates")
 
 
+def _template_candidates(template_name):
+    tdir = _templates_dir()
+    return [
+        os.path.join(tdir, f"{template_name}.json"),
+        os.path.join(tdir, f"{template_name}.example.json"),
+    ]
+
+
 def _available_templates():
-    """Return dict of template_name -> file_path for local .json or tracked .example.json files."""
+    """Return dict of template_name -> file_path for resolved templates in templates/."""
     tdir = _templates_dir()
     if not os.path.isdir(tdir):
         return {}
     templates = {}
     for fname in sorted(os.listdir(tdir)):
-        name = None
         if fname.endswith(".example.json"):
             name = fname[:-13]
         elif fname.endswith(".json"):
             name = fname[:-5]
-        if name is None:
+        else:
             continue
-        path = os.path.join(tdir, fname)
-        # Prefer local working copies over tracked examples when both exist.
-        if name not in templates or fname.endswith(".json"):
-            templates[name] = path
+        for candidate in _template_candidates(name):
+            if os.path.isfile(candidate):
+                templates[name] = candidate
+                break
     return templates
 
 
@@ -50,15 +58,16 @@ def _next_id(agent_type, existing_ids):
 
 
 @click.command()
-@click.argument("agent_type", required=False, default=None)
+@click.argument("agent_types", nargs=-1)
 @click.option("--id", "agent_id", default=None, help="Custom agent ID (default: auto-generate).")
 @click.option("--interval", default=None, help="Override template interval (e.g. 5m, 1h).")
 @click.option("--model", default=None, help="Override template model (e.g. gpt-5.4).")
 @click.option("--list", "list_templates", is_flag=True, help="List available templates.")
-def add(agent_type, agent_id, interval, model, list_templates):
-    """Add an agent from a template.
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after adding.")
+def add(agent_types, agent_id, interval, model, list_templates, apply_flag):
+    """Add agents from templates.
 
-    AGENT_TYPE is the template name (e.g. worker, planner).
+    AGENT_TYPES is one or more template names (e.g. worker, planner).
     """
     if list_templates:
         templates = _available_templates()
@@ -70,88 +79,112 @@ def add(agent_type, agent_id, interval, model, list_templates):
             click.echo(f"  {name}")
         return
 
-    if not agent_type:
+    if not agent_types:
         click.echo("Error: AGENT_TYPE is required (e.g. forge add worker).", err=True)
         click.echo("Use --list to see available templates.", err=True)
         sys.exit(1)
 
-    templates = _available_templates()
-    if agent_type not in templates:
-        click.echo(f"Error: no template '{agent_type}' found.", err=True)
-        click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+    if agent_id is not None and len(agent_types) > 1:
+        click.echo("Error: --id cannot be used with multiple agent types.", err=True)
         sys.exit(1)
 
-    with open(templates[agent_type]) as f:
-        template = json.load(f)
+    templates = _available_templates()
+    for agent_type in agent_types:
+        if agent_type not in templates:
+            click.echo(f"Error: no template '{agent_type}' found.", err=True)
+            click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+            sys.exit(1)
 
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
     existing_ids = [j["id"] for j in cron_data.get("jobs", [])]
 
-    if agent_id is None:
-        agent_id = _next_id(agent_type, existing_ids)
+    for agent_type in agent_types:
+        with open(templates[agent_type]) as f:
+            template = json.load(f)
 
-    if agent_id in existing_ids:
-        click.echo(f"Error: agent '{agent_id}' already exists.", err=True)
-        sys.exit(1)
+        if agent_id is not None:
+            aid = agent_id
+        else:
+            aid = _next_id(agent_type, existing_ids)
 
-    job = {"id": agent_id}
-    job["interval"] = interval if interval else template["interval"]
-    job["prompt"] = template["prompt"]
-    job["contexts"] = template.get("contexts", [])
-    job["agentic"] = template.get("agentic", False)
-    job["workspace"] = template.get("workspace", False)
-    template_model = template.get("model", "")
-    if model:
-        job["model"] = model
-    elif template_model:
-        job["model"] = template_model
-    if "repo" in template:
-        job["repo"] = template["repo"]
+        if aid in existing_ids:
+            click.echo(f"Error: agent '{aid}' already exists.", err=True)
+            sys.exit(1)
 
-    cron_data.setdefault("jobs", []).append(job)
+        job = {"id": aid}
+        job["interval"] = interval if interval else template["interval"]
+        job["prompt"] = template["prompt"]
+        job["contexts"] = template.get("contexts", [])
+        job["agentic"] = template.get("agentic", False)
+        job["workspace"] = template.get("workspace", False)
+        resolved_model = model if model is not None else template.get("model")
+        if resolved_model:
+            job["model"] = resolved_model
+        if "repo" in template:
+            job["repo"] = template["repo"]
+
+        cron_data.setdefault("jobs", []).append(job)
+        existing_ids.append(aid)
+
+        click.echo(click.style(
+            f"Staged {aid} (template: {agent_type}, interval: {job['interval']})",
+            fg="green",
+        ))
+        prompt_display = job["prompt"]
+        if len(prompt_display) > 60:
+            prompt_display = prompt_display[:57] + "..."
+        click.echo(f"  prompt:    \"{prompt_display}\"")
+        if job["contexts"]:
+            click.echo(f"  contexts:  {', '.join(job['contexts'])}")
+        click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
+        click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+        if job.get("model"):
+            click.echo(f"  model:     {job['model']}")
+
     save_cron_jobs(cron_path, cron_data)
 
-    click.echo(click.style(
-        f"Staged {agent_id} (template: {agent_type}, interval: {job['interval']})",
-        fg="green",
-    ))
-    prompt_display = job["prompt"]
-    if len(prompt_display) > 60:
-        prompt_display = prompt_display[:57] + "..."
-    click.echo(f"  prompt:    \"{prompt_display}\"")
-    if job["contexts"]:
-        click.echo(f"  contexts:  {', '.join(job['contexts'])}")
-    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
-    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
-    if job.get("model"):
-        click.echo(f"  model:     {job['model']}")
-    click.echo()
-    click.echo("Run `forge apply` to activate.")
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to activate.")
 
 
 @click.command()
-@click.argument("agent_id")
-def remove(agent_id):
-    """Remove an agent by ID."""
+@click.argument("agent_ids", nargs=-1, required=True)
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after removing.")
+def rm(agent_ids, apply_flag):
+    """Remove agents by ID."""
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
 
     jobs = cron_data.get("jobs", [])
-    removed = [j for j in jobs if j["id"] == agent_id]
-    new_jobs = [j for j in jobs if j["id"] != agent_id]
+    known_ids = {j["id"] for j in jobs}
 
-    if len(new_jobs) == len(jobs):
-        click.echo(f"Error: no agent '{agent_id}' found.", err=True)
+    missing = [aid for aid in agent_ids if aid not in known_ids]
+    if missing:
+        click.echo(f"Error: agents not found: {', '.join(missing)}", err=True)
         sys.exit(1)
 
-    cron_data["jobs"] = new_jobs
+    ids_to_remove = set(agent_ids)
+    removed = [j for j in jobs if j["id"] in ids_to_remove]
+    cron_data["jobs"] = [j for j in jobs if j["id"] not in ids_to_remove]
     save_cron_jobs(cron_path, cron_data)
 
-    interval = removed[0].get("interval", "?") if removed else "?"
-    click.echo(click.style(
-        f"Unstaged {agent_id} (was: interval {interval})",
-        fg="red",
-    ))
-    click.echo()
-    click.echo("Run `forge apply` to deactivate.")
+    for j in removed:
+        interval = j.get("interval", "?")
+        click.echo(click.style(
+            f"Unstaged {j['id']} (was: interval {interval})",
+            fg="red",
+        ))
+
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to deactivate.")

--- a/apps/forge-cli/tests/test_agents_add.py
+++ b/apps/forge-cli/tests/test_agents_add.py
@@ -1,0 +1,146 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from forge_cli.agents import add
+
+
+class AddCommandTests(unittest.TestCase):
+    def _write_template(self, directory, name, data):
+        path = directory / name
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def _invoke_add(self, repo_root, *args):
+        cron_dir = repo_root / "agent-kernel" / "cron"
+        cron_dir.mkdir(parents=True, exist_ok=True)
+        cron_path = cron_dir / "cron-jobs.json"
+        runner = CliRunner()
+        with patch("forge_cli.agents.repo_root", return_value=str(repo_root)):
+            with patch("forge_cli.agents.cron_jobs_path", return_value=str(cron_path)):
+                result = runner.invoke(add, list(args))
+        return result, cron_path
+
+    def test_add_prefers_local_json_template_over_example(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            templates_dir = repo_root / "templates"
+            templates_dir.mkdir(parents=True)
+            self._write_template(
+                templates_dir,
+                "worker.example.json",
+                {
+                    "interval": "2m",
+                    "prompt": "from example",
+                    "contexts": ["contexts/EXAMPLE.md"],
+                    "agentic": True,
+                    "workspace": True,
+                    "model": "gpt-5.4",
+                    "repo": "github.com/example/repo",
+                },
+            )
+            self._write_template(
+                templates_dir,
+                "worker.json",
+                {
+                    "interval": "7m",
+                    "prompt": "from local",
+                    "contexts": ["contexts/LOCAL.md"],
+                    "agentic": False,
+                    "workspace": False,
+                    "model": "o3",
+                    "repo": "github.com/local/repo",
+                },
+            )
+
+            result, cron_path = self._invoke_add(repo_root, "worker")
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            staged = json.loads(cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                staged,
+                {
+                    "stagger": True,
+                    "jobs": [
+                        {
+                            "id": "worker-01",
+                            "interval": "7m",
+                            "prompt": "from local",
+                            "contexts": ["contexts/LOCAL.md"],
+                            "agentic": False,
+                            "workspace": False,
+                            "model": "o3",
+                            "repo": "github.com/local/repo",
+                        }
+                    ],
+                },
+            )
+
+    def test_add_falls_back_to_example_template_when_local_file_absent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            templates_dir = repo_root / "templates"
+            templates_dir.mkdir(parents=True)
+            self._write_template(
+                templates_dir,
+                "worker.example.json",
+                {
+                    "interval": "3m",
+                    "prompt": "from example only",
+                    "contexts": ["contexts/EXAMPLE.md"],
+                    "agentic": True,
+                    "workspace": True,
+                    "model": "gpt-5.4",
+                    "repo": "github.com/example/repo",
+                },
+            )
+
+            result, cron_path = self._invoke_add(repo_root, "worker")
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            staged = json.loads(cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(staged["jobs"][0]["prompt"], "from example only")
+            self.assertEqual(staged["jobs"][0]["interval"], "3m")
+            self.assertEqual(staged["jobs"][0]["model"], "gpt-5.4")
+
+    def test_add_uses_template_model_by_default_and_allows_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            templates_dir = repo_root / "templates"
+            templates_dir.mkdir(parents=True)
+            self._write_template(
+                templates_dir,
+                "worker.example.json",
+                {
+                    "interval": "2m",
+                    "prompt": "template prompt",
+                    "contexts": [],
+                    "agentic": True,
+                    "workspace": True,
+                    "model": "gpt-5.4",
+                    "repo": "github.com/example/repo",
+                },
+            )
+
+            default_result, cron_path = self._invoke_add(repo_root, "worker")
+            self.assertEqual(default_result.exit_code, 0, default_result.output)
+            staged = json.loads(cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(staged["jobs"][0]["model"], "gpt-5.4")
+
+            override_result, override_cron_path = self._invoke_add(
+                repo_root,
+                "--model",
+                "claude-sonnet-4",
+                "worker",
+            )
+            self.assertEqual(override_result.exit_code, 0, override_result.output)
+            override_staged = json.loads(override_cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(override_staged["jobs"][-1]["model"], "claude-sonnet-4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,6 +28,8 @@ src/app/
     │   ├── route.ts          # GET (list) / POST (create) agents
     │   ├── apply/route.ts    # POST — run manage.py apply
     │   ├── clear/route.ts    # POST — reset staged config
+    │   ├── diff/route.ts     # GET — staged vs applied field-level diff
+    │   ├── reset/route.ts    # POST — restore staged config from applied state
     │   └── [id]/
     │       ├── route.ts      # DELETE agent
     │       └── force-run/route.ts  # POST — spawn agent run
@@ -46,7 +48,7 @@ src/app/
 | Component | File | Purpose |
 |-----------|------|---------|
 | **ResizableLayout** | `resizable-layout.tsx` | Three-panel layout: sidebar (agents), top-right (logs), bottom-right (events). Panels are resizable with drag handles and collapsible on double-click. Sizes persist to localStorage. |
-| **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (STAGED, ACTIVE, MODIFIED, ORPHAN), role badges, interval/countdown info. Supports add, delete, force-run, apply, and clear actions. Auto-refreshes every 5s. |
+| **AgentPanel** | `agent-panel.tsx` | Lists agents with status badges (NEW, ACTIVE, MODIFIED, DELETED), role badges, interval/countdown info, and branch context. Supports add, delete, force-run, apply, clear, diff, and reset actions. Auto-refreshes every 5s. |
 | **LogsPanel** | `logs-panel.tsx` | Streams logs via SSE (`/api/logs/stream`) with polling fallback (5s). Tabs for each agent plus an "All" view. Parses log blocks delimited by `=== RUN ===` / `=== END RUN ===` markers. Max 200 blocks displayed. |
 | **EventsPanel** | `events-panel.tsx` | Polls `/api/events` every 3s. Shows GitHub event cards with action badges (color-coded), issue numbers, actors, labels. Max 50 events displayed. |
 | **IssuesPanel** | `issues-panel.tsx` | Connects to `/api/issues/stream` for live issue snapshots with `/api/issues` polling fallback. Shows GitHub issues with label badges (color-coded by status/role/type). Filterable by status and role labels. Audio alert only when an issue newly gains `role:admin`. |
@@ -62,8 +64,8 @@ agent-kernel/logs/{id}.log        → GET /api/logs/stream  → LogsPanel (SSE)
 apps/webhook-monitor/events.jsonl → GET /api/events       → EventsPanel
 gh issue list (via CLI)             → GET /api/issues       → IssuesPanel fallback
 GitHub events JSONL                 → GET /api/issues/stream → IssuesPanel live snapshots
-templates/{type}.json
-  (fallback: templates/{type}.example.json) → POST /api/agents → (agent creation)
+templates/{type}.json or
+templates/{type}.example.json     → POST /api/agents      → (agent creation)
 .worktrees/{id}/.agent.lock       → GET /api/agents       → (running detection)
 ```
 
@@ -73,18 +75,18 @@ All paths are resolved relative to the repo root via `src/lib/paths.ts`. The rep
 
 ### `GET /api/agents`
 
-Returns all agents with computed status and metadata. Reads staged config from `cron-jobs.json` and active state from `cron-state.json`. Status is derived by comparing both:
+Returns all agents with computed status and metadata. Reads staged config from `cron-jobs.json` and applied state from `cron-state.json`. Status is derived by comparing both:
 
-- **staged** — in jobs but not state
-- **active** — in both with matching interval
-- **modified** — in both but interval differs
-- **orphan** — in state but not jobs
+- **new** — in staged config but not applied state yet
+- **active** — in both with matching applied interval
+- **modified** — in both, but one or more compared fields differ between staged and applied config (`interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`)
+- **deleted** — in applied state but removed from staged config
 
 Running state is detected via `.agent.lock` PID files in agent worktrees.
 
 ### `POST /api/agents`
 
-Creates a new agent. Body: `{ type: "worker"|"planner", id?: string, interval?: string, model?: string }`. Loads defaults from `templates/{type}.json` when a local working copy exists, otherwise from `templates/{type}.example.json`. Auto-generates ID as `{type}-{N}` if not provided.
+Creates a new agent. Body: `{ type: "<template-name>", id?: string, interval?: string, model?: string }`. Loads defaults from `templates/{type}.json` when a local working copy exists and falls back to `templates/{type}.example.json` otherwise. Auto-generates ID as `{type}-{N}` if not provided.
 
 ### `DELETE /api/agents/[id]`
 
@@ -101,6 +103,14 @@ Runs `manage.py apply` to activate staged config changes. Returns stdout/stderr.
 ### `POST /api/agents/clear`
 
 Resets staged config to empty.
+
+### `GET /api/agents/diff`
+
+Returns a field-level staged vs applied diff for agent records. Response shape is `{ hasDiff, agents }`, where each entry is tagged as `new`, `modified`, or `deleted`.
+
+### `POST /api/agents/reset`
+
+Rebuilds staged config from the currently applied state while preserving the top-level `stagger` setting from `cron-jobs.json`. If `cron-state.json` does not exist yet, reset treats the applied state as empty and clears staged-only changes instead of returning an error.
 
 ### `GET /api/logs/[agentId]?offset={n}`
 

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -2,14 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
 import {
+  availableTemplateTypes,
   atomicWriteJsonSync,
   cronJobsPath,
   cronStatePath,
-  getForgeRoot,
   lockFilePath,
   templatePath,
   worktreePath,
 } from "@/lib/paths";
+import { diffAgentConfig } from "@/lib/agent-config-diff";
 
 interface CronJob {
   id: string;
@@ -19,8 +20,9 @@ interface CronJob {
   agentic: boolean;
   workspace: boolean;
   enabled?: boolean;
-  model?: string;
   repo?: string;
+  runtime?: string;
+  model?: string;
 }
 
 interface CronState {
@@ -32,6 +34,12 @@ interface CronState {
       stagger_offset?: number;
       installed_at?: string;
       contexts?: string[];
+      prompt?: string;
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
     }
   >;
 }
@@ -89,7 +97,7 @@ function inferRole(id: string): string {
 function buildAgentFromJob(
   job: CronJob,
   jobState: CronState["jobs"][string] | undefined,
-  status: "staged" | "active" | "modified" | "orphan",
+  status: "new" | "active" | "modified" | "deleted",
   stagedInterval?: string
 ) {
   const intervalSeconds = parseIntervalSeconds(job.interval);
@@ -133,6 +141,7 @@ function buildAgentFromJob(
     agentic: job.agentic,
     workspace: job.workspace,
     repo: job.repo ?? "",
+    model: job.model ?? "",
     status,
     ...(stagedInterval ? { stagedInterval } : {}),
   };
@@ -165,15 +174,20 @@ export async function GET() {
     const inState = activeIds.has(job.id);
 
     if (!hasState || !inState) {
-      return buildAgentFromJob(job, undefined, "staged");
+      return buildAgentFromJob(job, undefined, "new");
     }
 
-    const activeInterval = jobState?.interval;
-    if (activeInterval && activeInterval !== job.interval) {
+    const changes = diffAgentConfig(job, jobState ?? {});
+    if (Object.keys(changes).length > 0) {
+      const activeInterval = jobState?.interval;
+
       // interval field shows the active (running) interval
       // stagedInterval shows what it will change to on next apply
-      const modifiedJob = { ...job, interval: activeInterval };
-      return buildAgentFromJob(modifiedJob, jobState, "modified", job.interval);
+      const modifiedJob = activeInterval ? { ...job, interval: activeInterval } : job;
+      const stagedInterval =
+        changes.interval && typeof job.interval === "string" ? job.interval : undefined;
+
+      return buildAgentFromJob(modifiedJob, jobState, "modified", stagedInterval);
     }
 
     return buildAgentFromJob(job, jobState, "active");
@@ -191,28 +205,11 @@ export async function GET() {
         agentic: false,
         workspace: false,
       };
-      agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
+      agents.push(buildAgentFromJob(orphanJob, jobState, "deleted"));
     }
   }
 
   return NextResponse.json({ agents });
-}
-
-function availableTemplateTypes(): Set<string> {
-  const templatesDir = path.join(getForgeRoot(), "templates");
-  try {
-    return new Set(
-      fs
-        .readdirSync(templatesDir)
-        .flatMap((f) => {
-          if (f.endsWith(".example.json")) return [f.replace(/\.example\.json$/, "")];
-          if (f.endsWith(".json")) return [f.replace(/\.json$/, "")];
-          return [];
-        })
-    );
-  } catch {
-    return new Set();
-  }
 }
 
 const SAFE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
@@ -223,9 +220,9 @@ export async function POST(request: NextRequest) {
     const type: string = body.type;
 
     const validTypes = availableTemplateTypes();
-    if (!type || !validTypes.has(type)) {
+    if (!type || !validTypes.includes(type)) {
       return NextResponse.json(
-        { error: `type must be one of: ${[...validTypes].sort().join(", ")}` },
+        { error: `type must be one of: ${validTypes.join(", ")}` },
         { status: 400 }
       );
     }
@@ -290,8 +287,8 @@ export async function POST(request: NextRequest) {
       contexts: template.contexts ?? [],
       agentic: template.agentic ?? true,
       workspace: template.workspace ?? true,
-      model: body.model ?? template.model ?? "",
       repo: template.repo ?? "",
+      model: body.model ?? template.model ?? "",
     };
 
     data.jobs.push(newJob);

--- a/apps/web/src/app/api/templates/route.ts
+++ b/apps/web/src/app/api/templates/route.ts
@@ -1,48 +1,25 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
-import path from "path";
-import { getForgeRoot } from "@/lib/paths";
+import { availableTemplateTypes, templatePath } from "@/lib/paths";
 
 export async function GET() {
-  const templatesDir = path.join(getForgeRoot(), "templates");
-
-  let files: string[];
-  try {
-    files = fs
-      .readdirSync(templatesDir)
-      .filter((f) => f.endsWith(".json") || f.endsWith(".example.json"))
-      .sort((a, b) => {
-        const aIsLocal = a.endsWith(".json") && !a.endsWith(".example.json");
-        const bIsLocal = b.endsWith(".json") && !b.endsWith(".example.json");
-        if (aIsLocal !== bIsLocal) {
-          return aIsLocal ? -1 : 1;
-        }
-        return a.localeCompare(b);
-      });
-  } catch {
+  const types = availableTemplateTypes();
+  if (types.length === 0) {
     return NextResponse.json({ templates: [] });
   }
 
-  const seen = new Set<string>();
-  const templates = files.flatMap((file) => {
-    const type = file.endsWith(".example.json")
-      ? file.replace(/\.example\.json$/, "")
-      : file.replace(/\.json$/, "");
-    if (seen.has(type)) {
-      return [];
-    }
-    seen.add(type);
-    const raw = fs.readFileSync(path.join(templatesDir, file), "utf-8");
+  const templates = types.map((type) => {
+    const raw = fs.readFileSync(templatePath(type), "utf-8");
     const data = JSON.parse(raw);
-    return [{
+    return {
       type,
       interval: data.interval ?? "2m",
       contexts: data.contexts ?? [],
       agentic: data.agentic ?? true,
       workspace: data.workspace ?? true,
-      model: data.model ?? "",
       repo: data.repo ?? "",
-    }];
+      model: data.model ?? "",
+    };
   });
 
   return NextResponse.json({ templates });

--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-type AgentStatus = "staged" | "active" | "modified" | "orphan";
+type AgentStatus = "new" | "active" | "modified" | "deleted";
 
 interface Agent {
   id: string;
@@ -19,6 +19,7 @@ interface Agent {
   agentic: boolean;
   workspace: boolean;
   repo: string;
+  model: string;
   branch: string | null;
   status: AgentStatus;
   stagedInterval?: string;
@@ -91,10 +92,10 @@ function RoleBadge({ role }: { role: string }) {
 }
 
 const statusBadgeConfig: Record<AgentStatus, { label: string; bg: string }> = {
-  staged: { label: "STAGED", bg: "bg-accent-yellow" },
+  new: { label: "NEW", bg: "bg-accent-yellow" },
   active: { label: "ACTIVE", bg: "bg-accent-green" },
   modified: { label: "MODIFIED", bg: "bg-accent-yellow" },
-  orphan: { label: "ORPHAN", bg: "bg-accent-red" },
+  deleted: { label: "DELETED", bg: "bg-accent-red" },
 };
 
 function StatusBadge({ status, agent }: { status: AgentStatus; agent: Agent }) {
@@ -163,7 +164,7 @@ function AgentCard({
   };
 
   const isStarted = feedback === "Started";
-  const isStaged = agent.status === "staged";
+  const isStaged = agent.status === "new";
 
   return (
     <div className="rounded-md bg-surface p-2 border border-border hover:bg-surface-hover transition-colors">
@@ -234,8 +235,8 @@ function AgentCard({
 const statusOrder: Record<AgentStatus, number> = {
   active: 0,
   modified: 1,
-  staged: 2,
-  orphan: 3,
+  new: 2,
+  deleted: 3,
 };
 
 function sortAgentsByStatus(agents: Agent[]): Agent[] {
@@ -250,6 +251,7 @@ interface Template {
   contexts: string[];
   agentic: boolean;
   workspace: boolean;
+  model: string;
 }
 
 function AddAgentModal({
@@ -270,6 +272,20 @@ function AddAgentModal({
   const [loading, setLoading] = useState(true);
   const backdropRef = useRef<HTMLDivElement>(null);
 
+  const getAutoId = useCallback(
+    (type: string) => {
+      const existing = agents
+        .filter((a) => a.role === type)
+        .map((a) => {
+          const match = a.id.match(new RegExp(`^${type}-(\\d+)$`));
+          return match ? parseInt(match[1], 10) : 0;
+        });
+      const next = existing.length > 0 ? Math.max(...existing) + 1 : 1;
+      return `${type}-${String(next).padStart(2, "0")}`;
+    },
+    [agents]
+  );
+
   useEffect(() => {
     fetch("/api/templates")
       .then((res) => res.json())
@@ -288,7 +304,7 @@ function AddAgentModal({
       })
       .catch(() => setError("Failed to load templates"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [getAutoId]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -308,20 +324,6 @@ function AddAgentModal({
     setAgentId(getAutoId(tpl.type));
     setError(null);
   };
-
-  const getAutoId = useCallback(
-    (type: string) => {
-      const existing = agents
-        .filter((a) => a.role === type)
-        .map((a) => {
-          const match = a.id.match(new RegExp(`^${type}-(\\d+)$`));
-          return match ? parseInt(match[1], 10) : 0;
-        });
-      const next = existing.length > 0 ? Math.max(...existing) + 1 : 1;
-      return `${type}-${String(next).padStart(2, "0")}`;
-    },
-    [agents]
-  );
 
   const handleSubmit = async () => {
     if (!selected) return;
@@ -535,12 +537,30 @@ export function AgentPanel() {
     }
   };
 
-  const stagedCount = agents.filter(
-    (a) => a.status === "staged" || a.status === "modified"
+  const handleReset = async () => {
+    try {
+      const res = await fetch("/api/agents/reset", { method: "POST" });
+      const data = await res.json();
+      if (data.success) {
+        const parts: string[] = [];
+        if (data.restored?.length) parts.push(`restored ${data.restored.length}`);
+        if (data.removed?.length) parts.push(`removed ${data.removed.length}`);
+        showFeedback(parts.length > 0 ? `Reset: ${parts.join(", ")}` : "Reset (no changes)");
+      } else {
+        showFeedback(`Reset failed: ${data.error ?? "unknown"}`);
+      }
+      fetchAgents();
+    } catch {
+      showFeedback("Reset failed");
+    }
+  };
+
+  const newCount = agents.filter(
+    (a) => a.status === "new" || a.status === "modified"
   ).length;
-  const orphanCount = agents.filter((a) => a.status === "orphan").length;
-  const hasPendingChanges = stagedCount > 0 || orphanCount > 0;
-  const hasStagedAgents = agents.filter((a) => a.status !== "orphan").length > 0;
+  const deletedCount = agents.filter((a) => a.status === "deleted").length;
+  const hasPendingChanges = newCount > 0 || deletedCount > 0;
+  const hasStagedAgents = agents.filter((a) => a.status !== "deleted").length > 0;
 
   return (
     <div className="dashboard-scrollbar h-full bg-surface px-3 pb-3 overflow-y-auto flex flex-col">
@@ -582,6 +602,18 @@ export function AgentPanel() {
           }
         >
           {clearConfirming ? "Confirm?" : "Clear"}
+        </button>
+        <button
+          className={`text-xs rounded px-2 py-1 border transition-colors ${
+            hasPendingChanges
+              ? "border-accent-yellow text-accent-yellow hover:bg-accent-yellow/20"
+              : "border-border text-muted-foreground cursor-not-allowed opacity-50"
+          }`}
+          onClick={hasPendingChanges ? handleReset : undefined}
+          disabled={!hasPendingChanges}
+          title={hasPendingChanges ? "Reset config to match applied state" : "No pending changes to reset"}
+        >
+          Reset
         </button>
         {actionFeedback && (
           <span className="text-xs text-accent-cyan ml-auto">{actionFeedback}</span>

--- a/apps/web/src/lib/paths.ts
+++ b/apps/web/src/lib/paths.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import { collectTemplateTypes, resolveTemplatePath } from "./template-resolution";
 
 /**
  * Resolve the repo root from which all data files are located.
@@ -39,11 +40,16 @@ export function logsDir(): string {
 }
 
 export function templatePath(type: string): string {
-  const localPath = path.join(getForgeRoot(), `templates/${type}.json`);
-  if (fs.existsSync(localPath)) {
-    return localPath;
+  return resolveTemplatePath(getForgeRoot(), type, fs.existsSync);
+}
+
+export function availableTemplateTypes(): string[] {
+  const templatesDir = path.join(getForgeRoot(), "templates");
+  try {
+    return collectTemplateTypes(fs.readdirSync(templatesDir));
+  } catch {
+    return [];
   }
-  return path.join(getForgeRoot(), `templates/${type}.example.json`);
 }
 
 export function eventsPath(): string {

--- a/apps/web/src/lib/template-resolution.test.ts
+++ b/apps/web/src/lib/template-resolution.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectTemplateTypes,
+  resolveTemplatePath,
+} from "./template-resolution.ts";
+
+test("collectTemplateTypes collapses local/example pairs into logical types", () => {
+  assert.deepEqual(
+    collectTemplateTypes([
+      "worker.example.json",
+      "worker.json",
+      "planner.example.json",
+      "README.md",
+      "super.json",
+    ]),
+    ["planner", "super", "worker"]
+  );
+});
+
+test("resolveTemplatePath prefers local templates before example fallbacks", () => {
+  const existingPaths = new Set(["/repo/templates/worker.json"]);
+
+  assert.equal(
+    resolveTemplatePath("/repo", "worker", (candidate) => existingPaths.has(candidate)),
+    "/repo/templates/worker.json"
+  );
+  assert.equal(
+    resolveTemplatePath("/repo", "planner", (candidate) => existingPaths.has(candidate)),
+    "/repo/templates/planner.example.json"
+  );
+});

--- a/apps/web/src/lib/template-resolution.ts
+++ b/apps/web/src/lib/template-resolution.ts
@@ -1,0 +1,25 @@
+export function collectTemplateTypes(files: string[]): string[] {
+  const types = new Set<string>();
+
+  for (const file of files) {
+    const match = file.match(/^(.+?)(?:\.example)?\.json$/);
+    if (match?.[1]) {
+      types.add(match[1]);
+    }
+  }
+
+  return [...types].sort();
+}
+
+export function resolveTemplatePath(
+  forgeRoot: string,
+  type: string,
+  existsSync: (path: string) => boolean
+): string {
+  const localPath = `${forgeRoot}/templates/${type}.json`;
+  if (existsSync(localPath)) {
+    return localPath;
+  }
+
+  return `${forgeRoot}/templates/${type}.example.json`;
+}

--- a/install.sh
+++ b/install.sh
@@ -13,18 +13,6 @@ info()  { echo "${GREEN}✓${RESET} $*"; }
 warn()  { echo "${YELLOW}⚠${RESET} $*"; }
 err()   { echo "${RED}✗${RESET} $*" >&2; }
 
-detect_repo_name() {
-  local remote
-  remote=$(git remote get-url origin 2>/dev/null || true)
-  case "$remote" in
-    git@github.com:*.git) echo "${remote#git@github.com:}" | sed 's/\.git$//' ;;
-    https://github.com/*.git) echo "${remote#https://github.com/}" | sed 's/\.git$//' ;;
-    https://github.com/*) echo "${remote#https://github.com/}" ;;
-    github.com/*) echo "$remote" ;;
-    *) echo "" ;;
-  esac
-}
-
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
 
@@ -150,22 +138,6 @@ else
   rm -f apps/webhook-monitor/config.toml.bak
   info "apps/webhook-monitor/config.toml created"
 fi
-
-template_repo="${FORGE_TEMPLATE_REPO:-$(detect_repo_name)}"
-for example in templates/*.example.json; do
-  [ -f "$example" ] || continue
-  local_copy="${example%.example.json}.json"
-  if [ -f "$local_copy" ]; then
-    info "${local_copy} exists, skipping"
-    continue
-  fi
-  cp "$example" "$local_copy"
-  if [ -n "$template_repo" ]; then
-    sed -i.bak "s|github.com/owner/repo|${template_repo}|g" "$local_copy"
-    rm -f "${local_copy}.bak"
-  fi
-  info "${local_copy} created from ${example##*/}"
-done
 echo
 
 # ── Verification ─────────────────────────────────────────────────────
@@ -215,5 +187,5 @@ ${GREEN}${BOLD}Setup complete!${RESET}
   Next steps:
     1. Edit agent-kernel/.env with your Claude OAuth token
     2. Edit apps/webhook-monitor/config.toml with your webhook secret
-    3. Run: uv run forge add worker && uv run forge cron apply
+    3. Run: uv run forge add worker && uv run forge apply
 EOF


### PR DESCRIPTION
**@worker-04**

## Summary
- replay the remaining template/model behavior onto `epic/878-template-models`
- fix the install next-step command to `uv run forge apply`
- add CLI and shared web-path regression coverage for template/example resolution and model propagation

## Verification
- `PATH="$HOME/.local/bin:$PATH" uv run python -m unittest discover -s apps/forge-cli/tests -p 'test_agents_add.py'`
- `node --test --experimental-strip-types ./apps/web/src/lib/template-resolution.test.ts`
