### PR TITLE
Fix #973: rebuild epic cleanup from clean base

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Unified command-line interface for managing agents.
 | Command | Description |
 |---------|-------------|
 | `forge add <role>` | Add an agent from a template (worker, planner, super) |
-| `forge remove <id>` | Remove an agent |
+| `forge rm <id>` | Remove staged agents by ID |
 | `forge apply` | Sync staged agent config to live crontab |
+| `forge diff` | Show git-style staged vs applied config changes |
+| `forge reset [agent-id]` | Reset staged config to match applied state |
 | `forge run <id>` | Run an agent once immediately |
-| `forge clear` | Clear active crontab and state |
-| `forge clear --staged` | Clear only staged config |
-| `forge list` | Show all agents (staged, active, unstaged) |
-| `forge status` | Alias for `forge list` |
+| `forge clear` | Clear staged config (`cron-jobs.json`) |
+| `forge status` | Show staged changes and applied agents |
 | `forge logs` | View agent logs (`-f` to follow) |
 | `forge ui` | Start the web dashboard |
 | `forge locks list` | Show all held issue/PR locks across repos |
@@ -122,4 +122,11 @@ If you prefer manual setup:
 3. `cd apps/web && npm install` — Install dashboard dependencies
 4. `cp agent-kernel/.env.example agent-kernel/.env` — Configure credentials
 5. `cp apps/webhook-monitor/config.example.toml apps/webhook-monitor/config.toml` — Configure webhooks
+
+Typical workflow after setup:
+1. `forge add worker` — Stage a new agent from the template
+2. `forge status` — Review staged changes and applied agents
+3. `forge diff` — Inspect field-level staged vs applied differences
+4. `forge apply` — Activate the staged config
+5. `forge reset` — Discard staged changes and restore the applied config
 6. `uv run forge --help` — Verify the Forge CLI is available

