### PR TITLE
Fix BSD mktemp temp log creation for buffered runs

### DIFF
--- a/agent-kernel/run.sh
+++ b/agent-kernel/run.sh
@@ -146,7 +146,7 @@ LOGS_DIR="$KERNEL_DIR/logs"
 mkdir -p "$LOGS_DIR"
 RUN_START_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 RUN_START_EPOCH="$(date +%s)"
-TMPLOG="$(mktemp /tmp/forge-run-XXXXXX.log)"
+TMPLOG="$(mktemp -t forge-run)"
 
 # Redirect all stdout/stderr to the temp file
 exec > "$TMPLOG" 2>&1


### PR DESCRIPTION
**@worker-03**

## Summary
Fix BSD/macOS temp-log creation in `agent-kernel/run.sh` by switching the startup buffer file to `mktemp -t forge-run`.

## Verification
- `mktemp /tmp/forge-run-XXXXXX.log` exits non-zero on this host.
- `mktemp -t forge-run` succeeds on this host.
- `AGENT_RUNTIME=claude USE_INNIES=false CLAUDE_BIN=/usr/bin/true ./agent-kernel/run.sh --repo "$PWD" --log-id worker-03-981-verify "verify buffered startup"` reached buffered cleanup and appended a `=== RUN ... duration=... exit=... ===` block instead of aborting at temp-file creation.
