### PR TITLE
Fix live dashboard parsing for multi-chunk buffered runs

### DIFF
--- a/apps/web/src/components/logs-panel.tsx
+++ b/apps/web/src/components/logs-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useLayoutEffect } from "react";
-import { LogBlock, parseLogBlocks } from "@/lib/log-parser";
+import { LogBlock, LogParserState, parseLogBlocks } from "@/lib/log-parser";
 import { getAgentColor } from "@/lib/colors";
 
 const MAX_BLOCKS = 200;
@@ -13,6 +13,7 @@ interface AgentOffset {
   [agentId: string]: number;
 }
 
+type AgentParserState = Record<string, LogParserState>;
 type AgentFilterState = Record<string, boolean>;
 
 function loadFilterState(): AgentFilterState {
@@ -50,6 +51,7 @@ export function LogsPanel() {
   const [filterOpen, setFilterOpen] = useState(false);
 
   const offsetsRef = useRef<AgentOffset>({});
+  const parserStatesRef = useRef<AgentParserState>({});
   const containerRef = useRef<HTMLDivElement>(null);
   const prevScrollTop = useRef(0);
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -128,13 +130,13 @@ export function LogsPanel() {
         let changed = false;
         for (const b of newBlocks) {
           const existing = blockMap.get(b.key);
-          if (!existing) {
-            blockMap.set(b.key, b);
-            changed = true;
-          } else if (
-            existing.type === "skip"
-              ? b.skipReason !== existing.skipReason
-              : b.content.length > existing.content.length
+          if (
+            !existing ||
+            existing.type !== b.type ||
+            existing.content !== b.content ||
+            existing.skipReason !== b.skipReason ||
+            existing.duration !== b.duration ||
+            existing.exitCode !== b.exitCode
           ) {
             blockMap.set(b.key, b);
             changed = true;
@@ -179,7 +181,11 @@ export function LogsPanel() {
     const newBlocks: LogBlock[] = [];
     for (const result of results) {
       if (result.data) {
-        newBlocks.push(...parseLogBlocks(result.agentId, result.data));
+        const parsed = parseLogBlocks(result.agentId, result.data, {
+          finalize: true,
+        });
+        newBlocks.push(...parsed.blocks);
+        parserStatesRef.current[result.agentId] = parsed.state;
       }
       offsetsRef.current[result.agentId] = result.offset;
     }
@@ -206,7 +212,11 @@ export function LogsPanel() {
     const newBlocks: LogBlock[] = [];
     for (const result of results) {
       if (result.data) {
-        newBlocks.push(...parseLogBlocks(result.agentId, result.data));
+        const parsed = parseLogBlocks(result.agentId, result.data, {
+          state: parserStatesRef.current[result.agentId],
+        });
+        newBlocks.push(...parsed.blocks);
+        parserStatesRef.current[result.agentId] = parsed.state;
       }
       offsetsRef.current[result.agentId] = result.offset;
     }
@@ -231,6 +241,7 @@ export function LogsPanel() {
   useEffect(() => {
     setBlocks([]);
     offsetsRef.current = {};
+    parserStatesRef.current = {};
 
     fetchInitialLogs();
 
@@ -240,8 +251,11 @@ export function LogsPanel() {
     es.addEventListener("log", (event) => {
       const { agentId, data, offset } = JSON.parse(event.data);
       if (data) {
-        const parsed = parseLogBlocks(agentId, data);
-        mergeBlocks(parsed);
+        const parsed = parseLogBlocks(agentId, data, {
+          state: parserStatesRef.current[agentId],
+        });
+        mergeBlocks(parsed.blocks);
+        parserStatesRef.current[agentId] = parsed.state;
       }
       offsetsRef.current[agentId] = offset;
 

--- a/apps/web/src/lib/log-parser.ts
+++ b/apps/web/src/lib/log-parser.ts
@@ -10,8 +10,26 @@ export interface LogBlock {
   skipReason?: string;
 }
 
+export interface LogParserState {
+  currentTimestamp: string | null;
+  currentDuration?: number;
+  currentExitCode?: number;
+  currentLines: string[];
+  pendingLine: string;
+}
+
 const RUN_MARKER = /^=== RUN (\S+) duration=(\d+)s exit=(\d+) ===$/;
 const SKIP_MARKER = /^=== SKIP (\S+) reason=(.+) ===$/;
+
+function createEmptyState(): LogParserState {
+  return {
+    currentTimestamp: null,
+    currentDuration: undefined,
+    currentExitCode: undefined,
+    currentLines: [],
+    pendingLine: "",
+  };
+}
 
 function formatTime(isoTimestamp: string): string {
   try {
@@ -29,94 +47,104 @@ function formatTime(isoTimestamp: string): string {
 
 export function parseLogBlocks(
   agentId: string,
-  raw: string
-): LogBlock[] {
-  const lines = raw.split("\n");
+  raw: string,
+  options?: {
+    state?: LogParserState;
+    finalize?: boolean;
+  }
+): { blocks: LogBlock[]; state: LogParserState } {
+  const state = options?.state
+    ? {
+        currentTimestamp: options.state.currentTimestamp,
+        currentDuration: options.state.currentDuration,
+        currentExitCode: options.state.currentExitCode,
+        currentLines: [...options.state.currentLines],
+        pendingLine: options.state.pendingLine,
+      }
+    : createEmptyState();
   const blocks: LogBlock[] = [];
-  let currentTimestamp: string | null = null;
-  let currentDuration: number | undefined = undefined;
-  let currentExitCode: number | undefined = undefined;
-  let currentLines: string[] = [];
 
-  for (const line of lines) {
-    // Check for skip entries first
+  const pushRunBlock = () => {
+    if (!state.currentTimestamp || state.currentLines.length === 0) {
+      return;
+    }
+
+    const content = state.currentLines.join("\n").trim();
+    if (!content) {
+      return;
+    }
+
+    blocks.push({
+      agentId,
+      timestamp: state.currentTimestamp,
+      displayTime: formatTime(state.currentTimestamp),
+      duration: state.currentDuration,
+      exitCode: state.currentExitCode,
+      content,
+      key: `${agentId}-${state.currentTimestamp}`,
+      type: "run",
+    });
+  };
+
+  const clearRunState = () => {
+    state.currentTimestamp = null;
+    state.currentDuration = undefined;
+    state.currentExitCode = undefined;
+    state.currentLines = [];
+  };
+
+  const processLine = (line: string) => {
     const skipMatch = line.match(SKIP_MARKER);
     if (skipMatch) {
-      // Flush any in-progress block
-      if (currentTimestamp && currentLines.length > 0) {
-        const content = currentLines.join("\n").trim();
-        if (content) {
-          blocks.push({
-            agentId,
-            timestamp: currentTimestamp,
-            displayTime: formatTime(currentTimestamp),
-            duration: currentDuration,
-            exitCode: currentExitCode,
-            content,
-            key: `${agentId}-${currentTimestamp}`,
-            type: "run",
-          });
-        }
-        currentTimestamp = null;
-        currentLines = [];
-        currentDuration = undefined;
-        currentExitCode = undefined;
-      }
-
-      const ts = skipMatch[1];
+      pushRunBlock();
+      clearRunState();
+      const timestamp = skipMatch[1];
       blocks.push({
         agentId,
-        timestamp: ts,
-        displayTime: formatTime(ts),
+        timestamp,
+        displayTime: formatTime(timestamp),
         content: "",
-        key: `${agentId}-skip-${ts}`,
+        key: `${agentId}-skip-${timestamp}`,
         type: "skip",
         skipReason: skipMatch[2],
       });
-      continue;
+      return;
     }
 
-    const match = line.match(RUN_MARKER);
-    if (match) {
-      if (currentTimestamp && currentLines.length > 0) {
-        const content = currentLines.join("\n").trim();
-        if (content) {
-          blocks.push({
-            agentId,
-            timestamp: currentTimestamp,
-            displayTime: formatTime(currentTimestamp),
-            duration: currentDuration,
-            exitCode: currentExitCode,
-            content,
-            key: `${agentId}-${currentTimestamp}`,
-            type: "run",
-          });
-        }
-      }
-      currentTimestamp = match[1];
-      currentDuration = parseInt(match[2], 10);
-      currentExitCode = parseInt(match[3], 10);
-      currentLines = [];
-    } else if (currentTimestamp) {
-      currentLines.push(line);
+    const runMatch = line.match(RUN_MARKER);
+    if (runMatch) {
+      pushRunBlock();
+      state.currentTimestamp = runMatch[1];
+      state.currentDuration = parseInt(runMatch[2], 10);
+      state.currentExitCode = parseInt(runMatch[3], 10);
+      state.currentLines = [];
+      return;
     }
+
+    if (state.currentTimestamp) {
+      state.currentLines.push(line);
+    }
+  };
+
+  const text = state.pendingLine + raw;
+  const lines = text.split("\n");
+  state.pendingLine = text.endsWith("\n") ? "" : (lines.pop() ?? "");
+  if (text.endsWith("\n")) {
+    lines.pop();
   }
 
-  if (currentTimestamp && currentLines.length > 0) {
-    const content = currentLines.join("\n").trim();
-    if (content) {
-      blocks.push({
-        agentId,
-        timestamp: currentTimestamp,
-        displayTime: formatTime(currentTimestamp),
-        duration: currentDuration,
-        exitCode: currentExitCode,
-        content,
-        key: `${agentId}-${currentTimestamp}`,
-        type: "run",
-      });
-    }
+  for (const line of lines) {
+    processLine(line);
   }
 
-  return blocks;
+  if (options?.finalize && state.pendingLine) {
+    processLine(state.pendingLine);
+    state.pendingLine = "";
+  }
+
+  if (state.currentTimestamp) {
+    pushRunBlock();
+  }
+
+  return { blocks, state };
 }


### PR DESCRIPTION
**@worker-05**

## Summary
- preserve per-agent parser state across SSE and polling chunks so live buffered runs can continue when a chunk starts mid-body
- update log block merging so in-progress RUN cards are replaced as content grows, while SKIP cards still behave correctly
- finalize only the initial `offset=0` parse so historical loads keep the current buffered-log format semantics

## Verification
- `npx tsc --noEmit`
- `npx eslint src/lib/log-parser.ts src/components/logs-panel.tsx`
- targeted `npx tsx --eval ...` parser simulation covering a >64KB RUN body split across two chunks plus a finalize path with a SKIP entry
