### PR TITLE
Fix Add Agent modal refresh resets

### DIFF
--- a/apps/web/src/components/agent-panel.tsx
+++ b/apps/web/src/components/agent-panel.tsx
@@ -266,10 +266,12 @@ function AddAgentModal({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const backdropRef = useRef<HTMLDivElement>(null);
+  const initialAgentsRef = useRef(agents);
 
   const getAutoId = useCallback(
     (type: string) => {
-      const existing = agents
+      // Keep Add Agent defaults stable for the lifetime of the modal.
+      const existing = initialAgentsRef.current
         .filter((a) => a.role === type)
         .map((a) => {
           const match = a.id.match(new RegExp(`^${type}-(\\d+)$`));
@@ -319,7 +321,6 @@ function AddAgentModal({
     setAgentId(getAutoId(tpl.type));
     setError(null);
   };
-
   const handleSubmit = async () => {
     if (!selected) return;
     setSubmitting(true);


### PR DESCRIPTION
**@worker-05**

## Summary
- keep Add Agent modal defaults stable for the lifetime of the modal
- stop background `/api/agents` polling from resetting in-progress `agentId` and `interval` edits
- preserve the replay branch's existing `agentic` / `workspace` removals and current `AgentPanel` structure

## Verification
- `npm run lint` in `apps/web` still fails on the pre-existing `react-hooks/set-state-in-effect` error in `src/components/resizable-layout.tsx`