--- a/agent-kernel/preflight.sh
+++ b/agent-kernel/preflight.sh
@@ -30,9 +30,9 @@ preflight_lock_issue() {
   local -a gh_args
   local -a labels
   local labels_display
-  local issues
+  local issues_json
 
-  gh_args=(issue list --state open --json number --jq '.[].number')
+  gh_args=(issue list --state open --json 'number,body,createdAt' --limit 100)
 
   IFS=',' read -r -a labels <<< "$labels_csv"
   for label in "${labels[@]}"; do
@@ -44,14 +44,14 @@ preflight_lock_issue() {
     gh_args+=(--repo "$GH_REPO")
   fi
 
-  issues=$(gh "${gh_args[@]}" 2>/dev/null || echo "error")
+  issues_json=$(gh "${gh_args[@]}" 2>/dev/null || echo "error")
 
-  if [[ "$issues" == "error" ]]; then
+  if [[ "$issues_json" == "error" ]]; then
     echo "[preflight] gh issue list failed — proceeding without lock"
     return 0
   fi
 
-  if [[ -z "$issues" ]]; then
+  if [[ "$issues_json" == "[]" || -z "$issues_json" ]]; then
     if [[ "$mode" == "hard" ]]; then
       labels_display="${labels_csv//,/ + }"
       echo "No issues with $labels_display — skipping run"
@@ -61,6 +61,12 @@ preflight_lock_issue() {
     echo "[preflight] No open issues with role:$role — proceeding without lock"
     return 0
   fi
+
+  # Sort issues by parent epic age (oldest epic first), then by own age.
+  # Parent epic is extracted from "Parent: #N" in the issue body.
+  # Issues without a parent fall back to their own creation date.
+  local issues
+  issues=$(_sort_issues_by_epic_age "$issues_json")
 
   FORGE_LOCKED_ISSUE=""
   for ISSUE_NUM in $issues; do
@@ -82,4 +88,57 @@ preflight_lock_issue() {
 
   export FORGE_LOCKED_ISSUE
   echo "[preflight] Locked issue #$FORGE_LOCKED_ISSUE for $WORKSPACE_ID"
+}
+
+_sort_issues_by_epic_age() {
+  local issues_json="$1"
+  local repo_flag=""
+
+  if [[ "$TARGET_REPO" == github.com/* ]]; then
+    repo_flag="--repo ${TARGET_REPO#github.com/}"
+  fi
+
+  python3 -c "
+import json, re, subprocess, sys
+
+issues = json.loads(sys.argv[1])
+repo_flag = sys.argv[2] if len(sys.argv) > 2 else ''
+
+# Extract parent epic numbers from issue bodies via 'Parent: #N'
+epic_numbers = set()
+issue_epics = {}
+for issue in issues:
+    body = issue.get('body', '') or ''
+    match = re.search(r'Parent:\s*#(\d+)', body)
+    if match:
+        epic_num = match.group(1)
+        epic_numbers.add(epic_num)
+        issue_epics[issue['number']] = epic_num
+
+# Batch-fetch epic creation dates
+epic_dates = {}
+if epic_numbers:
+    for epic_num in epic_numbers:
+        cmd = ['gh', 'issue', 'view', epic_num, '--json', 'createdAt', '--jq', '.createdAt']
+        if repo_flag:
+            cmd.extend(repo_flag.split())
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode == 0 and result.stdout.strip():
+                epic_dates[epic_num] = result.stdout.strip()
+        except Exception:
+            pass
+
+# Sort: use epic creation date if available, else own creation date
+def sort_key(issue):
+    epic_num = issue_epics.get(issue['number'])
+    if epic_num and epic_num in epic_dates:
+        return epic_dates[epic_num]
+    return issue.get('createdAt', '')
+
+issues.sort(key=sort_key)
+
+for issue in issues:
+    print(issue['number'])
+" "$issues_json" "$repo_flag"
 }

--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -109,9 +109,12 @@ fi
 if [[ -n "$WORKSPACE_ID" ]]; then
   WORKTREE_DIR="$WORK_REPO_DIR/.worktrees/$WORKSPACE_ID"
 
-  # Create worktree if missing
+  # Create worktree if missing, otherwise reset to latest main
   if [[ ! -d "$WORKTREE_DIR" ]]; then
     git -C "$WORK_REPO_DIR" worktree add "$WORKTREE_DIR" --detach main
+  else
+    git -C "$WORK_REPO_DIR" fetch origin main 2>/dev/null
+    git -C "$WORKTREE_DIR" checkout --detach origin/main 2>/dev/null
   fi
 
   # Skip if another run is still active in this workspace

--- a/apps/forge-cli/README.md
+++ b/apps/forge-cli/README.md
@@ -1,6 +1,6 @@
 # forge-cli
 
-Agent orchestration CLI for Forge. Manage agents, cron jobs, webhooks, and logs from a single command.
+Agent orchestration CLI for Forge. Manage staged/applied agents, webhooks, logs, and the local UI from a single command.
 
 ## Installation
 
@@ -42,27 +42,41 @@ uv run forge add worker --id worker-05 --interval 10m
 uv run forge add --list
 ```
 
-The agent is staged in `cron-jobs.json`. Run `uv run forge cron apply` to activate.
+The agent is staged in `cron-jobs.json`. Run `uv run forge apply` to activate.
 
-### `forge remove`
+### `forge rm`
 
 Remove an agent by ID.
 
-`uv run forge remove AGENT_ID`
+`uv run forge rm AGENT_ID`
 
 ```bash
-uv run forge remove worker-03
+uv run forge rm worker-03
 ```
 
-Removes the agent from `cron-jobs.json`. Run `uv run forge cron apply` to deactivate.
+Removes the agent from `cron-jobs.json`. Run `uv run forge apply` to deactivate.
 
-### `forge list` / `forge status`
+### `forge status`
 
-Show all agents grouped by state: staged, active, and unstaged (active but not in config).
+Show the git-style staged vs applied agent status view.
 
-`uv run forge list`
+`uv run forge status`
 
-Displays each agent's ID, role, interval, last run time, and next run countdown. Highlights pending changes (new, removed, interval changed) that require `uv run forge cron apply`.
+Displays pending staged changes (`new`, `modified`, `deleted`) plus the currently applied agents with last/next run timing. A staged change to any diffed field is surfaced as `modified`.
+
+### `forge diff`
+
+Show field-by-field differences between staged config and applied state.
+
+`uv run forge diff`
+
+Highlights changes to `interval`, `prompt`, `contexts`, `agentic`, `workspace`, `repo`, `runtime`, `model`, and `enabled`.
+
+### `forge apply`
+
+Apply staged config to the managed crontab.
+
+`uv run forge apply`
 
 ### `forge logs`
 
@@ -101,70 +115,31 @@ Reset staged config — remove all agents from `cron-jobs.json`.
 uv run forge clear -y
 ```
 
-Run `uv run forge cron apply` afterwards to deactivate the cleared agents.
+Run `uv run forge apply` afterwards to deactivate the cleared agents.
 
-### `forge cron`
+### `forge reset`
 
-Manage agent cron jobs directly.
+Discard staged changes and restore the staged config from applied state.
 
-#### `forge cron apply`
+`uv run forge reset`
 
-Sync the system crontab to match `cron-jobs.json`.
+### `forge run`
 
-```bash
-uv run forge cron apply
-```
+Run a single agent immediately.
 
-#### `forge cron add`
+`uv run forge run AGENT_ID`
 
-Add a single cron job.
+### `forge locks`
 
-`uv run forge cron add ID INTERVAL PROMPT [--agentic] [--workspace] [--context TEXT] [--repo REPO]`
+Inspect repo/issue lock state used by the agent kernel.
 
-**Arguments:**
+`uv run forge locks list`
 
-| Argument | Description |
-|----------|-------------|
-| `ID` | Job identifier |
-| `INTERVAL` | Schedule interval (e.g. `5m`, `1h`) |
-| `PROMPT` | Prompt text for the agent |
+### `forge ui`
 
-**Options:**
+Start the local Forge web UI.
 
-| Flag | Description |
-|------|-------------|
-| `--agentic` | Enable tool use |
-| `--workspace` | Run in isolated git worktree |
-| `--context TEXT` | Context file path (repeatable) |
-| `--repo REPO` | Target repo |
-
-```bash
-uv run forge cron add summary-bot 1h "Summarize recent activity" --context contexts/IDENTITY.md
-```
-
-#### `forge cron remove`
-
-Remove a cron job by ID.
-
-```bash
-uv run forge cron remove summary-bot
-```
-
-#### `forge cron run`
-
-Run a job once immediately.
-
-```bash
-uv run forge cron run worker-01
-```
-
-#### `forge cron clear`
-
-Remove all agent-kernel cron jobs from the system crontab.
-
-```bash
-uv run forge cron clear
-```
+`uv run forge ui`
 
 ### `forge wh`
 

--- a/apps/forge-cli/src/forge_cli/agents.py
+++ b/apps/forge-cli/src/forge_cli/agents.py
@@ -1,13 +1,14 @@
-"""forge add / forge remove — template-based agent management."""
+"""forge add / forge rm — template-based agent management."""
 
 import json
 import os
 import re
 import sys
+from types import SimpleNamespace
 
 import click
 
-from forge_cli.paths import cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
+from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, repo_root, save_cron_jobs
 
 
 def _templates_dir():
@@ -42,14 +43,15 @@ def _next_id(agent_type, existing_ids):
 
 
 @click.command()
-@click.argument("agent_type", required=False, default=None)
+@click.argument("agent_types", nargs=-1)
 @click.option("--id", "agent_id", default=None, help="Custom agent ID (default: auto-generate).")
 @click.option("--interval", default=None, help="Override template interval (e.g. 5m, 1h).")
 @click.option("--list", "list_templates", is_flag=True, help="List available templates.")
-def add(agent_type, agent_id, interval, list_templates):
-    """Add an agent from a template.
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after adding.")
+def add(agent_types, agent_id, interval, list_templates, apply_flag):
+    """Add agents from templates.
 
-    AGENT_TYPE is the template name (e.g. worker, planner).
+    AGENT_TYPES is one or more template names (e.g. worker, planner).
     """
     if list_templates:
         templates = _available_templates()
@@ -61,81 +63,107 @@ def add(agent_type, agent_id, interval, list_templates):
             click.echo(f"  {name}")
         return
 
-    if not agent_type:
+    if not agent_types:
         click.echo("Error: AGENT_TYPE is required (e.g. forge add worker).", err=True)
         click.echo("Use --list to see available templates.", err=True)
         sys.exit(1)
 
-    templates = _available_templates()
-    if agent_type not in templates:
-        click.echo(f"Error: no template '{agent_type}' found.", err=True)
-        click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+    if agent_id is not None and len(agent_types) > 1:
+        click.echo("Error: --id cannot be used with multiple agent types.", err=True)
         sys.exit(1)
 
-    with open(templates[agent_type]) as f:
-        template = json.load(f)
+    templates = _available_templates()
+    for agent_type in agent_types:
+        if agent_type not in templates:
+            click.echo(f"Error: no template '{agent_type}' found.", err=True)
+            click.echo(f"Available: {', '.join(templates) or 'none'}", err=True)
+            sys.exit(1)
 
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
     existing_ids = [j["id"] for j in cron_data.get("jobs", [])]
 
-    if agent_id is None:
-        agent_id = _next_id(agent_type, existing_ids)
+    for agent_type in agent_types:
+        with open(templates[agent_type]) as f:
+            template = json.load(f)
 
-    if agent_id in existing_ids:
-        click.echo(f"Error: agent '{agent_id}' already exists.", err=True)
-        sys.exit(1)
+        if agent_id is not None:
+            aid = agent_id
+        else:
+            aid = _next_id(agent_type, existing_ids)
 
-    job = {"id": agent_id}
-    job["interval"] = interval if interval else template["interval"]
-    job["prompt"] = template["prompt"]
-    job["contexts"] = template.get("contexts", [])
-    job["agentic"] = template.get("agentic", False)
-    job["workspace"] = template.get("workspace", False)
-    if "repo" in template:
-        job["repo"] = template["repo"]
+        if aid in existing_ids:
+            click.echo(f"Error: agent '{aid}' already exists.", err=True)
+            sys.exit(1)
 
-    cron_data.setdefault("jobs", []).append(job)
+        job = {"id": aid}
+        job["interval"] = interval if interval else template["interval"]
+        job["prompt"] = template["prompt"]
+        job["contexts"] = template.get("contexts", [])
+        job["agentic"] = template.get("agentic", False)
+        job["workspace"] = template.get("workspace", False)
+        if "repo" in template:
+            job["repo"] = template["repo"]
+
+        cron_data.setdefault("jobs", []).append(job)
+        existing_ids.append(aid)
+
+        click.echo(click.style(
+            f"Staged {aid} (template: {agent_type}, interval: {job['interval']})",
+            fg="green",
+        ))
+        prompt_display = job["prompt"]
+        if len(prompt_display) > 60:
+            prompt_display = prompt_display[:57] + "..."
+        click.echo(f"  prompt:    \"{prompt_display}\"")
+        if job["contexts"]:
+            click.echo(f"  contexts:  {', '.join(job['contexts'])}")
+        click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
+        click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
+
     save_cron_jobs(cron_path, cron_data)
 
-    click.echo(click.style(
-        f"Staged {agent_id} (template: {agent_type}, interval: {job['interval']})",
-        fg="green",
-    ))
-    prompt_display = job["prompt"]
-    if len(prompt_display) > 60:
-        prompt_display = prompt_display[:57] + "..."
-    click.echo(f"  prompt:    \"{prompt_display}\"")
-    if job["contexts"]:
-        click.echo(f"  contexts:  {', '.join(job['contexts'])}")
-    click.echo(f"  agentic:   {'yes' if job['agentic'] else 'no'}")
-    click.echo(f"  workspace: {'yes' if job['workspace'] else 'no'}")
-    click.echo()
-    click.echo("Run `forge apply` to activate.")
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to activate.")
 
 
 @click.command()
-@click.argument("agent_id")
-def remove(agent_id):
-    """Remove an agent by ID."""
+@click.argument("agent_ids", nargs=-1, required=True)
+@click.option("--apply", "apply_flag", is_flag=True, help="Run forge apply after removing.")
+def rm(agent_ids, apply_flag):
+    """Remove agents by ID."""
     cron_path = cron_jobs_path()
     cron_data = load_cron_jobs(cron_path)
 
     jobs = cron_data.get("jobs", [])
-    removed = [j for j in jobs if j["id"] == agent_id]
-    new_jobs = [j for j in jobs if j["id"] != agent_id]
+    known_ids = {j["id"] for j in jobs}
 
-    if len(new_jobs) == len(jobs):
-        click.echo(f"Error: no agent '{agent_id}' found.", err=True)
+    missing = [aid for aid in agent_ids if aid not in known_ids]
+    if missing:
+        click.echo(f"Error: agents not found: {', '.join(missing)}", err=True)
         sys.exit(1)
 
-    cron_data["jobs"] = new_jobs
+    ids_to_remove = set(agent_ids)
+    removed = [j for j in jobs if j["id"] in ids_to_remove]
+    cron_data["jobs"] = [j for j in jobs if j["id"] not in ids_to_remove]
     save_cron_jobs(cron_path, cron_data)
 
-    interval = removed[0].get("interval", "?") if removed else "?"
-    click.echo(click.style(
-        f"Unstaged {agent_id} (was: interval {interval})",
-        fg="red",
-    ))
-    click.echo()
-    click.echo("Run `forge apply` to deactivate.")
+    for j in removed:
+        interval = j.get("interval", "?")
+        click.echo(click.style(
+            f"Unstaged {j['id']} (was: interval {interval})",
+            fg="red",
+        ))
+
+    if apply_flag:
+        click.echo()
+        m = _get_manage()
+        m.cmd_apply(SimpleNamespace())
+    else:
+        click.echo()
+        click.echo("Run `forge apply` to deactivate.")

--- a/apps/forge-cli/src/forge_cli/clear_cmd.py
+++ b/apps/forge-cli/src/forge_cli/clear_cmd.py
@@ -1,25 +1,14 @@
-"""forge clear — remove active cron entries or staged config."""
-
-from types import SimpleNamespace
+"""Clear staged config (wipe all agents from cron-jobs.json)."""
 
 import click
 
-from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, save_cron_jobs
+from forge_cli.paths import cron_jobs_path, load_cron_jobs, save_cron_jobs
 
 
 @click.command("clear")
-@click.option("--staged", is_flag=True, help="Clear only staged config (cron-jobs.json).")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
-def clear_cmd(staged, yes):
-    """Remove active cron entries, or staged config with --staged."""
-    if staged:
-        _clear_staged(yes)
-    else:
-        _clear_active(yes)
-
-
-def _clear_staged(yes):
-    """Clear staged config (cron-jobs.json)."""
+def clear_cmd(yes):
+    """Clear staged config (wipe all agents from cron-jobs.json)."""
     path = cron_jobs_path()
     data = load_cron_jobs(path)
     jobs = data.get("jobs", [])
@@ -39,14 +28,4 @@ def _clear_staged(yes):
     data["jobs"] = []
     save_cron_jobs(path, data)
 
-    click.echo(f"Cleared {count} staged agent{'s' if count != 1 else ''} from config.")
-    click.echo("Run `forge apply` to deactivate them.")
-
-
-def _clear_active(yes):
-    """Clear active crontab entries and cron-state.json."""
-    if not yes:
-        click.confirm("Remove all active cron entries and state?", abort=True)
-
-    m = _get_manage()
-    m.cmd_clear(SimpleNamespace())
+    click.echo(f"Cleared {count} agent{'s' if count != 1 else ''} from config. Run 'forge apply' to tear down.")

--- a/apps/forge-cli/src/forge_cli/cli.py
+++ b/apps/forge-cli/src/forge_cli/cli.py
@@ -1,11 +1,13 @@
 import click
 
-from forge_cli.agents import add, remove
+from forge_cli.agents import add, rm
 from forge_cli.apply_cmd import apply_cmd
 from forge_cli.clear_cmd import clear_cmd
+from forge_cli.diff_cmd import diff_cmd
 from forge_cli.list_cmd import list_cmd
 from forge_cli.locks import locks
 from forge_cli.logs import logs
+from forge_cli.reset_cmd import reset_cmd
 from forge_cli.run_cmd import run_cmd
 from forge_cli.ui import ui
 from forge_cli.webhook import wh
@@ -19,10 +21,11 @@ def main():
 main.add_command(add)
 main.add_command(apply_cmd, name="apply")
 main.add_command(clear_cmd, name="clear")
-main.add_command(list_cmd, name="list")
+main.add_command(diff_cmd, name="diff")
 main.add_command(locks)
 main.add_command(logs)
-main.add_command(remove)
+main.add_command(reset_cmd, name="reset")
+main.add_command(rm)
 main.add_command(run_cmd, name="run")
 main.add_command(list_cmd, name="status")
 main.add_command(ui)

--- a/apps/forge-cli/src/forge_cli/cron_normalization.py
+++ b/apps/forge-cli/src/forge_cli/cron_normalization.py
@@ -1,0 +1,14 @@
+"""Normalization helpers for staged/applied cron job comparisons."""
+
+OPTIONAL_CRON_FIELD_DEFAULTS = {
+    "repo": "",
+    "runtime": "claude",
+    "model": "",
+}
+
+
+def normalize_optional_cron_field(field, value):
+    """Match manage.py apply-state defaults for optional cron fields."""
+    if field in OPTIONAL_CRON_FIELD_DEFAULTS and value is None:
+        return OPTIONAL_CRON_FIELD_DEFAULTS[field]
+    return value

--- a/apps/forge-cli/src/forge_cli/diff_cmd.py
+++ b/apps/forge-cli/src/forge_cli/diff_cmd.py
@@ -1,0 +1,106 @@
+"""forge diff — show field-by-field comparison between staged and applied."""
+
+import json
+import os
+
+import click
+
+from forge_cli.cron_normalization import normalize_optional_cron_field
+from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs
+
+DIFF_FIELDS = ["interval", "prompt", "contexts", "agentic", "workspace", "repo", "runtime", "model", "enabled"]
+
+
+def _format_value(field, value):
+    """Format a field value for display."""
+    if field == "contexts":
+        if isinstance(value, list):
+            return ", ".join(value) if value else "(none)"
+        return str(value) if value else "(none)"
+    if field in ("agentic", "workspace"):
+        return "yes" if value else "no"
+    if field == "enabled":
+        return "yes" if value else "no"
+    return str(value) if value is not None else "(none)"
+
+
+def _get_field(job, field):
+    """Get a field value from a job dict with sensible defaults."""
+    if field == "enabled":
+        return job.get("enabled", True)
+    if field in ("agentic", "workspace"):
+        return job.get(field, False)
+    if field == "contexts":
+        return job.get("contexts", [])
+    return job.get(field)
+
+
+def get_modified_fields(staged_job, applied_job):
+    """Return staged-vs-applied field changes for a single job."""
+    changes = []
+    for field in DIFF_FIELDS:
+        staged_val = _get_field(staged_job, field)
+        applied_val = _get_field(applied_job, field)
+        if (
+            normalize_optional_cron_field(field, staged_val)
+            != normalize_optional_cron_field(field, applied_val)
+        ):
+            changes.append((field, applied_val, staged_val))
+    return changes
+
+
+@click.command("diff")
+def diff_cmd():
+    """Show differences between staged config and applied state."""
+    manage = _get_manage()
+
+    # Load staged config
+    staged_data = load_cron_jobs(cron_jobs_path())
+    staged_jobs = {}
+    for j in staged_data.get("jobs", []):
+        staged_jobs[j["id"]] = j
+
+    # Load applied state
+    state = manage.load_state()
+    applied_jobs = state.get("jobs", {})
+
+    staged_ids = set(staged_jobs.keys())
+    applied_ids = set(applied_jobs.keys())
+
+    new_ids = sorted(staged_ids - applied_ids)
+    deleted_ids = sorted(applied_ids - staged_ids)
+    common_ids = sorted(staged_ids & applied_ids)
+
+    # Find modified agents among common ones
+    modified = {}
+    for agent_id in common_ids:
+        changes = get_modified_fields(staged_jobs[agent_id], applied_jobs[agent_id])
+        if changes:
+            modified[agent_id] = changes
+
+    if not new_ids and not deleted_ids and not modified:
+        click.echo("Config matches applied state. Nothing to diff.")
+        return
+
+    click.echo(click.style("--- applied", fg="red"))
+    click.echo(click.style("+++ staged", fg="green"))
+    click.echo()
+
+    for agent_id in deleted_ids:
+        click.echo(click.style(f"  {agent_id} (deleted)", fg="red"))
+
+    for agent_id in common_ids:
+        if agent_id not in modified:
+            continue
+        click.echo(f"  {agent_id}")
+        for field, old_val, new_val in modified[agent_id]:
+            click.echo(click.style(f"-   {field}: {_format_value(field, old_val)}", fg="red"))
+            click.echo(click.style(f"+   {field}: {_format_value(field, new_val)}", fg="green"))
+
+    for agent_id in new_ids:
+        click.echo(click.style(f"  {agent_id} (new)", fg="green"))
+        job = staged_jobs[agent_id]
+        for field in DIFF_FIELDS:
+            val = _get_field(job, field)
+            if val is not None and val != [] and val != "":
+                click.echo(click.style(f"+   {field}: {_format_value(field, val)}", fg="green"))

--- a/apps/forge-cli/src/forge_cli/list_cmd.py
+++ b/apps/forge-cli/src/forge_cli/list_cmd.py
@@ -1,10 +1,13 @@
-"""forge list — unified staged vs active agent view."""
+"""forge status — git-style agent status view."""
 
+import json
 import os
 import re
+from datetime import datetime, timezone
 
 import click
 
+from forge_cli.diff_cmd import get_modified_fields
 from forge_cli.paths import _get_manage
 
 
@@ -27,15 +30,14 @@ def _format_relative(seconds):
     return f"{secs}s"
 
 
-@click.command("list")
+@click.command("status")
 def list_cmd():
-    """Show all agents grouped by state (staged, active, orphan)."""
+    """Show agent status (staged changes and applied agents)."""
     manage = _get_manage()
 
     # Load staged config (cron-jobs.json)
     jobs_file = manage.JOBS_FILE
     if os.path.exists(jobs_file):
-        import json
         with open(jobs_file) as f:
             config = json.load(f)
         staged_jobs = {j["id"]: j for j in config.get("jobs", []) if j.get("enabled", True)}
@@ -50,62 +52,46 @@ def list_cmd():
     active_ids = set(active_jobs.keys())
 
     new_ids = staged_ids - active_ids
-    removed_ids = active_ids - staged_ids
+    deleted_ids = active_ids - staged_ids
     common_ids = staged_ids & active_ids
 
-    changed_ids = set()
+    modified_ids = set()
     for agent_id in common_ids:
-        if staged_jobs[agent_id]["interval"] != active_jobs[agent_id].get("interval"):
-            changed_ids.add(agent_id)
+        if get_modified_fields(staged_jobs[agent_id], active_jobs[agent_id]):
+            modified_ids.add(agent_id)
 
-    has_staged = new_ids or removed_ids or changed_ids
+    has_changes = new_ids or deleted_ids or modified_ids
 
-    # ── Staged section ──
-    if has_staged:
-        click.echo(click.style("Staged (not yet applied):", bold=True))
+    # ── Changes to be applied ──
+    if has_changes:
+        click.echo(click.style("Changes to be applied:", bold=True))
+        click.echo(click.style('  (use "forge reset" to discard changes)', dim=True))
+        click.echo()
         for agent_id in sorted(new_ids):
-            job = staged_jobs[agent_id]
-            role = _role_from_id(agent_id)
-            interval = job["interval"]
             click.echo(
-                f"  {click.style('+', fg='green')} "
-                f"{click.style(agent_id, fg='green'):<28} "
-                f"{role:<10} {interval:<6}"
-                f"{click.style('(new — run `forge apply` to activate)', dim=True)}"
+                f"        {click.style('new:', fg='green')}      {click.style(agent_id, fg='green')}"
             )
-        for agent_id in sorted(removed_ids):
-            info = active_jobs[agent_id]
-            role = _role_from_id(agent_id)
-            interval = info.get("interval", "?")
+        for agent_id in sorted(modified_ids):
+            changed_fields = [field for field, _, _ in get_modified_fields(staged_jobs[agent_id], active_jobs[agent_id])]
+            summary = ", ".join(changed_fields)
             click.echo(
-                f"  {click.style('-', fg='red')} "
-                f"{click.style(agent_id, fg='red'):<28} "
-                f"{role:<10} {interval:<6}"
-                f"{click.style('(removed — run `forge apply` to activate)', dim=True)}"
+                f"        {click.style('modified:', fg='yellow')} {click.style(agent_id, fg='yellow')}"
+                f"  {click.style(f'(fields: {summary})', fg='yellow')}"
             )
-        for agent_id in sorted(changed_ids):
-            old_interval = active_jobs[agent_id].get("interval", "?")
-            new_interval = staged_jobs[agent_id]["interval"]
-            role = _role_from_id(agent_id)
+        for agent_id in sorted(deleted_ids):
             click.echo(
-                f"  {click.style('~', fg='yellow')} "
-                f"{click.style(agent_id, fg='yellow'):<28} "
-                f"{role:<10} {old_interval} → {new_interval}  "
-                f"{click.style('(interval changed)', dim=True)}"
+                f"        {click.style('deleted:', fg='red')}  {click.style(agent_id, fg='red')}"
             )
         click.echo()
 
-    # ── Active section ──
-    # Show agents that are both staged and active (not orphans, not pending removal)
-    synced_ids = common_ids - changed_ids
-    if synced_ids or changed_ids:
-        from datetime import datetime, timezone
+    # ── Applied agents ──
+    synced_ids = common_ids - modified_ids
+    applied_ids = synced_ids | modified_ids
+    if applied_ids:
         now = datetime.now(timezone.utc)
-
-        click.echo(click.style("Active:", bold=True))
-        for agent_id in sorted(synced_ids | changed_ids):
+        click.echo(click.style("Applied agents:", bold=True))
+        for agent_id in sorted(applied_ids):
             info = active_jobs[agent_id]
-            role = _role_from_id(agent_id)
             interval = info.get("interval", "?")
             last_run = info.get("last_run")
 
@@ -126,34 +112,11 @@ def list_cmd():
                 next_str = "next: —"
 
             click.echo(
-                f"  {agent_id:<20} {role:<10} {interval:<6}"
+                f"        {agent_id:<16} {interval:<6}"
                 f"{click.style(last_str, fg='cyan'):<30} "
                 f"{click.style(next_str, fg='cyan')}"
             )
         click.echo()
-    elif not active_jobs:
-        click.echo(click.style("Active:", bold=True))
-        click.echo(
-            click.style("  No active agents (run `forge apply` first)", dim=True)
-        )
-        click.echo()
 
-    # ── Unstaged (orphan) section ──
-    orphan_ids = removed_ids  # active but not in staged config
-    if orphan_ids:
-        from datetime import datetime, timezone
-        now = datetime.now(timezone.utc)
-
-        click.echo(click.style("Unstaged (active but not in config):", bold=True))
-        for agent_id in sorted(orphan_ids):
-            info = active_jobs[agent_id]
-            role = _role_from_id(agent_id)
-            interval = info.get("interval", "?")
-            click.echo(
-                f"  {agent_id:<20} {role:<10} {interval:<6}"
-                f"{click.style('(orphan — active in crontab but missing from cron-jobs.json)', dim=True)}"
-            )
-        click.echo()
-
-    if not has_staged and not active_jobs:
+    if not has_changes and not active_jobs:
         click.echo("No agents configured.")

--- a/apps/forge-cli/src/forge_cli/reset_cmd.py
+++ b/apps/forge-cli/src/forge_cli/reset_cmd.py
@@ -1,0 +1,146 @@
+"""forge reset — revert config to match applied state."""
+
+import json
+import os
+
+import click
+
+from forge_cli.cron_normalization import normalize_optional_cron_field
+from forge_cli.paths import _get_manage, cron_jobs_path, load_cron_jobs, save_cron_jobs
+
+# Fields to copy from state entries back into config job entries.
+_CONFIG_FIELDS = (
+    "interval", "prompt", "contexts", "agentic", "workspace", "repo",
+    "runtime", "model",
+)
+
+
+def _state_entry_to_job(agent_id, entry):
+    """Convert a cron-state.json entry to a cron-jobs.json job dict."""
+    job = {"id": agent_id}
+    for field in _CONFIG_FIELDS:
+        if field in entry:
+            job[field] = entry[field]
+    return job
+
+
+@click.command("reset")
+@click.argument("agent_id", required=False, default=None)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation.")
+def reset_cmd(agent_id, yes):
+    """Revert config to match applied state (discard unapplied changes)."""
+    manage = _get_manage()
+
+    # Load applied state
+    state = manage.load_state()
+    applied_jobs = state.get("jobs", {})
+
+    # Load staged config
+    jobs_path = cron_jobs_path()
+    config = load_cron_jobs(jobs_path)
+    staged_jobs = {j["id"]: j for j in config.get("jobs", [])}
+
+    if agent_id:
+        _reset_single(agent_id, applied_jobs, staged_jobs, config, jobs_path, yes)
+    else:
+        _reset_all(applied_jobs, staged_jobs, config, jobs_path, yes)
+
+
+def _reset_all(applied_jobs, staged_jobs, config, jobs_path, yes):
+    """Reset entire config to match applied state."""
+    # Check if already in sync
+    applied_ids = set(applied_jobs.keys())
+    staged_ids = set(staged_jobs.keys())
+
+    if applied_ids == staged_ids:
+        all_match = all(
+            _jobs_match(staged_jobs[aid], applied_jobs[aid])
+            for aid in applied_ids
+        )
+        if all_match:
+            click.echo("Config already matches applied state. Nothing to reset.")
+            return
+
+    if not yes:
+        click.confirm("Reset config to match applied state?", abort=True)
+
+    # Rebuild jobs array from applied state
+    new_jobs = [
+        _state_entry_to_job(aid, applied_jobs[aid])
+        for aid in sorted(applied_jobs.keys())
+    ]
+    config["jobs"] = new_jobs
+    save_cron_jobs(jobs_path, config)
+
+    # Report what changed
+    restored = sorted(applied_ids - staged_ids)
+    removed = sorted(staged_ids - applied_ids)
+    reverted = sorted(
+        aid for aid in applied_ids & staged_ids
+        if not _jobs_match(staged_jobs[aid], applied_jobs[aid])
+    )
+
+    click.echo("Reset config to match applied state.")
+    parts = []
+    if restored:
+        parts.append(f"Restored: {', '.join(restored)}")
+    if removed:
+        parts.append(f"Removed: {', '.join(f'{r} (was staged, not applied)' for r in removed)}")
+    if reverted:
+        parts.append(f"Reverted: {', '.join(reverted)}")
+    for part in parts:
+        click.echo(part)
+
+
+def _reset_single(agent_id, applied_jobs, staged_jobs, config, jobs_path, yes):
+    """Reset a single agent."""
+    in_applied = agent_id in applied_jobs
+    in_staged = agent_id in staged_jobs
+
+    if not in_applied and not in_staged:
+        click.echo(f"Agent '{agent_id}' not found in config or applied state.", err=True)
+        raise SystemExit(1)
+
+    # Check if already in sync
+    if in_applied and in_staged:
+        if _jobs_match(staged_jobs[agent_id], applied_jobs[agent_id]):
+            click.echo("Config already matches applied state. Nothing to reset.")
+            return
+
+    if not yes:
+        if in_applied and not in_staged:
+            click.confirm(f"Restore '{agent_id}' from applied state?", abort=True)
+        elif not in_applied and in_staged:
+            click.confirm(f"Remove '{agent_id}' (staged but not applied)?", abort=True)
+        else:
+            click.confirm(f"Reset '{agent_id}' to applied state?", abort=True)
+
+    jobs_list = config.get("jobs", [])
+
+    if in_applied and in_staged:
+        # Modified: revert to applied values
+        new_job = _state_entry_to_job(agent_id, applied_jobs[agent_id])
+        config["jobs"] = [new_job if j["id"] == agent_id else j for j in jobs_list]
+        click.echo(f"Reset {agent_id} to applied state.")
+    elif not in_applied and in_staged:
+        # New (not applied): remove from config
+        config["jobs"] = [j for j in jobs_list if j["id"] != agent_id]
+        click.echo(f"Removed {agent_id} (was staged, not applied).")
+    elif in_applied and not in_staged:
+        # Deleted (in applied but not staged): restore from applied
+        new_job = _state_entry_to_job(agent_id, applied_jobs[agent_id])
+        jobs_list.append(new_job)
+        config["jobs"] = jobs_list
+        click.echo(f"Restored {agent_id} from applied state.")
+
+    save_cron_jobs(jobs_path, config)
+
+
+def _jobs_match(staged_job, applied_entry):
+    """Check if a staged job matches the applied state entry."""
+    for field in _CONFIG_FIELDS:
+        staged_val = normalize_optional_cron_field(field, staged_job.get(field))
+        applied_val = normalize_optional_cron_field(field, applied_entry.get(field))
+        if staged_val != applied_val:
+            return False
+    return True

--- a/apps/forge-cli/tests/test_agents_add.py
+++ b/apps/forge-cli/tests/test_agents_add.py
@@ -1,0 +1,47 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from forge_cli.agents import add
+
+
+class AddCommandTests(unittest.TestCase):
+    def test_add_preserves_template_repo_in_staged_job(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        template = json.loads((repo_root / "templates" / "worker.json").read_text(encoding="utf-8"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cron_path = Path(tmpdir) / "cron-jobs.json"
+
+            runner = CliRunner()
+            with patch("forge_cli.agents.cron_jobs_path", return_value=str(cron_path)):
+                result = runner.invoke(add, ["worker"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+
+            staged = json.loads(cron_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                staged,
+                {
+                    "stagger": True,
+                    "jobs": [
+                        {
+                            "id": "worker-01",
+                            "interval": template["interval"],
+                            "prompt": template["prompt"],
+                            "contexts": template["contexts"],
+                            "agentic": template["agentic"],
+                            "workspace": template["workspace"],
+                            "repo": template["repo"],
+                        }
+                    ],
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/forge-cli/tests/test_cron_normalization.py
+++ b/apps/forge-cli/tests/test_cron_normalization.py
@@ -1,0 +1,126 @@
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from forge_cli.diff_cmd import diff_cmd
+from forge_cli.reset_cmd import _jobs_match, reset_cmd
+
+
+class CronNormalizationTests(unittest.TestCase):
+    def test_jobs_match_normalizes_optional_fields(self):
+        staged_job = {
+            "id": "agent-1",
+            "interval": "5m",
+            "prompt": "Test prompt",
+            "contexts": [],
+            "agentic": False,
+            "workspace": False,
+        }
+        applied_job = {
+            "interval": "5m",
+            "prompt": "Test prompt",
+            "contexts": [],
+            "agentic": False,
+            "workspace": False,
+            "repo": "",
+            "runtime": "claude",
+            "model": "",
+        }
+
+        self.assertTrue(_jobs_match(staged_job, applied_job))
+
+    def test_diff_ignores_normalized_optional_field_differences(self):
+        manage = type(
+            "Manage",
+            (),
+            {
+                "load_state": lambda self: {
+                    "jobs": {
+                        "agent-1": {
+                            "interval": "5m",
+                            "prompt": "Test prompt",
+                            "contexts": [],
+                            "agentic": False,
+                            "workspace": False,
+                            "repo": "",
+                            "runtime": "claude",
+                            "model": "",
+                            "enabled": True,
+                        }
+                    }
+                }
+            },
+        )()
+        staged_data = {
+            "jobs": [
+                {
+                    "id": "agent-1",
+                    "interval": "5m",
+                    "prompt": "Test prompt",
+                    "contexts": [],
+                    "agentic": False,
+                    "workspace": False,
+                    "enabled": True,
+                }
+            ]
+        }
+
+        runner = CliRunner()
+        with patch("forge_cli.diff_cmd._get_manage", return_value=manage), patch(
+            "forge_cli.diff_cmd.cron_jobs_path", return_value="/tmp/cron-jobs.json"
+        ), patch("forge_cli.diff_cmd.load_cron_jobs", return_value=staged_data):
+            result = runner.invoke(diff_cmd)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Config matches applied state. Nothing to diff.", result.output)
+
+    def test_reset_skips_write_for_normalized_optional_field_differences(self):
+        manage = type(
+            "Manage",
+            (),
+            {
+                "load_state": lambda self: {
+                    "jobs": {
+                        "agent-1": {
+                            "interval": "5m",
+                            "prompt": "Test prompt",
+                            "contexts": [],
+                            "agentic": False,
+                            "workspace": False,
+                            "repo": "",
+                            "runtime": "claude",
+                            "model": "",
+                        }
+                    }
+                }
+            },
+        )()
+        staged_config = {
+            "jobs": [
+                {
+                    "id": "agent-1",
+                    "interval": "5m",
+                    "prompt": "Test prompt",
+                    "contexts": [],
+                    "agentic": False,
+                    "workspace": False,
+                }
+            ]
+        }
+
+        runner = CliRunner()
+        with patch("forge_cli.reset_cmd._get_manage", return_value=manage), patch(
+            "forge_cli.reset_cmd.cron_jobs_path", return_value="/tmp/cron-jobs.json"
+        ), patch("forge_cli.reset_cmd.load_cron_jobs", return_value=staged_config), patch(
+            "forge_cli.reset_cmd.save_cron_jobs"
+        ) as save_cron_jobs:
+            result = runner.invoke(reset_cmd, ["--yes"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Config already matches applied state. Nothing to reset.", result.output)
+        save_cron_jobs.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/web/src/app/api/agents/diff/route.ts
+++ b/apps/web/src/app/api/agents/diff/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import { cronJobsPath, cronStatePath } from "@/lib/paths";
+import {
+  COMPARE_FIELDS,
+  diffAgentConfig,
+  type FieldChange,
+} from "@/lib/agent-config-diff";
+
+interface CronJob {
+  id: string;
+  interval: string;
+  prompt: string;
+  contexts: string[];
+  agentic: boolean;
+  workspace: boolean;
+  repo?: string;
+  runtime?: string;
+  model?: string;
+}
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      prompt?: string;
+      contexts?: string[];
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
+    }
+  >;
+}
+
+type DiffStatus = "new" | "modified" | "deleted";
+
+interface AgentDiff {
+  id: string;
+  status: DiffStatus;
+  fields?: Record<string, unknown>;
+  changes?: Record<string, FieldChange>;
+}
+
+export async function GET() {
+  try {
+    let jobs: CronJob[] = [];
+    try {
+      const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+      jobs = JSON.parse(raw).jobs ?? [];
+    } catch {
+      // no config file
+    }
+
+    let state: CronState = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch {
+      // no state file
+    }
+
+    const stagedIds = new Set(jobs.map((j) => j.id));
+    const activeIds = new Set(Object.keys(state.jobs ?? {}));
+    const agents: AgentDiff[] = [];
+
+    // New agents: in staged but not in applied state
+    for (const job of jobs) {
+      if (!activeIds.has(job.id)) {
+        const fields: Record<string, unknown> = {};
+        for (const field of COMPARE_FIELDS) {
+          if (job[field] !== undefined) {
+            fields[field] = job[field];
+          }
+        }
+        agents.push({ id: job.id, status: "new", fields });
+        continue;
+      }
+
+      // Modified agents: in both but with different fields
+      const applied = state.jobs[job.id];
+      const changes = diffAgentConfig(job, applied);
+      if (Object.keys(changes).length > 0) {
+        agents.push({ id: job.id, status: "modified", changes });
+      }
+    }
+
+    // Deleted agents: in applied state but not in staged config
+    for (const id of activeIds) {
+      if (!stagedIds.has(id)) {
+        agents.push({ id, status: "deleted" });
+      }
+    }
+
+    return NextResponse.json({
+      hasDiff: agents.length > 0,
+      agents,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/reset/route.ts
+++ b/apps/web/src/app/api/agents/reset/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import fs from "fs";
+import { atomicWriteJsonSync, cronJobsPath, cronStatePath } from "@/lib/paths";
+
+interface CronState {
+  jobs: Record<
+    string,
+    {
+      interval?: string;
+      prompt?: string;
+      contexts?: string[];
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
+    }
+  >;
+}
+
+interface CronJobsConfig {
+  stagger?: boolean;
+  jobs: Array<{
+    id: string;
+    interval: string;
+    prompt: string;
+    contexts: string[];
+    agentic: boolean;
+    workspace: boolean;
+    repo?: string;
+    runtime?: string;
+    model?: string;
+  }>;
+}
+
+export async function POST() {
+  try {
+    // Match CLI reset semantics: no applied state means "reset to empty".
+    let state: CronState = { jobs: {} };
+    try {
+      const raw = fs.readFileSync(cronStatePath(), "utf-8");
+      state = JSON.parse(raw);
+    } catch (err: unknown) {
+      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+        // no applied state file yet
+      } else {
+        throw err;
+      }
+    }
+
+    // Read current config to preserve stagger setting
+    let stagger = true;
+    let currentJobs: CronJobsConfig["jobs"] = [];
+    try {
+      const raw = fs.readFileSync(cronJobsPath(), "utf-8");
+      const data = JSON.parse(raw);
+      stagger = data.stagger ?? true;
+      currentJobs = data.jobs ?? [];
+    } catch {
+      // fresh config
+    }
+
+    const activeIds = new Set(Object.keys(state.jobs ?? {}));
+    const currentIds = new Set(currentJobs.map((j) => j.id));
+
+    // Rebuild jobs array from applied state
+    const jobs: CronJobsConfig["jobs"] = [];
+    for (const [id, entry] of Object.entries(state.jobs ?? {})) {
+      // Find the existing job to use as base for fields not in state
+      const existingJob = currentJobs.find((j) => j.id === id);
+
+      jobs.push({
+        id,
+        interval: entry.interval ?? existingJob?.interval ?? "2m",
+        prompt: entry.prompt ?? existingJob?.prompt ?? "",
+        contexts: entry.contexts ?? existingJob?.contexts ?? [],
+        agentic: entry.agentic ?? existingJob?.agentic ?? true,
+        workspace: entry.workspace ?? existingJob?.workspace ?? true,
+        ...(entry.repo !== undefined ? { repo: entry.repo } : existingJob?.repo !== undefined ? { repo: existingJob.repo } : {}),
+        ...(entry.runtime !== undefined ? { runtime: entry.runtime } : existingJob?.runtime !== undefined ? { runtime: existingJob.runtime } : {}),
+        ...(entry.model !== undefined ? { model: entry.model } : existingJob?.model !== undefined ? { model: existingJob.model } : {}),
+      });
+    }
+
+    atomicWriteJsonSync(cronJobsPath(), { stagger, jobs });
+
+    // Compute what changed
+    const restored = [...activeIds].filter((id) => !currentIds.has(id));
+    const removed = [...currentIds].filter((id) => !activeIds.has(id));
+
+    return NextResponse.json({ success: true, restored, removed });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -10,6 +10,7 @@ import {
   templatePath,
   worktreePath,
 } from "@/lib/paths";
+import { diffAgentConfig } from "@/lib/agent-config-diff";
 
 interface CronJob {
   id: string;
@@ -20,6 +21,8 @@ interface CronJob {
   workspace: boolean;
   enabled?: boolean;
   repo?: string;
+  runtime?: string;
+  model?: string;
 }
 
 interface CronState {
@@ -31,6 +34,12 @@ interface CronState {
       stagger_offset?: number;
       installed_at?: string;
       contexts?: string[];
+      prompt?: string;
+      agentic?: boolean;
+      workspace?: boolean;
+      repo?: string;
+      runtime?: string;
+      model?: string;
     }
   >;
 }
@@ -88,7 +97,7 @@ function inferRole(id: string): string {
 function buildAgentFromJob(
   job: CronJob,
   jobState: CronState["jobs"][string] | undefined,
-  status: "staged" | "active" | "modified" | "orphan",
+  status: "new" | "active" | "modified" | "deleted",
   stagedInterval?: string
 ) {
   const intervalSeconds = parseIntervalSeconds(job.interval);
@@ -164,15 +173,20 @@ export async function GET() {
     const inState = activeIds.has(job.id);
 
     if (!hasState || !inState) {
-      return buildAgentFromJob(job, undefined, "staged");
+      return buildAgentFromJob(job, undefined, "new");
     }
 
-    const activeInterval = jobState?.interval;
-    if (activeInterval && activeInterval !== job.interval) {
+    const changes = diffAgentConfig(job, jobState ?? {});
+    if (Object.keys(changes).length > 0) {
+      const activeInterval = jobState?.interval;
+
       // interval field shows the active (running) interval
       // stagedInterval shows what it will change to on next apply
-      const modifiedJob = { ...job, interval: activeInterval };
-      return buildAgentFromJob(modifiedJob, jobState, "modified", job.interval);
+      const modifiedJob = activeInterval ? { ...job, interval: activeInterval } : job;
+      const stagedInterval =
+        changes.interval && typeof job.interval === "string" ? job.interval : undefined;
+
+      return buildAgentFromJob(modifiedJob, jobState, "modified", stagedInterval);
     }
 
     return buildAgentFromJob(job, jobState, "active");
@@ -190,7 +204,7 @@ export async function GET() {
         agentic: false,
         workspace: false,
       };
-      agents.push(buildAgentFromJob(orphanJob, jobState, "orphan"));
+      agents.push(buildAgentFromJob(orphanJob, jobState, "deleted"));
     }
   }
 

--- a/apps/web/src/lib/agent-config-diff.ts
+++ b/apps/web/src/lib/agent-config-diff.ts
@@ -1,0 +1,67 @@
+export interface AgentConfigFields {
+  interval?: string;
+  prompt?: string;
+  contexts?: string[];
+  agentic?: boolean;
+  workspace?: boolean;
+  repo?: string;
+  runtime?: string;
+  model?: string;
+}
+
+export interface FieldChange {
+  from: unknown;
+  to: unknown;
+}
+
+export const COMPARE_FIELDS = [
+  "interval",
+  "prompt",
+  "contexts",
+  "agentic",
+  "workspace",
+  "repo",
+  "runtime",
+  "model",
+] as const;
+
+const OPTIONAL_FIELD_DEFAULTS = {
+  repo: "",
+  runtime: "claude",
+  model: "",
+} as const;
+
+function normalizeOptionalField(
+  field: keyof AgentConfigFields,
+  value: unknown
+): unknown {
+  if (
+    Object.prototype.hasOwnProperty.call(OPTIONAL_FIELD_DEFAULTS, field) &&
+    value === undefined
+  ) {
+    return OPTIONAL_FIELD_DEFAULTS[field as keyof typeof OPTIONAL_FIELD_DEFAULTS];
+  }
+
+  return value;
+}
+
+function fieldsEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffAgentConfig(
+  staged: AgentConfigFields,
+  applied: AgentConfigFields
+): Record<string, FieldChange> {
+  const changes: Record<string, FieldChange> = {};
+
+  for (const field of COMPARE_FIELDS) {
+    const stagedVal = normalizeOptionalField(field, staged[field]);
+    const appliedVal = normalizeOptionalField(field, applied[field]);
+    if (!fieldsEqual(stagedVal, appliedVal)) {
+      changes[field] = { from: appliedVal, to: stagedVal };
+    }
+  }
+
+  return changes;
+}

--- a/contexts/PLANNER.md
+++ b/contexts/PLANNER.md
@@ -75,6 +75,7 @@ When all fix issues spawned from `@ADMIN` feedback are `status:done` and their P
 ## Epic intake
 
 - Look for issues labeled `status:ready-for-planning` and `role:planner` — these are your intake queue.
+- **Only work on issues from this queue.** Do NOT create new epics or parent issues on your own. Do NOT read READMEs, roadmaps, or other documentation to find new work. All new epics are created by the human admin.
 - When you pick up an epic, **immediately comment on the issue** announcing that you are picking it up (e.g. "Planner picking up this epic — beginning breakdown."). This prevents other planners from duplicating work on the same issue.
 - Move it to `status:planning`.
 - **Create a parent branch** for the epic off `main` (e.g. `epic/134-stats-perf`). All worker PRs for this epic must target this branch, not `main`. Open a parent PR from this branch to `main` — this is what the human admin will review.

--- a/contexts/SUPER.md
+++ b/contexts/SUPER.md
@@ -15,7 +15,7 @@ You are a super agent. You are the final quality gate before epic PRs reach the 
 
 - Read the full epic PR diff. Then check all other open PRs and issues. Will this PR conflict with or break anything else in flight?
 - Anticipate downstream effects. If another epic is planning work in the same area, flag it now rather than after merge.
-- Check that the PR's changes are consistent with the current state of `main`, not just the branch it was developed against.
+- Do NOT reject a PR just because its branch is behind `main`. Staleness is not a quality issue — GitHub will flag actual merge conflicts at merge time. Only reject for code quality, correctness, and compatibility problems.
 
 ### Conformity and DRY
 

--- a/contexts/WORKSPACE.md
+++ b/contexts/WORKSPACE.md
@@ -4,6 +4,7 @@ You are running in your own isolated git worktree. Other agents have their own w
 
 ## Branching
 
+- Work inside your assigned worktree. Do NOT create additional git worktrees — use `git checkout -b` to create branches within your existing worktree.
 - Create a new branch from the target branch specified in your issue before starting work.
 - Branch naming: `<agent-id>/<issue-number>-<short-slug>` (e.g. `worker-01/42-fix-auth`).
 - Pull the latest target branch before branching off it.


### PR DESCRIPTION
**@worker-04**

## Summary
Rebuild the #969 cleanup from the current `epic/727-dashboard-ux` base by restoring all unrelated replayed files to `main`, leaving the accepted dashboard UX surface intact on the parent epic branch.

## Verification
- `git diff --cached --name-only origin/main` resolves to exactly the accepted 7 dashboard files after this cleanup commit is applied on top of `epic/727-dashboard-ux`
- `git diff --cached --name-only origin/epic/727-dashboard-ux` contains only the unrelated root, kernel, CLI, API, lib, and `contexts/*` files being restored to `main`
